### PR TITLE
Add ESLint rule for self-closing React tags

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
   plugins: ["react"],
   rules: {
     "react/prop-types": "off",
+    "react/self-closing-comp": "error",
     "react/prefer-stateless-function": "error"
   },
   settings: {

--- a/pages/browse.js
+++ b/pages/browse.js
@@ -9,7 +9,7 @@ const Home = () => (
       <link rel="icon" href="/favicon.ico" />
     </Head>
 
-    <Layout></Layout>
+    <Layout />
   </div>
 );
 

--- a/pages/create.js
+++ b/pages/create.js
@@ -9,7 +9,7 @@ const Home = () => (
       <link rel="icon" href="/favicon.ico" />
     </Head>
 
-    <Layout></Layout>
+    <Layout />
   </div>
 );
 

--- a/pages/forum.js
+++ b/pages/forum.js
@@ -9,7 +9,7 @@ const Home = () => (
       <link rel="icon" href="/favicon.ico" />
     </Head>
 
-    <Layout></Layout>
+    <Layout />
   </div>
 );
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,7 @@ const Home = () => (
     </Head>
 
     <Layout>
-      <IndexLayout></IndexLayout>
+      <IndexLayout />
     </Layout>
   </div>
 );

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -9,7 +9,7 @@ const Home = () => (
       <link rel="icon" href="/favicon.ico" />
     </Head>
 
-    <Layout></Layout>
+    <Layout />
   </div>
 );
 

--- a/src/components/general/Header.js
+++ b/src/components/general/Header.js
@@ -4,7 +4,7 @@ import Link from "../ui/Link";
 
 const Header = () => (
   <Container>
-    <img src="https://climateconnect.earth/logo.png"></img>
+    <img src="https://climateconnect.earth/logo.png" />
     <LinkContainer>
       <Link href="forum">Forum</Link>
       <Link href="browse">Browse</Link>

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -10,7 +10,7 @@ export default function Layout({ children }) {
   return (
     <ThemeProvider theme={theme}>
       <LayoutContainer>
-        <Header></Header>
+        <Header />
         <Content>{children}</Content>
         <Footer />
       </LayoutContainer>

--- a/src/components/project/ProjectPreview.js
+++ b/src/components/project/ProjectPreview.js
@@ -8,21 +8,21 @@ export default function ProjectPreview({ project }) {
   return (
     <Container>
       {/* placeholder images */}
-      <Image src={`https://picsum.photos/id/${rand}/240/210`}></Image>
+      <Image src={`https://picsum.photos/id/${rand}/240/210`} />
       <Content>
         <h2>{project.name}</h2>
         <Labels>{project.labels.join(", ")}</Labels>
 
         <IconRow>
-          <img src={project.organisation_image}></img>
+          <img src={project.organisation_image} />
           <span>{project.organisation_name}</span>
         </IconRow>
         <IconRow>
-          <img src="./placeholder.svg"></img>
+          <img src="./placeholder.svg" />
           <span>{project.location}</span>
         </IconRow>
         <IconRow>
-          <img src="./world.svg"></img>
+          <img src="./world.svg" />
           <span>{project.impact}</span>
         </IconRow>
         <Button type="outlined">Get Involved</Button>

--- a/src/layouts/IndexLayout.js
+++ b/src/layouts/IndexLayout.js
@@ -9,7 +9,7 @@ function renderProjects() {
   // TEMPORARY DATA
   return TEMP_FEATURED_DATA.projects.map(project => {
     // TODO: replace key with project id
-    return <ProjectPreview project={project} key={project.name}></ProjectPreview>;
+    return <ProjectPreview project={project} key={project.name} />;
   });
 }
 


### PR DESCRIPTION
Components without children can be self-closed to avoid unnecessary extra closing tag. For example:

```jsx
// This:
<Foo />

// Instead of this:
<Foo></Foo>
```

This enables the [`react/self-closing-comp` ESLint rule][1] to enforce this, and fixes this throughout the codebase.

[1]: https://github.com/yannickcr/eslint-plugin-react/blob/HEAD/docs/rules/self-closing-comp.md