### PR TITLE
make select field more generic

### DIFF
--- a/src/components/general/Form.js
+++ b/src/components/general/Form.js
@@ -68,12 +68,14 @@ export default function Form({
       ) : (
         <></>
       )}
-      <form action={formAction.href} method={formAction.method}>
+      <form action={formAction && formAction.href} method={formAction && formAction.method}>
         {fields.map(field => {
           if (field.select) {
             return (
               <SelectField
-                field={field}
+                defaultValue={field.select.defaultValue}
+                values={field.select.values}
+                label={field.label}
                 className={classes.blockElement}
                 key={field.label + fields.indexOf(field)}
               />

--- a/src/components/general/SelectField.js
+++ b/src/components/general/SelectField.js
@@ -1,46 +1,39 @@
 import React from "react";
 import { TextField } from "@material-ui/core";
-import { makeStyles } from "@material-ui/core/styles";
 
-const useStyles = makeStyles(theme => ({
-  blockElement: {
-    display: "block",
-    maxWidth: 250,
-    height: 56,
-    margin: "0 auto",
-    marginTop: theme.spacing(2)
-  },
-  maxHeight: {
-    maxHeight: 100
-  }
-}));
-
-export default function SelectField({ field }) {
-  const classes = useStyles();
-  const defaultValue = field.select.defaultValue ? field.select.defaultValue : "";
+export default function SelectField({
+  defaultValue,
+  label,
+  values,
+  onChange,
+  required,
+  className
+}) {
+  if (!defaultValue) defaultValue = "";
   const [value, setValue] = React.useState(defaultValue);
 
   const handleChange = event => {
     setValue(event.target.value);
+    if (onChange) onChange(event);
   };
 
   //TODO: possibly address warnings, that are produced by this component
   return (
     <TextField
       select
+      required={required}
       fullWidth
-      label={field.label}
-      className={classes.blockElement}
+      label={label}
       value={value}
       variant="outlined"
       onChange={handleChange}
-      required={field.required}
+      className={className}
       SelectProps={{
         native: true
       }}
     >
-      {!field.defaultValue || field.defaultValue === "" ? <option value="" /> : <></>}
-      {field.select.values.map(value => {
+      {!defaultValue || defaultValue === "" ? <option value="" /> : <></>}
+      {values.map(value => {
         return (
           <option value={value.name} key={value.key}>
             {value.name}


### PR DESCRIPTION
This PR 

- makes it possible to use the Form component without declaring a formAction.

- updates the SelectField component, so you don't have to artificially create a "field" object, but can instead directly pass the properties to it.

I found this useful when building the component for #92 and #93 