### PR TITLE
Prepare app for Google Cloud deployment

### DIFF
--- a/backend/.gcloudignore
+++ b/backend/.gcloudignore
@@ -1,0 +1,6 @@
+# For more information on this file, run:
+# $ gcloud topic gcloudignore
+.gcloudignore
+.git
+.gitignore
+__pycache__/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+/app.yaml

--- a/backend/climateconnect_main/settings.py
+++ b/backend/climateconnect_main/settings.py
@@ -26,7 +26,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = env('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = env('ENVIRONMENT') in ('development', 'test',)
 
 ALLOWED_HOSTS = env('ALLOWED_HOSTS').split(',')
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,5 @@
+from climateconnect_main.wsgi import application
+
+# Google App engine looks for a main.py file at the root of the app with a
+# WSGI-compatible export called app.
+app = application


### PR DESCRIPTION
This adds a few things to prepare the app for deployment to Google Cloud:

1. Adds a `.gcloudignore`
2. Sets the `DEBUG` flag to `False` in production (or more correctly, in non-development and non-test)
3. Adds a `main.py`, which Google Cloud uses to start the app
4. Ignores `/app.yaml`, which contains sensitive info used in deployments