### PR TITLE
Create components for various types of dialogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "lodash": "^4.17.15",
     "next": "9.1.1",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "react-avatar-editor": "^12.0.0-beta.0",
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "enzyme": "^3.10.0",

--- a/src/components/dialogs/ConfirmDialog.js
+++ b/src/components/dialogs/ConfirmDialog.js
@@ -1,0 +1,62 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import GenericDialog from "./GenericDialog";
+
+const useStyles = makeStyles(theme => ({
+  buttonsContainer: {
+    marginTop: theme.spacing(3),
+    textAlign: "right"
+  },
+  button: {
+    marginLeft: theme.spacing(2)
+  }
+}));
+
+export default function ConfirmDialog(props) {
+  const { onClose, open, cancelText, confirmText, text, title, className } = props;
+  const classes = useStyles();
+
+  const handleCancel = () => {
+    onClose(false);
+  };
+
+  const handleConfirm = () => {
+    onClose(true);
+  };
+
+  return (
+    <GenericDialog onClose={handleCancel} open={open} title={title} className={className}>
+      <div>{text}</div>
+      <div className={classes.buttonsContainer}>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleCancel}
+          className={classes.button}
+        >
+          {cancelText}
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleConfirm}
+          className={classes.button}
+        >
+          {confirmText}
+        </Button>
+      </div>
+    </GenericDialog>
+  );
+}
+
+ConfirmDialog.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+  cancelText: PropTypes.string.isRequired,
+  confirmText: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  className: PropTypes.string
+};

--- a/src/components/dialogs/EnterTextDialog.js
+++ b/src/components/dialogs/EnterTextDialog.js
@@ -1,0 +1,71 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { TextField } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import GenericDialog from "./GenericDialog";
+
+const useStyles = makeStyles({
+  textField: {
+    width: "100%"
+  }
+});
+
+export default function EnterTextDialog({
+  onClose,
+  open,
+  title,
+  inputLabel,
+  applyText,
+  maxLength,
+  className
+}) {
+  const classes = useStyles();
+  const [element, setElement] = React.useState(null);
+
+  const handleClose = () => {
+    onClose();
+    setElement(null);
+  };
+
+  const applyElement = () => {
+    onClose(element);
+    setElement(null);
+  };
+
+  const handleChange = event => {
+    setElement(event.target.value);
+  };
+
+  return (
+    <GenericDialog
+      onClose={handleClose}
+      open={open}
+      title={title}
+      useApplyButton={true}
+      onApply={applyElement}
+      applyText={applyText ? applyText : "Apply"}
+    >
+      <div className={className}>
+        <TextField
+          className={classes.textField}
+          label={inputLabel}
+          autoFocus={true}
+          variant="outlined"
+          onChange={handleChange}
+          defaultValue={element}
+          inputProps={{ maxLength: { maxLength } }}
+        />
+      </div>
+    </GenericDialog>
+  );
+}
+
+EnterTextDialog.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  inputLabel: PropTypes.string.isRequired,
+  applyText: PropTypes.string.isRequired,
+  maxLength: PropTypes.number,
+  className: PropTypes.string
+};

