### PR TITLE
Installed and added django-rest-knox to backend project for token auth.

### DIFF
--- a/backend/climateconnect_main/settings.py
+++ b/backend/climateconnect_main/settings.py
@@ -43,7 +43,8 @@ LIBRARY_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'rest_framework'
+    'rest_framework',
+    'knox'
 ]
 
 INSTALLED_APPS = CUSTOM_APPS + LIBRARY_APPS
@@ -131,3 +132,10 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'knox.auth.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication'
+    ]
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,12 @@
 asgiref==3.2.4
+cffi==1.14.0
+cryptography==2.8
 Django==2.2.11
+django-rest-knox==4.1.0
 djangorestframework==3.11.0
 psycopg2==2.8.4
+pycparser==2.20
 python-dotenv==0.12.0
 pytz==2019.3
+six==1.14.0
 sqlparse==0.3.1


### PR DESCRIPTION
Resolves #110 

I have installed django-rest-knox libarry for token authentication. I have updated settings file so that it includes knox in the installed apps, use token auth for all rest frameworks API. 

When you merge the request to develop or pull the branch locally you will have to run migration to create database tables. Knox creates database tables to store token securely. 

This will enable us to work on #123 ticket.