### PR TITLE
Move <Head> usage to <Layout>

### DIFF
--- a/pages/browse.js
+++ b/pages/browse.js
@@ -1,16 +1,10 @@
 import React from "react";
-import Head from "next/head";
 import Layout from "../src/components/layout";
 
 const Home = () => (
-  <div>
-    <Head>
-      <title>Browse</title>
-      <link rel="icon" href="/favicon.ico" />
-    </Head>
-
-    <Layout />
-  </div>
+  <Layout title="Browse">
+    <h1>Browse Projects</h1>
+  </Layout>
 );
 
 export default Home;

--- a/pages/create.js
+++ b/pages/create.js
@@ -1,16 +1,10 @@
 import React from "react";
-import Head from "next/head";
 import Layout from "../src/components/layout";
 
 const Home = () => (
-  <div>
-    <Head>
-      <title>Create a Project</title>
-      <link rel="icon" href="/favicon.ico" />
-    </Head>
-
-    <Layout />
-  </div>
+  <Layout title="Create a Project">
+    <h1>Create a Project</h1>
+  </Layout>
 );
 
 export default Home;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,19 +1,11 @@
 import React from "react";
-import Head from "next/head";
 import Layout from "./../src/components/layout";
 import IndexLayout from "../src/layouts/IndexLayout";
 
 const Home = () => (
-  <div>
-    <Head>
-      <title>Home</title>
-      <link rel="icon" href="/favicon.ico" />
-    </Head>
-
-    <Layout>
-      <IndexLayout />
-    </Layout>
-  </div>
+  <Layout title="Home">
+    <IndexLayout />
+  </Layout>
 );
 
 export default Home;

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -1,16 +1,10 @@
 import React from "react";
-import Head from "next/head";
 import Layout from "../src/components/layout";
 
 const Home = () => (
-  <div>
-    <Head>
-      <title>Sign In</title>
-      <link rel="icon" href="/favicon.ico" />
-    </Head>
-
-    <Layout />
-  </div>
+  <Layout title="Sign In">
+    <h1>Sign In</h1>
+  </Layout>
 );
 
 export default Home;

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,20 +1,27 @@
 import React from "react";
 import styled from "styled-components";
+import Head from "next/head";
 import Header from "./general/Header";
 import "./../reset.css";
 import Footer from "./general/Footer";
 import { ThemeProvider } from "styled-components";
 import theme from "./../theme";
 
-export default function Layout({ children }) {
+export default function Layout({ title, children }) {
   return (
-    <ThemeProvider theme={theme}>
-      <LayoutContainer>
-        <Header />
-        <Content>{children}</Content>
-        <Footer />
-      </LayoutContainer>
-    </ThemeProvider>
+    <>
+      <Head>
+        <title>{title}</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <ThemeProvider theme={theme}>
+        <LayoutContainer>
+          <Header />
+          <Content>{children}</Content>
+          <Footer />
+        </LayoutContainer>
+      </ThemeProvider>
+    </>
   );
 }
 


### PR DESCRIPTION
We were duplicating some stuff in `<Head>` across every page. This moves that stuff to `<Layout>` to shorten the code and reduce repetition.