### PR TITLE
Create env variable that enables us to deploy just the static pages from the dev branch

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,9 @@
+require("dotenv").config();
+
 const withCSS = require("@zeit/next-css");
 module.exports = withCSS({
-  cssModules: true
+  cssModules: true,
+  env: {
+    PRE_LAUNCH: process.env.PRE_LAUNCH
+  }
 });

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@material-ui/core": "^4.5.2",
     "@material-ui/icons": "^4.5.1",
     "@zeit/next-css": "^1.0.1",
+    "dotenv": "^8.2.0",
     "lodash": "^4.17.15",
     "next": "9.1.1",
     "react": "^16.12.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,14 +3,21 @@ import Layout from "../src/components/layouts/layout";
 import ProjectPreviews from "./../src/components/project/ProjectPreviews";
 import fakeProjectData from "../public/data/projects.json";
 import { times } from "lodash";
+import About from "./about";
 
 const fakeProjectTemplate = fakeProjectData.projects[0];
 const fakeProjects = times(6, () => fakeProjectTemplate);
 
 export default function Index() {
   return (
-    <Layout title="Work on the most effective climate projects">
-      <ProjectPreviews projects={fakeProjects} />
-    </Layout>
+    <>
+      {process.env.PRE_LAUNCH === "true" ? (
+        <About />
+      ) : (
+        <Layout title="Work on the most effective climate projects">
+          <ProjectPreviews projects={fakeProjects} />
+        </Layout>
+      )}
+    </>
   );
 }

--- a/src/components/general/Header.js
+++ b/src/components/general/Header.js
@@ -66,20 +66,18 @@ export default function Header() {
 
   return (
     <Box component="header" className={classes.root}>
-      {process.env.PRE_LAUNCH === "true" ? (
-        <Container className={classes.container}>
-          <img src="/images/logo.png" alt="Climate Connect" className={classes.logo} />
-        </Container>
-      ) : (
-        <Container className={classes.container}>
-          <Link href="/">
-            <a>
-              <img src="/images/logo.png" alt="Climate Connect" className={classes.logo} />
-            </a>
-          </Link>
-          {isNarrowScreen ? <NarrowScreenLinks /> : <NormalScreenLinks />}
-        </Container>
-      )}
+      <Container className={classes.container}>
+        <Link href="/">
+          <a>
+            <img src="/images/logo.png" alt="Climate Connect" className={classes.logo} />
+          </a>
+        </Link>
+        {process.env.PRE_LAUNCH === "true" ? (
+          <></>
+        ) : (
+          <>{isNarrowScreen ? <NarrowScreenLinks /> : <NormalScreenLinks />}</>
+        )}
+      </Container>
     </Box>
   );
 }

--- a/src/components/general/Header.js
+++ b/src/components/general/Header.js
@@ -66,15 +66,20 @@ export default function Header() {
 
   return (
     <Box component="header" className={classes.root}>
-      <Container className={classes.container}>
-        <Link href="/">
-          <a>
-            <img src="/images/logo.png" alt="Climate Connect" className={classes.logo} />
-          </a>
-        </Link>
-
-        {isNarrowScreen ? <NarrowScreenLinks /> : <NormalScreenLinks />}
-      </Container>
+      {process.env.PRE_LAUNCH === "true" ? (
+        <Container className={classes.container}>
+          <img src="/images/logo.png" alt="Climate Connect" className={classes.logo} />
+        </Container>
+      ) : (
+        <Container className={classes.container}>
+          <Link href="/">
+            <a>
+              <img src="/images/logo.png" alt="Climate Connect" className={classes.logo} />
+            </a>
+          </Link>
+          {isNarrowScreen ? <NarrowScreenLinks /> : <NormalScreenLinks />}
+        </Container>
+      )}
     </Box>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2925,6 +2925,11 @@ dot-prop@^5.0.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"


### PR DESCRIPTION
resolves #73 

I have added a `PRE_LAUNCH` environment variable to `.env` file. This will help us deploying static pages from the dev branch without commenting out these pages. I have installed `dotenv` library to use env variables fetched from `.env` file. 

If the PRE_LAUNCH === 'true' it will show the about page into as a main page. 
<img width="1440" alt="Screen Shot 2020-02-06 at 8 30 03 AM" src="https://user-images.githubusercontent.com/15343711/73957346-12388680-48bb-11ea-8887-1dd50b0c48e4.png">

if PRE_LAUNCH === 'false' it will show the default project page we had before. 
<img width="1439" alt="Screen Shot 2020-02-06 at 8 30 37 AM" src="https://user-images.githubusercontent.com/15343711/73957396-267c8380-48bb-11ea-9931-29e0cccae1fb.png">

Please feel free to make any suggestions you have for this PR. 