### PR TITLE
Infinite scrolling on main page

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^16.12.0",
     "react-avatar-editor": "^12.0.0-beta.0",
     "react-dom": "^16.12.0",
+    "react-infinite-scroller": "^1.2.4",
     "react-linkify": "^1.0.0-alpha",
     "react-timeago": "^4.4.0",
     "react-truncate": "^2.4.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,14 +4,27 @@ import ProjectPreviews from "./../src/components/project/ProjectPreviews";
 import fakeProjectData from "../public/data/projects.json";
 import About from "./about";
 
-export default function Index({ projects }) {
+export default function Index({ projectsObject }) {
+  console.log(projectsObject);
+  const [hasMore, setHasMore] = React.useState(true);
+
+  const loadMoreProjects = async page => {
+    const newProjectsObject = await getProjects(page);
+    const newProjects = newProjectsObject.projects;
+    setHasMore(newProjectsObject.hasMore);
+    return [...newProjects];
+  };
   return (
     <>
       {process.env.PRE_LAUNCH === "true" ? (
         <About />
       ) : (
         <Layout title="Work on the most effective climate projects">
-          <ProjectPreviews projects={projects} />
+          <ProjectPreviews
+            projects={projectsObject.projects}
+            loadFunc={loadMoreProjects}
+            hasMore={hasMore}
+          />
         </Layout>
       )}
     </>
@@ -20,11 +33,13 @@ export default function Index({ projects }) {
 
 Index.getInitialProps = async () => {
   return {
-    projects: await getProjects()
+    projectsObject: await getProjects(0)
   };
 };
 
-async function getProjects() {
-  const projects = fakeProjectData.projects;
-  return [...projects];
+//TODO replace by db call. console.log is just there to pass lint
+async function getProjects(page) {
+  console.log(page);
+  const projects = fakeProjectData.projects.slice(0, 6);
+  return { projects: [...projects, ...projects], hasMore: true };
 }

--- a/pages/messageUser/[profileUrl].js
+++ b/pages/messageUser/[profileUrl].js
@@ -99,7 +99,6 @@ function MessagingLayout({ user, chatting_partner, message_history }) {
       ]);
     }
     setCurMessage("");
-    console.log(messages);
     if (event) event.preventDefault();
   };
 

--- a/pages/projects/[projectId].js
+++ b/pages/projects/[projectId].js
@@ -113,9 +113,6 @@ const sortByDate = (a, b) => {
 async function getProjectByIdIfExists(projectId) {
   const project = { ...TEMP_FEATURED_DATA.projects.find(({ id }) => id === projectId) };
   project.team = await getFullProfiles(project.team);
-  console.log(project.status);
-  console.log(project);
-  console.log(TEMP_FEATURED_DATA.projects.find(({ id }) => id === projectId));
   project.timeline_posts = await Promise.all(
     project.timeline_posts.sort(sortByDate).map(async post => {
       return {

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -49,7 +49,6 @@ export default function Signin() {
         Router.push("/");
       })
       .catch(function(error) {
-        console.log(error.response.data.message);
         setErrorMessage(error.response.data.message);
       });
   };

--- a/src/components/project/ProjectPreviews.js
+++ b/src/components/project/ProjectPreviews.js
@@ -2,6 +2,7 @@ import React from "react";
 import ProjectPreview from "./ProjectPreview";
 import { Grid } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
+import InfiniteScroll from "react-infinite-scroller";
 
 const useStyles = makeStyles({
   reset: {
@@ -11,17 +12,46 @@ const useStyles = makeStyles({
   }
 });
 
-export default function ProjectPreviews({ projects }) {
+export default function ProjectPreviews({ projects, loadFunc, hasMore }) {
   const classes = useStyles();
+  const [gridItems, setGridItems] = React.useState(
+    projects.map((p, index) => <GridItem key={index} project={p} />)
+  );
+  if (!loadFunc) hasMore = false;
 
+  const loadMore = async page => {
+    const newProjects = await loadFunc(page);
+    const newGridItems = newProjects.map((p, index) => (
+      <GridItem key={(index + 1) * page} project={p} />
+    ));
+    setGridItems([...gridItems, ...newGridItems]);
+  };
   // TODO: use `project.id` instead of index when using real projects
   return (
-    <Grid container component="ul" className={`${classes.reset} ${classes.root}`} spacing={2}>
-      {projects.map((project, index) => (
-        <Grid item xs={12} sm={6} md={4} lg={3} component="li" key={index}>
-          <ProjectPreview project={project} />
-        </Grid>
-      ))}
+    <InfiniteScroll
+      pageStart={0}
+      loadMore={loadMore}
+      hasMore={hasMore}
+      loader={
+        <div className="loader" key={0}>
+          Loading ...
+        </div>
+      }
+      element={Grid}
+      container
+      component="ul"
+      className={`${classes.reset} ${classes.root}`}
+      spacing={2}
+    >
+      {gridItems}
+    </InfiniteScroll>
+  );
+}
+
+function GridItem({ project }) {
+  return (
+    <Grid item xs={12} sm={6} md={4} lg={3} component="li">
+      <ProjectPreview project={project} />
     </Grid>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7293,7 +7293,7 @@ prop-types-exact@1.2.0, prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7466,6 +7466,13 @@ react-error-overlay@5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
   integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
+
+react-infinite-scroller@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.2.4.tgz#f67eaec4940a4ce6417bebdd6e3433bfc38826e9"
+  integrity sha512-/oOa0QhZjXPqaD6sictN2edFMsd3kkMiE19Vcz5JDgHpzEJVqYcmq+V3mkwO88087kvKGe1URNksHEOt839Ubw==
+  dependencies:
+    prop-types "^15.5.8"
 
 react-is@16.8.6:
   version "16.8.6"


### PR DESCRIPTION
- Removes some unnecesary console.logs
- Uses the `react-infinite-scroller` package to allow infinite scrolling on the main page
--> known issue: passing `element={Grid}` to the `InfiniteScroll` component on `ProjectPreviews.js` causes a prop type warning: `Failed prop type: Invalid prop `element` supplied to `InfiniteScroll`, expected a ReactNode.`. This could easily be fixed by making a small change to the package as documented in [this](https://github.com/CassetteRocks/react-infinite-scroller/issues/225) issue. However it's unlikely that a PR on that package will get merged as the last real commit was 5 months ago and there are 23 open PRs. So one possibility would be to fork it, but then we might miss potential future security update. For now I'm just accepting the warning.