### PR TITLE
Fix frontend environment variables for Google Cloud

### DIFF
--- a/frontend/.gcloudignore
+++ b/frontend/.gcloudignore
@@ -18,3 +18,6 @@ node_modules/
 
 # Next.js
 .next/
+
+# Development environment variables
+.env

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,12 +1,31 @@
-require("dotenv").config();
-
+const pick = require("lodash/pick");
 const withCSS = require("@zeit/next-css");
+
+// Google Cloud has us define environment variables in app.yaml. However, these
+// environment variables are not available at build time, only at runtime. To
+// get around this, we read the variables from app.yaml here.
+//
+// This is a bit of a hack but is fairly straightforward. If we change our
+// production build setup, we should revisit this code.
+let environmentVariableSource;
+if (process.env.IS_BUILDING_ON_GOOGLE_CLOUD) {
+  const yaml = require("js-yaml");
+  const fs = require("fs");
+  const path = require("path");
+
+  const appDotYamlPath = path.join(__dirname, "app.yaml");
+  const appDotYamlContents = fs.readFileSync(appDotYamlPath, "utf8");
+  const appDotYaml = yaml.safeLoad(appDotYamlContents);
+
+  environmentVariableSource = appDotYaml.env_variables;
+} else {
+  require("dotenv").config();
+  environmentVariableSource = process.env;
+}
+
 module.exports = withCSS({
   cssModules: true,
-  env: {
-    PRE_LAUNCH: process.env.PRE_LAUNCH,
-    API_URL: process.env.API_URL
-  },
+  env: pick(environmentVariableSource, ["PRE_LAUNCH", "API_URL"]),
   exportPathMap: async function(defaultPathMap) {
     if (process.env.PRE_LAUNCH)
       return {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "gcp-build": "yarn build",
+    "gcp-build": "IS_BUILDING_ON_GOOGLE_CLOUD=1 yarn build",
     "pretest": "yarn run lint",
     "format": "prettier --write '**/*.{js,jsx,json,md}'",
     "lint": "eslint .",
@@ -48,6 +48,7 @@
     "eslint": "^6.6.0",
     "eslint-plugin-react": "^7.16.0",
     "jest": "^24.9.0",
+    "js-yaml": "^3.13.1",
     "prettier": "^1.18.2",
     "pretty-quick": "^2.0.0"
   }


### PR DESCRIPTION
Google Cloud has us define environment variables in `app.yaml`. However, these environment variables are not available at build time, only at runtime.

To get around this, we read the variables from `app.yaml` during the build.

This is a bit of a hack but I hope it's straightforward. If we change our production build setup, we should revisit this solution.