### PR TITLE
Update <Link> styles to be more generic

### DIFF
--- a/src/components/general/Header.js
+++ b/src/components/general/Header.js
@@ -30,6 +30,12 @@ const Container = styled.nav`
     height: 54px;
     width: 54px;
   }
+
+  a {
+    padding: 6px;
+    margin-right: 36px;
+    font-size: 1.1rem;
+  }
 `;
 
 const LinkContainer = styled.div``;

--- a/src/components/ui/Link.js
+++ b/src/components/ui/Link.js
@@ -11,12 +11,9 @@ export default function LinkItem({ children, type, href }) {
 }
 
 const StyledLink = styled.a`
-  padding: 6px;
   color: ${({ theme }) => theme.colors.primary};
-  margin-right: 36px;
   text-decoration: none;
   cursor: pointer;
-  font-size: 1.1rem;
   transition: 0.25s ease-in-out;
 
   :hover {


### PR DESCRIPTION
This updates the `<Link>` component's styles.

Before this change, they were only used in the header, so they had styles that were specific to the header. We'll want to use this component in more places, so I removed the header-specific styles and moved them into the `<Header>` component.

This was useful while working on the project page (see #14).