### PR TITLE
Make the header responsive

### DIFF
--- a/src/components/general/Header.js
+++ b/src/components/general/Header.js
@@ -1,7 +1,36 @@
-import React from "react";
+import React, { useState } from "react";
+import noop from "lodash/noop";
 import Link from "next/link";
-import { Box, Container, Button } from "@material-ui/core";
+import {
+  Box,
+  Container,
+  Button,
+  IconButton,
+  SwipeableDrawer,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText
+} from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
+import MenuIcon from "@material-ui/icons/Menu";
+import AddCircleIcon from "@material-ui/icons/AddCircle";
+import AccountCircleIcon from "@material-ui/icons/AccountCircle";
+
+const LINKS = [
+  {
+    href: "/create",
+    text: "Create a project",
+    iconForDrawer: AddCircleIcon
+  },
+  {
+    href: "/signin",
+    text: "Sign in",
+    iconForDrawer: AccountCircleIcon,
+    isOutlinedInHeader: true
+  }
+];
 
 const useStyles = makeStyles(theme => {
   return {
@@ -10,7 +39,7 @@ const useStyles = makeStyles(theme => {
       borderBottom: `1px solid ${theme.palette.grey[300]}`
     },
     container: {
-      padding: theme.spacing(1),
+      padding: theme.spacing(2),
       display: "flex",
       justifyContent: "space-between",
       alignItems: "center"
@@ -18,14 +47,16 @@ const useStyles = makeStyles(theme => {
     logo: {
       height: 60
     },
-    buttonMarginRight: {
-      marginRight: theme.spacing(1)
+    buttonMarginLeft: {
+      marginLeft: theme.spacing(1)
     }
   };
 });
 
 export default function Header() {
   const classes = useStyles();
+
+  const isNarrowScreen = useMediaQuery(theme => theme.breakpoints.down("xs"));
 
   return (
     <Box component="header" className={classes.root}>
@@ -40,19 +71,73 @@ export default function Header() {
           </a>
         </Link>
 
-        <Box>
-          <Link href="/create">
-            <Button color="primary" className={classes.buttonMarginRight}>
-              Create a project
-            </Button>
-          </Link>
-          <Link href="/signin">
-            <Button variant="outlined" color="primary">
-              Sign in
-            </Button>
-          </Link>
-        </Box>
+        {isNarrowScreen ? <NarrowScreenLinks /> : <NormalScreenLinks />}
       </Container>
     </Box>
+  );
+}
+
+function NormalScreenLinks() {
+  const classes = useStyles();
+
+  return (
+    <Box>
+      {LINKS.map((link, index) => {
+        const buttonProps = {};
+        if (index !== 0) {
+          buttonProps.className = classes.buttonMarginLeft;
+        }
+        if (link.isOutlinedInHeader) {
+          buttonProps.variant = "outlined";
+        }
+        return (
+          <Link href={link.href} key={link.href}>
+            <Button color="primary" {...buttonProps}>
+              {link.text}
+            </Button>
+          </Link>
+        );
+      })}
+    </Box>
+  );
+}
+
+function NarrowScreenLinks() {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  const openDrawer = setIsDrawerOpen.bind(null, true);
+  const closeDrawer = setIsDrawerOpen.bind(null, false);
+
+  return (
+    <>
+      <IconButton edge="start" color="inherit" aria-label="menu" onClick={openDrawer}>
+        <MenuIcon />
+      </IconButton>
+
+      <SwipeableDrawer
+        anchor="right"
+        open={isDrawerOpen}
+        // `onOpen` is a required property, even though we don't use it.
+        onOpen={noop}
+        onClose={closeDrawer}
+        disableBackdropTransition={true}
+      >
+        <List>
+          {LINKS.map(link => {
+            const Icon = link.iconForDrawer;
+            return (
+              <Link href={link.href} key={link.href}>
+                <ListItem button component="a" onClick={closeDrawer}>
+                  <ListItemIcon>
+                    <Icon />
+                  </ListItemIcon>
+                  <ListItemText primary={link.text} />
+                </ListItem>
+              </Link>
+            );
+          })}
+        </List>
+      </SwipeableDrawer>
+    </>
   );
 }

--- a/test/components/general/header.test.js
+++ b/test/components/general/header.test.js
@@ -1,10 +1,16 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
+import { ThemeProvider } from "@material-ui/core/styles";
 import Header from "../../../src/components/general/Header";
+import theme from "../../../src/theme";
 
 describe("Header Component", () => {
   it("contains a logo image", () => {
-    const wrapper = shallow(<Header />);
+    const wrapper = mount(
+      <ThemeProvider theme={theme}>
+        <Header />
+      </ThemeProvider>
+    );
     expect(wrapper.find("img")).toHaveLength(1);
     expect(wrapper.find("img").prop("alt")).toEqual("Climate Connect");
   });


### PR DESCRIPTION
This makes the `<Header />` component responsive on narrow screens (like mobile phones). On wide screens, it uses the buttons as before. On narrow screens, it renders an expandable drawer.

![Screencast of what it looks like on iPhone](https://user-images.githubusercontent.com/777712/72559240-f9175980-3869-11ea-9208-5b2b15cd19dc.gif)

![Screencast of what it looks like on dekstop](https://user-images.githubusercontent.com/777712/72559244-fa488680-3869-11ea-9c90-f8c431997835.gif)

If you're on a narrow screen (such as a phone), we briefly render the "real" buttons before JavaScript can kick in and hide them. I felt that this was acceptable for environments with slow connections (they should be able to click the buttons while the page is loading) or environments without JavaScript. However, it's a bit wonky, so we should consider filing an issue or fixing it now.