--- a/src/components/dialogs/GenericDialog.js
+++ b/src/components/dialogs/GenericDialog.js
@@ -1,0 +1,79 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Dialog, DialogTitle, Button, IconButton } from "@material-ui/core";
+import KeyboardBackspaceIcon from "@material-ui/icons/KeyboardBackspace";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles(theme => ({
+  dialog: {
+    [theme.breakpoints.up("sm")]: {
+      padding: theme.spacing(8)
+    }
+  },
+  dialogContent: {
+    padding: theme.spacing(2)
+  },
+  closeButton: {
+    position: "absolute",
+    left: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500]
+  },
+  titleText: {
+    marginLeft: theme.spacing(5)
+  },
+  applyButton: {
+    position: "absolute",
+    right: theme.spacing(2),
+    top: theme.spacing(1.5)
+  }
+}));
+
+//This component should only be used by other "dialog" components
+export default function GenericDialog({
+  onClose,
+  open,
+  title,
+  useApplyButton,
+  onApply,
+  applyText,
+  children
+}) {
+  const classes = useStyles();
+
+  const handleCancel = () => {
+    onClose(false);
+  };
+  return (
+    <Dialog className={classes.dialog} onClose={handleCancel} open={open} maxWidth="md">
+      <DialogTitle>
+        {onClose ? (
+          <IconButton aria-label="close" className={classes.closeButton} onClick={onClose}>
+            <KeyboardBackspaceIcon />
+          </IconButton>
+        ) : null}
+        <span className={classes.titleText}>{title}</span>
+        {useApplyButton && applyText && (
+          <Button
+            variant="contained"
+            color="primary"
+            className={classes.applyButton}
+            onClick={onApply}
+          >
+            {applyText}
+          </Button>
+        )}
+      </DialogTitle>
+      <div className={classes.dialogContent}>{children}</div>
+    </Dialog>
+  );
+}
+
+GenericDialog.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  useApplyButton: PropTypes.boolean,
+  onApply: PropTypes.func,
+  applyText: PropTypes.string
+};

--- a/src/components/dialogs/SelectDialog.js
+++ b/src/components/dialogs/SelectDialog.js
@@ -1,0 +1,115 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button, TextField } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import SelectField from "./../general/SelectField";
+import GenericDialog from "./GenericDialog";
+
+const useStyles = makeStyles(theme => ({
+  textField: {
+    width: "100%"
+  },
+  marginTop: {
+    marginTop: theme.spacing(2)
+  },
+  applyButton: {
+    position: "absolute",
+    right: theme.spacing(2),
+    top: theme.spacing(1.5)
+  },
+  dialogContent: {
+    width: theme.spacing(50)
+  }
+}));
+
+/*
+@values: the possible options of the select field. [{key:String, name:String, additionalInfo: Array}]
+@supportAdditionalInfo: declares whether it should be possible to ask the user for additional info when he chooses an option
+If @supportAdditionalInfo is true, you can optionally add an 'additionalInfo' property to each element of @values
+*/
+export default function SelectDialog({
+  onClose,
+  open,
+  title,
+  label,
+  values,
+  supportAdditionalInfo,
+  className
+}) {
+  const classes = useStyles();
+  const [element, setElement] = React.useState(null);
+  const [additionalInfo, setAdditionalInfo] = React.useState({});
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const applyElement = event => {
+    event.preventDefault();
+    onClose(element, additionalInfo);
+  };
+
+  const handleSelectChange = event => {
+    setElement(values.filter(x => x.name === event.target.value)[0].key);
+    if (supportAdditionalInfo) {
+      const value = values.filter(val => val.name === event.target.value)[0];
+      if (value.additionalInfo.length > 0) {
+        setAdditionalInfo(
+          value.additionalInfo.map(x => {
+            return { ...x, value: "" };
+          })
+        );
+      } else {
+        setAdditionalInfo([]);
+      }
+    }
+  };
+
+  const handleAdditionalInfoChange = (key, event) => {
+    const tempAdditionalInfo = [...additionalInfo];
+    tempAdditionalInfo.filter(x => x.key === key)[0].value = event.target.value;
+    setAdditionalInfo(tempAdditionalInfo);
+  };
+
+  return (
+    <GenericDialog onClose={handleClose} open={open} title={title}>
+      <form className={className} onSubmit={applyElement}>
+        <SelectField
+          required
+          className={classes.textField}
+          onChange={handleSelectChange}
+          label={label}
+          values={supportAdditionalInfo ? values.map(x => x.name) : values}
+        />
+        {supportAdditionalInfo &&
+          additionalInfo.length > 0 &&
+          additionalInfo.map((e, i) => (
+            <TextField
+              required
+              variant="outlined"
+              type="text"
+              key={i}
+              placeholder={additionalInfo[i].name}
+              className={`${classes.textField} ${classes.marginTop}`}
+              onChange={e => handleAdditionalInfoChange(additionalInfo[i].key, e)}
+            >
+              {additionalInfo[i].value}
+            </TextField>
+          ))}
+        <Button variant="contained" color="primary" className={classes.applyButton} type="submit">
+          Add
+        </Button>
+      </form>
+    </GenericDialog>
+  );
+}
+
+SelectDialog.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  values: PropTypes.array.isRequired,
+  supportAdditionalInfo: PropTypes.bool.isRequired,
+  className: PropTypes.string
+};

