### PR TITLE
Fix footer in 2020 (and beyond)

### DIFF
--- a/src/components/general/Footer.js
+++ b/src/components/general/Footer.js
@@ -16,7 +16,7 @@ export default function Footer() {
 
   return (
     <Box component="footer" className={classes.root}>
-      © ClimateConnect 2019
+      © ClimateConnect {new Date().getFullYear()}
     </Box>
   );
 }


### PR DESCRIPTION
The site footer was hard-coded "© ClimateConnect 2019", which is wrong in 2020. This updates that.