### PR TITLE
Add lint rule to prefer stateless function components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,8 @@ module.exports = {
   },
   plugins: ["react"],
   rules: {
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "react/prefer-stateless-function": "error"
   },
   settings: {
     react: {

--- a/src/components/general/Button.js
+++ b/src/components/general/Button.js
@@ -1,11 +1,9 @@
-import React, { Component } from "react";
+import React from "react";
 import styled from "styled-components";
 
-export default class Button extends Component {
-  render() {
-    const { type, children } = this.props;
-    return <StyledButton type={type}>{children}</StyledButton>;
-  }
+export default function Button(props) {
+  const { type, children } = props;
+  return <StyledButton type={type}>{children}</StyledButton>;
 }
 
 const StyledButton = styled.button`


### PR DESCRIPTION
After some internal discussion, we decided to use function components (with hooks) unless you have a very good reason to use a class component.

This adds [`react/prefer-stateless-function` ESLint rule][1] which gives a lint error if you try to use a class component that should be a stateless function component.

This doesn't go all the way to achieving our stated goal—it won't error if you use class components that have state—but I think this is a useful way to enforce a piece of our style rule.

[1]: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md