--- a/src/components/dialogs/UploadImageDialog.js
+++ b/src/components/dialogs/UploadImageDialog.js
@@ -1,0 +1,121 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Slider } from "@material-ui/core";
+import { makeStyles, useTheme } from "@material-ui/core/styles";
+//Package AvatarEditor returns an object {default: defaultFunction} instead of a function which triggers a warning. This is why we use <AvatarEditor.default> in the exported function.
+import AvatarEditor from "react-avatar-editor";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
+import GenericDialog from "./GenericDialog";
+
+const useStyles = makeStyles({
+  avatarEditor: {
+    margin: "0 auto",
+    display: "block"
+  },
+  slider: {
+    display: "block",
+    margin: "0 auto"
+  }
+});
+
+export default function UploadImageDialog({
+  onClose,
+  open,
+  imageUrl,
+  borderRadius,
+  ratio,
+  height,
+  mobileHeight,
+  mediumHeight
+}) {
+  const classes = useStyles();
+  const theme = useTheme();
+  const defaultValue = 25;
+  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const mediumScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const smallScreen = useMediaQuery(theme.breakpoints.down("xs"));
+
+  const [scale, setScale] = React.useState(1);
+  const [editor, setEditor] = React.useState(null);
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const handleSliderChange = (e, newValue) => {
+    /*Down allow scaling down lower than 10% for usability. 
+    Dividing newValue by (defaultValue/0.9) is done so that the scale===1 at default value*/
+    setScale(0.1 + newValue / (defaultValue / 0.9));
+  };
+
+  const applyImage = () => {
+    onClose(editor.getImageScaledToCanvas());
+  };
+
+  const setEditorRef = editor => setEditor(editor);
+
+  const widthToUse =
+    mobileHeight && smallScreen
+      ? mobileHeight * ratio
+      : mediumHeight && mediumScreen
+      ? mediumHeight * ratio
+      : height * ratio;
+  const heightToUse =
+    smallScreen && mobileHeight
+      ? mobileHeight
+      : mediumHeight && mediumScreen
+      ? mediumHeight
+      : height;
+  const sliderMaxWidth =
+    smallScreen && mobileHeight
+      ? mobileHeight * ratio + 100
+      : mediumHeight && mediumScreen
+      ? mediumHeight * ratio + 100
+      : height * ratio + 100;
+
+  return (
+    <GenericDialog
+      className={classes.dialog}
+      onClose={handleClose}
+      aria-labelledby="simple-dialog-title"
+      open={open}
+      fullScreen={fullScreen}
+      title={"Upload an image"}
+      useApplyButton={true}
+      applyText="Apply"
+      onApply={applyImage}
+    >
+      <div className={classes.dialogContent}>
+        <AvatarEditor.default
+          className={classes.avatarEditor}
+          image={imageUrl}
+          ref={setEditorRef}
+          width={widthToUse}
+          height={heightToUse}
+          border={50}
+          color={[0, 0, 0, 0.6]} // RGBA
+          scale={scale}
+          rotate={0}
+          borderRadius={borderRadius ? borderRadius : 0}
+        />
+        <Slider
+          aria-label="Image size"
+          defaultValue={defaultValue}
+          className={classes.slider}
+          onChange={handleSliderChange}
+          style={{ maxWidth: sliderMaxWidth }}
+        />
+      </div>
+    </GenericDialog>
+  );
+}
+
+UploadImageDialog.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+  imageUrl: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
+  ratio: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+  mobileHeight: PropTypes.number,
+  mediumHeight: PropTypes.number
+};

