### PR TITLE
Skeleton of project page

### DIFF
--- a/pages/projects/[projectId].js
+++ b/pages/projects/[projectId].js
@@ -1,0 +1,45 @@
+import React from "react";
+import Link from "next/link";
+import Layout from "../../src/components/layout";
+import { Container } from "@material-ui/core";
+import TEMP_FEATURED_DATA from "../../projects.json";
+
+export default function ProjectPage({ project }) {
+  return (
+    <Layout title={project ? project.name : "Project not found"}>
+      {project ? <ProjectLayout project={project} /> : <NoProjectFoundLayout />}
+    </Layout>
+  );
+}
+
+ProjectPage.getInitialProps = async ctx => {
+  return {
+    project: await getProjectByIdIfExists(ctx.query.projectId)
+  };
+};
+
+function ProjectLayout({ project }) {
+  return (
+    <Container maxWidth="xl">
+      <p>{project.description}</p>
+    </Container>
+  );
+}
+
+function NoProjectFoundLayout() {
+  return (
+    <>
+      <p>Project not found.</p>
+      <p>
+        <Link href="/">
+          <a>Click here to return to the homepage.</a>
+        </Link>
+      </p>
+    </>
+  );
+}
+
+// This will likely become asynchronous in the future (a database lookup or similar) so it's marked as `async`, even though everything it does is synchronous.
+async function getProjectByIdIfExists(projectId) {
+  return TEMP_FEATURED_DATA.projects.find(({ id }) => id === projectId);
+}

--- a/src/components/project/ProjectPreview.js
+++ b/src/components/project/ProjectPreview.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Router from "next/router";
 import {
   Typography,
   Card,
@@ -29,7 +30,12 @@ export default function ProjectPreview({ project }) {
   const classes = useStyles();
 
   return (
-    <Card className={classes.root}>
+    <Card
+      className={classes.root}
+      onClick={() => {
+        Router.push(`/projects/${project.id}`);
+      }}
+    >
       <CardMedia
         className={classes.media}
         title={project.name}


### PR DESCRIPTION
This adds a skeleton for a project page at `/projects/[projectId]`. For example, visiting `/projects/78b6677c-28d2-4b2b-9825-4479706d2402` will show the sample project.

<img width="992" alt="Screenshot of project page" src="https://user-images.githubusercontent.com/777712/71783379-a311fe80-2fab-11ea-927f-b6e914472ac6.png">

Closes #46.