### PR TITLE
Prefer `const` over `let` when linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
   },
   plugins: ["react"],
   rules: {
+    "prefer-const": "error",
     "react/prop-types": "off",
     "react/self-closing-comp": "error",
     "react/prefer-stateless-function": "error"


### PR DESCRIPTION
If you never reassign a variable, you can use `const` instead of `let`, which makes it easier to read and can prevent bugs.

This adds the built-in [`prefer-const` ESLint rule][1] to enforce this.

[1]: https://eslint.org/docs/rules/prefer-const