### PR TITLE
Create generic AccountPage component for profile and organization accounts

### DIFF
--- a/pages/organizations/[organizationUrl].js
+++ b/pages/organizations/[organizationUrl].js
@@ -1,10 +1,13 @@
 import React from "react";
 import Link from "next/link";
+import { Typography, Container } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
 import WideLayout from "../../src/components/layouts/WideLayout";
+import AccountPage from "../../src/components/account/AccountPage";
 import ProfilePreviews from "../../src/components/profile/ProfilePreviews";
 import ProjectPreviews from "../../src/components/project/ProjectPreviews";
-import { Container, Avatar, Typography, Chip } from "@material-ui/core";
-import { makeStyles } from "@material-ui/core/styles";
+
 import TEMP_FEATURED_DATA from "../../public/data/organizations.json";
 import TEMP_PROJECT_DATA from "../../public/data/projects.json";
 import TEMP_MEMBER_DATA from "../../public/data/profiles.json";
@@ -12,73 +15,12 @@ import TEMP_MEMBER_DATA from "../../public/data/profiles.json";
 const DEFAULT_BACKGROUND_IMAGE = "/images/background1.jpg";
 
 const useStyles = makeStyles(theme => ({
-  avatar: {
-    height: theme.spacing(20),
-    width: theme.spacing(20),
-    margin: "0 auto",
-    marginTop: theme.spacing(-11),
-    fontSize: 50,
-    backgroundcolor: "white",
-    "& img": {
-      objectFit: "contain",
-      backgroundColor: "white"
-    },
-    border: `1px solid ${theme.palette.grey[300]}`
-  },
-  avatarWithInfo: {
-    textAlign: "center",
-    width: theme.spacing(40),
-    margin: "0 auto",
-    [theme.breakpoints.up("sm")]: {
-      margin: 0,
-      display: "inline-block",
-      width: "auto"
-    }
-  },
-  organizationInfo: {
-    [theme.breakpoints.up("sm")]: {
-      display: "inline-block"
-    },
-    padding: 0,
-    marginTop: theme.spacing(1)
-  },
-  name: {
-    fontWeight: "bold",
-    padding: theme.spacing(1),
-    paddingLeft: 0,
-    paddingRight: 0
-  },
-  subtitle: {
-    color: `${theme.palette.secondary.main}`
-  },
-  content: {
-    paddingTop: theme.spacing(1),
-    paddingBottom: theme.spacing(1),
-    color: `${theme.palette.secondary.main}`,
-    fontWeight: "bold"
-  },
-  noPadding: {
-    padding: 0
-  },
-  infoContainer: {
-    [theme.breakpoints.up("sm")]: {
-      display: "flex"
-    }
-  },
   cardHeadline: {
     marginTop: theme.spacing(3),
     marginBottom: theme.spacing(1)
   },
-  noprofile: {
-    textAlign: "center",
-    padding: theme.spacing(5)
-  },
-  marginTop: {
-    marginTop: theme.spacing(1)
-  },
-  chip: {
-    marginBottom: theme.spacing(1),
-    marginRight: theme.spacing(1)
+  subtitle: {
+    color: `${theme.palette.secondary.main}`
   }
 }));
 
@@ -97,58 +39,20 @@ export default function OrganizationPage({ organization, projects, members }) {
 OrganizationPage.getInitialProps = async ctx => {
   return {
     organization: await getOrganizationByUrlIfExists(ctx.query.organizationUrl),
-    projects: await getProjects(ctx.query.organizationUrl),
-    members: await getMembers(ctx.query.organizationUrl)
+    projects: await getProjectsByOrganization(ctx.query.organizationUrl),
+    members: await getMembersByOrganization(ctx.query.organizationUrl)
   };
 };
 
 function OrganizationLayout({ organization, projects, members }) {
   const classes = useStyles();
-
-  const displayOrganizationInfo = info =>
-    info.map(i => (
-      <div key={i.key}>
-        <div className={classes.subtitle}>{i.name}:</div>
-        <div className={classes.content}>{i.value}</div>
-      </div>
-    ));
-
   return (
-    <Container maxWidth="lg" className={classes.noPadding}>
-      <div
-        style={{
-          background: `url(${
-            organization.background_image ? organization.background_image : DEFAULT_BACKGROUND_IMAGE
-          })`,
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-          width: "100%",
-          height: 305
-        }}
-      />
-      <Container className={classes.infoContainer}>
-        <Container className={classes.avatarWithInfo}>
-          <Avatar
-            alt={organization.name}
-            component="div"
-            size="large"
-            src={organization.logo}
-            className={classes.avatar}
-          />
-          <Typography variant="h5" className={classes.name}>
-            {organization.name}
-          </Typography>
-          <Container className={classes.noPadding}>
-            {organization.types &&
-              organization.types.map(type => (
-                <Chip label={type} key={type} className={classes.chip} />
-              ))}
-          </Container>
-        </Container>
-        <Container className={classes.organizationInfo}>
-          {displayOrganizationInfo(organization.info)}
-        </Container>
-      </Container>
+    <AccountPage
+      account={organization}
+      default_background={DEFAULT_BACKGROUND_IMAGE}
+      editHref={"/editOrganization/" + organization.url}
+      type="organization"
+    >
       <Container>
         <div className={`${classes.subtitle} ${classes.cardHeadline}`}>Projects:</div>
         {projects && projects.length ? (
@@ -165,7 +69,7 @@ function OrganizationLayout({ organization, projects, members }) {
           <Typography>None of the members of this organization has signed up yet!</Typography>
         )}
       </Container>
-    </Container>
+    </AccountPage>
   );
 }
 
@@ -183,17 +87,17 @@ function NoOrganizationFoundLayout() {
   );
 }
 
-// This will likely become asynchronous in the future (a database lookup or similar) so it's marked as `async`, even though everything it does is synchronous.
+// These will likely become asynchronous in the future (a database lookup or similar) so it's marked as `async`, even though everything it does is synchronous.
 async function getOrganizationByUrlIfExists(organizationUrl) {
   return TEMP_FEATURED_DATA.organizations.find(({ url }) => url === organizationUrl);
 }
 
-async function getProjects(organizationUrl) {
+async function getProjectsByOrganization(organizationUrl) {
   return TEMP_PROJECT_DATA.projects.filter(project =>
     project.organization_url.includes(organizationUrl)
   );
 }
 
-async function getMembers(organizationUrl) {
+async function getMembersByOrganization(organizationUrl) {
   return TEMP_MEMBER_DATA.profiles.filter(member => member.organizations.includes(organizationUrl));
 }

--- a/pages/profiles/[profileUrl].js
+++ b/pages/profiles/[profileUrl].js
@@ -1,11 +1,13 @@
 import React from "react";
 import Link from "next/link";
+import { Container, Typography } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
 import WideLayout from "../../src/components/layouts/WideLayout";
 import ProjectPreviews from "./../../src/components/project/ProjectPreviews";
 import OrganizationPreviews from "./../../src/components/organization/OrganizationPreviews";
-import ProfilePreview from "./../../src/components/profile/ProfilePreview";
-import { Container, Typography } from "@material-ui/core";
-import { makeStyles } from "@material-ui/core/styles";
+import AccountPage from "./../../src/components/account/AccountPage";
+
 import TEMP_FEATURED_DATA from "../../public/data/profiles.json";
 import TEMP_PROJECT_DATA from "../../public/data/projects.json";
 import TEMP_ORGANIZATION_DATA from "../../public/data/organizations.json";
@@ -79,7 +81,7 @@ export default function ProfilePage({ profile, projects, organizations }) {
 ProfilePage.getInitialProps = async ctx => {
   return {
     profile: await getProfileByUrlIfExists(ctx.query.profileUrl),
-    organizations: await getOrganizations(ctx.query.profileUrl),
+    organizations: await getOrganizationsByUser(ctx.query.profileUrl),
     projects: await getProjects(ctx.query.profileUrl)
   };
 };
@@ -87,49 +89,12 @@ ProfilePage.getInitialProps = async ctx => {
 function ProfileLayout({ profile, projects, organizations }) {
   const classes = useStyles();
   return (
-    <Container maxWidth="lg" className={classes.noPadding}>
-      <div
-        style={{
-          background: `url(${
-            profile.background_image ? profile.background_image : DEFAULT_BACKGROUND_IMAGE
-          })`,
-          "background-size": "cover",
-          "background-position": "center",
-          width: "100%",
-          height: 305
-        }}
-      />
-      <Container className={classes.infoContainer}>
-        <Container className={classes.profilePreview}>
-          <ProfilePreview profile={profile} />
-        </Container>
-        <Container className={classes.memberInfoContainer}>
-          {profile.bio && (
-            <>
-              <div className={`${classes.subtitle} ${classes.marginTop}`}>Bio:</div>
-              <div className={classes.content}>{profile.bio}</div>
-            </>
-          )}
-          {profile.location && (
-            <>
-              <div className={classes.subtitle}>Location:</div>
-              <div className={classes.content}>{profile.location}</div>
-            </>
-          )}
-          {profile.skills && (
-            <>
-              <div className={classes.subtitle}>Skills:</div>
-              <div className={classes.content}>{profile.skills.join(", ")}</div>
-            </>
-          )}
-          {profile.availability && (
-            <>
-              <div className={classes.subtitle}>Availability:</div>
-              <div className={classes.content}>{profile.availability} hours per week</div>
-            </>
-          )}
-        </Container>
-      </Container>
+    <AccountPage
+      account={profile}
+      default_background={DEFAULT_BACKGROUND_IMAGE}
+      editHref={"/editProfile/" + profile.url}
+      type="profile"
+    >
       <Container>
         <div className={`${classes.subtitle} ${classes.cardHeadline}`}>Projects:</div>
         {projects && projects.length ? (
@@ -146,7 +111,7 @@ function ProfileLayout({ profile, projects, organizations }) {
           <Typography>This user is not involved in any organizations yet!</Typography>
         )}
       </Container>
-    </Container>
+    </AccountPage>
   );
 }
 
@@ -173,7 +138,7 @@ async function getProjects(profileUrl) {
   return TEMP_PROJECT_DATA.projects.filter(project => project.members.includes(profileUrl));
 }
 
-async function getOrganizations(profileUrl) {
+async function getOrganizationsByUser(profileUrl) {
   return TEMP_ORGANIZATION_DATA.organizations.filter(
     org => org.members && org.members.includes(profileUrl)
   );

--- a/public/data/organization_info_metadata.json
+++ b/public/data/organization_info_metadata.json
@@ -1,0 +1,23 @@
+{
+  "location": {
+    "name": "Location"
+  },
+  "shortdescription": {
+    "name": "Description"
+  },
+  "school": {
+    "name": "School/University"
+  },
+  "city": {
+    "name": "City"
+  },
+  "state": {
+    "name": "State"
+  },
+  "country": {
+    "name": "Country"
+  },
+  "organ": {
+    "name": "Organ"
+  }
+}

--- a/public/data/organization_types.json
+++ b/public/data/organization_types.json
@@ -1,0 +1,70 @@
+{
+  "max_types": 2,
+  "organization_types": [
+    {
+      "name": "Volunteer group",
+      "key": "volunteergroup",
+      "additionalInfo": []
+    },
+    {
+      "name": "NGO",
+      "key": "ngo",
+      "additionalInfo": []
+    },
+    {
+      "name": "Student organization",
+      "key": "studentorganization",
+      "additionalInfo": ["school"]
+    },
+    {
+      "name": "Social movement",
+      "key": "socialmovement",
+      "additionalInfo": []
+    },
+    {
+      "name": "For-profit company",
+      "key": "forprofitcompany",
+      "additionalInfo": []
+    },
+    {
+      "name": "Non-profit company",
+      "key": "nonprofitcompany",
+      "additionalInfo": []
+    },
+    {
+      "name": "Governmental organization",
+      "key": "governmentalorganization",
+      "additionalInfo": []
+    },
+    {
+      "name": "City government",
+      "key": "city",
+      "additionalInfo": ["city"]
+    },
+    {
+      "name": "State",
+      "key": "state",
+      "additionalInfo": ["state"]
+    },
+    {
+      "name": "Federal government",
+      "key": "federalgovernment",
+      "additionalInfo": ["country", "organ"]
+    },
+    {
+      "name": "Intergovernmental organization",
+      "key": "intergovernmentalorganization",
+      "additionalInfo": []
+    },
+    {
+      "name": "Educational facility",
+      "key": "educationalfacility",
+      "additionalInfo": []
+    },
+    {
+      "name": "Research facility",
+      "key": "researchfacility",
+      "additionalInfo": []
+    }
+  ]
+}

--- a/public/data/organizations.json
+++ b/public/data/organizations.json
@@ -3,7 +3,7 @@
     {
       "url": "climateconnect",
       "name": "Climate Connect",
-      "logo": "/images/logonotext.png",
+      "image": "/images/logonotext.png",
       "members": [
         "tobiasrehm",
         "christophstoll",
@@ -18,96 +18,61 @@
       "admins": ["tobiasrehm", "christophstoll", "thomasbove"],
       "parentgroup": null,
       "subgroups": [],
-      "info": [
-        {
-          "key": "location",
-          "name": "Location",
-          "value": "International"
-        },
-        {
-          "key": "shortdescription",
-          "name": "Description",
-          "value": "Connecting climate activists around the world."
-        }
-      ],
+      "info": {
+        "location": "International",
+        "shortdescription": "Connecting climate activists around the world."
+      },
       "background_image": "/images/climateconnectbackground.jpg",
-      "types": ["Volunteer group", "Non-profit company"]
+      "types": ["volunteergroup", "nonprofitcompany"]
     },
     {
       "url": "sneep",
       "name": "sneep",
-      "logo": "/images/sneep.png",
+      "image": "/images/sneep.png",
       "members": ["christophstoll", "tobiasrehm", "nadineschneider", "reginareck", "tobiasbaume"],
       "admins": [],
       "subgroups": ["sneeperlangen", "sneepnuernberg"],
-      "info": [
-        {
-          "key": "location",
-          "name": "Location",
-          "value": "Europe"
-        },
-        {
-          "key": "shortdescription",
-          "name": "Description",
-          "value": "student network for ethics in economics and practice"
-        }
-      ],
-      "types": ["Volunteer group"]
+      "info": {
+        "location": "Europe",
+        "shortdescription": "student network for ethics in economics and practice"
+      },
+      "additionalInfo": {
+        "school": "across schools"
+      },
+      "background_image": "/images/background1.jpg",
+      "types": ["volunteergroup", "studentorganization"]
     },
     {
       "url": "sneeperlangen",
       "name": "sneep Erlangen",
-      "logo": "/images/sneep.png",
+      "image": "/images/sneep.png",
       "members": ["tobiasrehm", "christophstoll", "reginareck", "nadineschneider"],
       "admins": ["tobiasrehm", "reginareck"],
       "parentgroup": "sneep",
       "subgroups": [],
-      "info": [
-        {
-          "key": "location",
-          "name": "Location",
-          "value": "Erlangen, Germany"
-        },
-        {
-          "key": "school",
-          "name": "University/School",
-          "value": "FAU Erlangen-Nürnberg"
-        },
-        {
-          "key": "shortdescription",
-          "name": "Description",
-          "value": "Our local group is especially focused on climate action."
-        }
-      ],
+      "info": {
+        "location": "Erlangen, Germany",
+        "shortdescription": "Our local group is especially focused on climate action.",
+        "school": "FAU Erlangen-Nürnberg"
+      },
       "background_image": "/images/sneepbackground.jpg",
-      "types": ["Volunteer group", "Student organization"]
+      "types": ["volunteergroup", "studentorganization"]
     },
     {
       "url": "sneepnuernberg",
       "name": "sneep Nürnberg",
-      "logo": "/images/sneep.png",
+      "image": "/images/sneep.png",
       "members": ["tobiasbaume"],
       "admins": ["tobiasbaume"],
       "parentgroup": "sneep",
       "subgroups": [],
-      "info": [
-        {
-          "key": "location",
-          "name": "Location",
-          "value": "Nürnberg, Germany"
-        },
-        {
-          "key": "school",
-          "name": "University/School",
-          "value": "FAU Erlangen-Nürnberg"
-        },
-        {
-          "key": "shortdescription",
-          "name": "Description",
-          "value": "Our local group is especially focused on ethics in economics."
-        }
-      ],
-      "types": ["Volunteer group", "Student organization"]
+      "info": {
+        "location": "Erlangen, Germany",
+        "shortdescription": "Our local group is especially focused on ethics in economics.",
+        "school": "FAU Erlangen-Nürnberg"
+      },
+      "background_image": "/images/background1.jpg",
+      "types": ["volunteergroup", "studentorganization"]
     },
     {
       "url": "emptytestorganisation",
@@ -118,7 +83,9 @@
           "name": "Description",
           "value": "We're empty and testing."
         }
-      ]
+      ],
+      "background_image": "/images/background1.jpg",
+      "types": ["federalgovernment"]
     }
   ]
 }

--- a/public/data/profile_info_metadata.json
+++ b/public/data/profile_info_metadata.json
@@ -1,0 +1,33 @@
+{
+  "availability": {
+    "name": "Availability",
+    "additionalText": " hours per week",
+    "type": "select",
+    "options": [
+      "1-2",
+      "3-5",
+      "6-10",
+      "11-15",
+      "16-20",
+      "21-25",
+      "26-30",
+      "31-35",
+      "36-40",
+      "more than 40 "
+    ]
+  },
+  "skills": {
+    "name": "Skills",
+    "type": "array",
+    "addText": "Add skill"
+  },
+  "bio": {
+    "name": "Bio",
+    "type": "text",
+    "maxLength": 240
+  },
+  "location": {
+    "name": "Location",
+    "type": "location"
+  }
+}

--- a/public/data/profile_types.json
+++ b/public/data/profile_types.json
@@ -1,0 +1,10 @@
+{
+  "max_types": 1,
+  "profile_types": [
+    {
+      "name": "Climate Protector",
+      "key": "climateprotector",
+      "additionalInfo": []
+    }
+  ]
+}

--- a/public/data/profiles.json
+++ b/public/data/profiles.json
@@ -3,100 +3,157 @@
     {
       "url": "christophstoll",
       "name": "Christoph Stoll",
-      "image": "christophstoll.jpg",
-      "location": "Erlangen, Germany",
+      "image": "/images/christophstoll.jpg",
       "background_image": "/images/background1.jpg",
-      "type": "Climate Protector",
-      "bio": "Member of sneep Erlangen since 2017 💚🌍💚 Co-founder of Climate Connect",
-      "skills": ["programming", "calculating CO2-emissions"],
-      "availability": 5,
-      "organizations": ["sneeperlangen", "sneep", "climateconnect"]
+      "types": ["climateprotector"],
+      "organizations": ["sneeperlangen", "sneep", "climateconnect"],
+      "info": {
+        "location": "Erlangen, Germany",
+        "bio": "Member of sneep Erlangen since 2017 💚🌍💚 Co-founder of Climate Connect",
+        "skills": ["programming", "calculating CO2-emissions"],
+        "availability": "6-10"
+      }
     },
     {
       "name": "Tobias Rehm",
       "url": "tobiasrehm",
-      "image": "tobiasrehm.jpg",
-      "location": "Erlangen, Germany",
-      "type": "Climate Protector",
-      "organizations": ["sneeperlangen", "sneep", "climateconnect"]
+      "image": "/images/tobiasrehm.jpg",
+      "types:": ["climateprotector"],
+      "organizations": ["sneeperlangen", "sneep", "climateconnect"],
+      "info": {
+        "location": "Erlangen, Germany",
+        "bio": "Member of sneep Erlangen since 2017 💚🌍💚 Co-founder of Climate Connect",
+        "skills": ["design", "calculating CO2-emissions"],
+        "availability": "6-10"
+      }
+    },
+    {
+      "name": "Lasse Rehm",
+      "url": "lasserehm",
+      "image": "/images/tobiasrehm.jpg",
+      "types:": ["climateprotector"],
+      "organizations": [],
+      "info": {
+        "location": "Erlangen, Germany",
+        "bio": null,
+        "skills": [],
+        "availability": null
+      }
     },
     {
       "url": "thomasbove",
       "name": "Thomas Bove",
-      "image": "thomasbove.jpg",
-      "location": "Paris, France",
-      "type": "Climate Protector",
+      "image": "/images/thomasbove.jpg",
+      "info": {
+        "location": "Paris, France",
+        "bio": null,
+        "skills": [],
+        "availability": null
+      },
+      "types:": ["climateprotector"],
       "organizations": ["climateconnect"]
     },
     {
       "url": "michaelfischer",
       "name": "Michael Fischer",
-      "image": "michaelfischer.jpg",
-      "location": "Erlangen, Germany",
-      "type": "Climate Protector",
-      "organizations": ["climateconnect"]
-    },
-    {
-      "url": "reecelangerock",
-      "name": "Reece Langerock",
-      "image": "reecelangerock.jpg",
-      "location": "Chicago, USA",
-      "type": "Climate Protector",
+      "image": "/images/michaelfischer.jpg",
+      "info": {
+        "location": "Erlangen, Germany",
+        "bio": null,
+        "skills": [],
+        "availability": null
+      },
+      "types:": ["climateprotector"],
       "organizations": ["climateconnect"]
     },
     {
       "url": "evanhahn",
       "name": "Evan Hahn",
-      "image": "evanhahn.jpg",
-      "location": "Chicago, USA",
-      "type": "Climate Protector",
+      "image": "/images/evanhahn.jpg",
+      "info": {
+        "location": "Chicago, USA",
+        "bio": null,
+        "skills": [],
+        "availability": null
+      },
+      "types:": ["climateprotector"],
       "organizations": ["climateconnect"]
     },
     {
       "url": "nadineschneider",
       "name": "Nadine Schneider",
-      "image": "nadineschneider.jpg",
-      "location": "Erlangen, Germany",
-      "type": "Climate Protector",
+      "image": "/images/nadineschneider.jpg",
+      "info": {
+        "location": "München, Germany",
+        "bio": null,
+        "skills": [],
+        "availability": null
+      },
+      "types:": ["climateprotector"],
       "organizations": ["climateconnect", "sneep", "sneeperlangen"]
     },
     {
       "url": "dipdhanesha",
       "name": "Dip Dhanesha",
-      "image": "dipdhanesha.jpg",
-      "location": "San Francisco, USA",
-      "type": "Climate Protector",
+      "image": "/images/dipdhanesha.jpg",
+      "info": {
+        "location": "San Francisco, USA",
+        "bio": null,
+        "skills": [],
+        "availability": null
+      },
+      "types:": ["climateprotector"],
       "organizations": ["climateconnect"]
     },
     {
       "url": "annkathrinbernauer",
       "name": "Ann-Kathrin Bernauer",
-      "image": "annkathrinbernauer.jpg",
-      "location": "Wuppertal, Germany",
-      "type": "Climate Protector",
+      "image": "/images/annkathrinbernauer.jpg",
+      "info": {
+        "location": "Wuppertal, Germany",
+        "bio": null,
+        "skills": [],
+        "availability": null
+      },
+      "types:": ["climateprotector"],
       "organizations": ["climateconnect"]
     },
     {
       "url": "reginareck",
       "name": "Regina Reck",
       "image": null,
-      "location": "Erlangen, Germany",
-      "type": "Climate Protector",
+      "info": {
+        "location": "Erlangen, Germany",
+        "bio": null,
+        "skills": [],
+        "availability": null
+      },
+      "types:": ["climateprotector"],
       "organizations": ["sneeperlangen", "sneep"]
     },
     {
       "url": "tobiasbaume",
       "name": "Tobias Baume",
       "image": null,
-      "location": "Nürnberg, Germany",
-      "type": "Climate Protector",
+      "info": {
+        "location": "Nürnberg, Germany",
+        "bio": null,
+        "skills": [],
+        "availability": null
+      },
+      "types:": ["climateprotector"],
       "organizations": ["sneeperlangen", "sneep"]
     },
     {
       "url": "emptytestuser",
       "name": "Empty Testuser",
       "image": null,
-      "location": "Nowhere and everywhere",
+      "info": {
+        "location": null,
+        "bio": null,
+        "skills": [],
+        "availability": null
+      },
       "type": "Observer",
       "organizations": []
     }

--- a/src/components/account/AccountPage.js
+++ b/src/components/account/AccountPage.js
@@ -1,0 +1,196 @@
+import React from "react";
+import { Container, Avatar, Typography, Chip, Button } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import profile_info_metadata from "./../../../public/data/profile_info_metadata.json";
+import organization_info_metadata from "./../../../public/data/organization_info_metadata.json";
+import profile_types from "./../../../public/data/profile_types.json";
+import organization_types from "./../../../public/data/organization_types.json";
+
+const useStyles = makeStyles(theme => ({
+  avatar: {
+    height: theme.spacing(20),
+    width: theme.spacing(20),
+    margin: "0 auto",
+    marginTop: theme.spacing(-11),
+    fontSize: 50,
+    backgroundcolor: "white",
+    "& img": {
+      objectFit: "contain",
+      backgroundColor: "white"
+    },
+    border: `1px solid ${theme.palette.grey[300]}`
+  },
+  avatarWithInfo: {
+    textAlign: "center",
+    width: theme.spacing(40),
+    margin: "0 auto",
+    [theme.breakpoints.up("sm")]: {
+      margin: 0,
+      display: "inline-block",
+      width: "auto"
+    }
+  },
+  accountInfo: {
+    padding: 0,
+    marginTop: theme.spacing(1),
+    [theme.breakpoints.up("sm")]: {
+      paddingRight: theme.spacing(15)
+    }
+  },
+  name: {
+    fontWeight: "bold",
+    padding: theme.spacing(1),
+    paddingLeft: 0,
+    paddingRight: 0
+  },
+  subtitle: {
+    color: `${theme.palette.secondary.main}`
+  },
+  content: {
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+    color: `${theme.palette.secondary.main}`,
+    fontWeight: "bold"
+  },
+  noPadding: {
+    padding: 0
+  },
+  infoContainer: {
+    [theme.breakpoints.up("sm")]: {
+      display: "flex"
+    },
+    position: "relative"
+  },
+  noprofile: {
+    textAlign: "center",
+    padding: theme.spacing(5)
+  },
+  marginTop: {
+    marginTop: theme.spacing(1)
+  },
+  chip: {
+    marginBottom: theme.spacing(1),
+    marginRight: theme.spacing(1)
+  },
+  editButton: {
+    position: "absolute",
+    right: theme.spacing(1),
+    width: theme.spacing(16),
+    top: theme.spacing(12),
+    [theme.breakpoints.up("sm")]: {
+      top: theme.spacing(1)
+    },
+    [theme.breakpoints.down("xs")]: {
+      width: theme.spacing(14),
+      textAlign: "center"
+    }
+  }
+}));
+
+export default function AccountPage({ type, account, default_background, editHref, children }) {
+  const classes = useStyles();
+
+  const displayInfoArrayData = (key, infoEl) => {
+    return (
+      <div key={key} className={classes.infoElement}>
+        <div className={classes.subtitle}>{infoEl.name}:</div>
+        <div className={classes.chipArray}>
+          {infoEl.value.map(entry => (
+            <Chip size="medium" label={entry} key={entry} className={classes.chip} />
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  const displayAccountInfo = info =>
+    Object.keys(info).map(key => {
+      const i = getFullInfoElement(key, info[key], type);
+      const value = Array.isArray(i.value) ? i.value.join(", ") : i.value;
+      const additionalText = i.additionalText ? i.additionalText : "";
+      if (i.type === "array") {
+        return displayInfoArrayData(key, i);
+      } else {
+        return (
+          <div key={key}>
+            <div className={classes.subtitle}>{i.name}:</div>
+            <div className={classes.content}>{value + additionalText}</div>
+          </div>
+        );
+      }
+    });
+
+  return (
+    <Container maxWidth="lg" className={classes.noPadding}>
+      <div
+        style={{
+          background: `url(${
+            account.background_image ? account.background_image : default_background
+          })`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          width: "100%",
+          height: 305
+        }}
+      />
+      <Container className={classes.infoContainer}>
+        <Button className={classes.editButton} color="primary" variant="contained" href={editHref}>
+          Edit Profile
+        </Button>
+        <Container className={classes.avatarWithInfo}>
+          <Avatar
+            alt={account.name}
+            component="div"
+            size="large"
+            src={account.image}
+            className={classes.avatar}
+          />
+          <Typography variant="h5" className={classes.name}>
+            {account.name}
+          </Typography>
+          <Container className={classes.noPadding}>
+            {account.types &&
+              getTypesOfAccount(type, account).map(type => (
+                <Chip label={type.name} key={type.key} className={classes.chip} />
+              ))}
+          </Container>
+        </Container>
+        <Container className={classes.accountInfo}>{displayAccountInfo(account.info)}</Container>
+      </Container>
+      {children}
+    </Container>
+  );
+}
+
+//below functions will be replaced with db call later --> potentially retrieve these props directly on the page instead of on the component
+const getInfoMetadata = accountType => {
+  if (accountType !== "profile" && accountType != "organization")
+    throw new Error('accountType has to be "profile" or "organization".');
+  return accountType === "profile" ? profile_info_metadata : organization_info_metadata;
+};
+
+const getFullInfoElement = (key, value, type) => {
+  if (type === "profile") return { ...profile_info_metadata[key], value: value };
+  if (type === "organization") return { ...organization_info_metadata[key], value: value };
+};
+
+const getTypes = accountType => {
+  if (accountType !== "profile" && accountType != "organization")
+    throw new Error('accountType has to be "profile" or "organization".');
+  const types =
+    accountType === "profile" ? profile_types.profile_types : organization_types.organization_types;
+  return types.map(type => {
+    return {
+      ...type,
+      additionalInfo: type.additionalInfo.map(info => {
+        return { ...getInfoMetadata(accountType)[info], key: info };
+      })
+    };
+  });
+};
+
+const getTypesOfAccount = (type, account) => {
+  if (type !== "profile" && type != "organization")
+    throw new Error('type has to be "profile" or "organization".');
+  return getTypes(type).filter(type => account.types.includes(type.key));
+};

--- a/src/components/organization/OrganizationMetadata.js
+++ b/src/components/organization/OrganizationMetadata.js
@@ -40,7 +40,7 @@ export default function OrganizationMetaData({ organization }) {
         <span className={classes.cardIconBox}>
           <PlaceIcon className={classes.cardIcon} />
         </span>
-        {organization.location}
+        {organization.info.location}
       </Box>
       <Box>
         <span className={classes.cardIconBox}>

--- a/src/components/organization/OrganizationPreview.js
+++ b/src/components/organization/OrganizationPreview.js
@@ -40,20 +40,19 @@ const useStyles = makeStyles(theme => {
 
 export default function OrganizationPreview({ organization }) {
   const classes = useStyles();
-
   return (
     <Card
       className={classes.root}
       variant="outlined"
       onClick={() => {
-        Router.push(`/organization/${organization.url}`);
+        Router.push(`/organizations/${organization.url}`);
       }}
     >
       <CardMedia
         className={classes.media}
         component={"div"}
         title={organization.name}
-        image={organization.logo}
+        image={organization.image}
       />
       <CardContent>
         <Typography variant="subtitle1" component="h2" className={classes.bold}>

--- a/src/components/profile/ProfilePreview.js
+++ b/src/components/profile/ProfilePreview.js
@@ -29,13 +29,8 @@ export default function ProfilePreview({ profile }) {
   const classes = useStyles();
 
   return (
-    <Link href={"/profile/" + profile.url} className={classes.avatarWithInfo}>
-      <Avatar
-        alt={profile.name}
-        size="large"
-        src={"/images/" + profile.image}
-        className={classes.avatar}
-      />
+    <Link href={"/profiles/" + profile.url} className={classes.avatarWithInfo}>
+      <Avatar alt={profile.name} size="large" src={profile.image} className={classes.avatar} />
       <Typography variant="h5" className={classes.name}>
         {profile.name}
       </Typography>


### PR DESCRIPTION
This PR is the first of a series of changes, that I made in order to make the profile and organization pages editable.

It contains the following:
- A generic AccountPage component which is being used by the organization page and the account page
- Some big changes to the structure of the json objects, that store the temporary data. I tried to set them up in a way that each of them could be a database table once we start using a database. Some of the data in the files is not being used in this PR, but will be in a later one