--- a/src/components/dialogs/UploadImageDialog.js
+++ b/src/components/dialogs/UploadImageDialog.js
@@ -86,7 +86,7 @@ export default function UploadImageDialog({
       onApply={applyImage}
     >
       <div className={classes.dialogContent}>
-        <AvatarEditor.default
+        <AvatarEditor
           className={classes.avatarEditor}
           image={imageUrl}
           ref={setEditorRef}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2199,6 +2199,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -6872,7 +6877,7 @@ prop-types-exact@1.2.0, prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7026,6 +7031,13 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-avatar-editor@^12.0.0-beta.0:
+  version "12.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/react-avatar-editor/-/react-avatar-editor-12.0.0-beta.0.tgz#e19d8ab1c5bcd480de090ff97cd95dcdaa52d964"
+  integrity sha512-7vrkqjmXDCZuBRpRsrldeN0/BAW1/rx/k+5WE1AhvQMMGXYGwy1GY3YF97okzgBYwZV3OocGyx8oauOcTz2xAw==
+  dependencies:
+    react-draggable "^4.1.0"
+
 react-dom@^16.12.0:
   version "16.12.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
@@ -7035,6 +7047,14 @@ react-dom@^16.12.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.18.0"
+
+react-draggable@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.2.0.tgz#40cc5209082ca7d613104bf6daf31372cc0e1114"
+  integrity sha512-5wFq//gEoeTYprnd4ze8GrFc+Rbnx+9RkOMR3vk4EbWxj02U6L6T3yrlKeiw4X5CtjD2ma2+b3WujghcXNRzkw==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
 
 react-error-overlay@5.1.6:
   version "5.1.6"


### PR DESCRIPTION
This PR is the second of a series of changes, that I made in order to make the profile and organization pages editable.

It contains the following:

- a GenericDialog component which is just an empty dialog with a certain title layout and styling. If we want to make changes to the way dialogs look on our site, we just need to change the styling in this component. All specific dialog components extend this component.
- A ConfirmDialog component for whenever we need a user to confirm or cancel an action.
- An EnterTextDialog component for letting the user enter free text.
- A SelectDialog for letting a user select out of a number of values. Optionally the user can be asked to submit additional information if he chooses a certain value. A real world example for this would be an organization choosing "student organization as their account type and being asked for the name of their school as additional information.
- An UploadImageDialog for uploading and image to the website and cropping it to your needs.

Known issue:
Using the AvatarEditor component from the "react-avatar-editor" package throws the following warning in the terminal where I run `yarn dev`, but no warnings/errors in the browser:
```Warning: React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: object.```
According to [this issue](https://github.com/mosch/react-avatar-editor/issues/325) it might be a compatability problem of the package. I tried using `<AvatarEditor.default>` instead of `<AvatarEditor>`, which eliminated the warning in terminal, but throws an error in browser.

Demonstrations of how each component could be used:
ConfirmDialog
![Screenshot from 2020-03-02 15-23-08](https://user-images.githubusercontent.com/10531079/75684794-c8647580-5c99-11ea-8268-5d2f04e90a1f.png)
EnterTextDialog
![Screenshot from 2020-03-02 15-53-41](https://user-images.githubusercontent.com/10531079/75687419-0fed0080-5c9e-11ea-8d13-d84055d023b0.png)
SelectDialog
![Screenshot from 2020-03-02 15-22-14](https://user-images.githubusercontent.com/10531079/75684738-a7038980-5c99-11ea-8a2d-540f06955d9d.png)
UploadImageDialog
![Screenshot from 2020-03-02 15-54-33](https://user-images.githubusercontent.com/10531079/75687464-22673a00-5c9e-11ea-9446-80ca6d3034b6.png)