### PR TITLE
Feature/manage project members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__
 *.swo
 *.py[cod]
 .idea/
+*.yaml
 
 # vscode
 /.vscode

--- a/backend/climateconnect_api/views/user_views.py
+++ b/backend/climateconnect_api/views/user_views.py
@@ -150,7 +150,7 @@ class ListMemberProjectsView(ListAPIView):
 
     def get_queryset(self):
         searched_user = UserProfile.objects.get(url_slug=self.kwargs['url_slug']).user
-        if self.request.user == searched_user:            
+        if self.request.user == searched_user:     
             return ProjectMember.objects.filter(
                 user=searched_user
             ).order_by('-id')

--- a/backend/climateconnect_main/settings.py
+++ b/backend/climateconnect_main/settings.py
@@ -64,7 +64,8 @@ MIDDLEWARE = [
 
 CORS_ORIGIN_WHITELIST = [
     "http://localhost:3000",
-    "https://frontend-dot-inbound-lexicon-271522.ey.r.appspot.com"
+    "https://frontend-dot-inbound-lexicon-271522.ey.r.appspot.com",
+    "https://alpha.climateconnect.earth"
 ]
 APPEND_SLASH = False
 

--- a/backend/organization/serializers/project.py
+++ b/backend/organization/serializers/project.py
@@ -109,10 +109,16 @@ class ProjectMemberSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ProjectMember
-        fields = ('user', 'role', 'role_in_project', 'availability')
+        fields = ('id', 'user', 'role', 'role_in_project', 'availability')
 
     def get_user(self, obj):
         return UserProfileStubSerializer(UserProfile.objects.filter(user=obj.user)[0]).data
+
+class InsertProjectMemberSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = ProjectMember
+        fields = ('id', 'user', 'role', 'role_in_project', 'availability')
 
 class ProjectCollaboratorsSerializer(serializers.ModelSerializer):
     collaborating_organization = serializers.SerializerMethodField()

--- a/backend/organization/urls.py
+++ b/backend/organization/urls.py
@@ -63,12 +63,16 @@ urlpatterns = [
     path('projects/<str:url_slug>/comments/', project_views.ListProjectCommentsView.as_view(), name="project-comments-api"),
     path('create_project/', project_views.CreateProjectView.as_view(), name='create-project-api'),
     path(
-        'projects/<int:project_id>/add_members/',
+        'projects/<str:url_slug>/add_members/',
         project_views.AddProjectMembersView.as_view(), name='add-project-members-api'
     ),
     path(
-        'projects/<int:project_id>/members/<int:member_id>/',
+        'projects/<str:url_slug>/members/<int:pk>/',
         project_views.UpdateProjectMemberView.as_view(), name='update-project-member-api'
+    ),
+    path(
+        'projects/<str:url_slug>/change_creator/',
+        project_views.ChangeProjectCreator.as_view(), name='change-project-creator-view'
     ),
     path('projecttags/', project_views.ListProjectTags.as_view(), name='list-project-tags'),
     path('projectstatus/', project_views.ListProjectStatus.as_view(), name='list-project-status')

--- a/backend/organization/views/organization_views.py
+++ b/backend/organization/views/organization_views.py
@@ -221,9 +221,7 @@ class ChangeOrganizationCreator(APIView):
             }, status=status.HTTP_400_BAD_REQUEST)
 
         organization = Organization.objects.get(url_slug=url_slug)
-        roles = Role.objects.all()        
-        logger.error(new_creator_user)
-        logger.error(organization)
+        roles = Role.objects.all()     
         if OrganizationMember.objects.filter(user=new_creator_user, organization = organization).exists():
             # update old creator profile and new creator profile
             logger.error('updating new creator')
@@ -270,6 +268,7 @@ class ListOrganizationProjectsAPIView(ListAPIView):
     def get_queryset(self):
         return ProjectParents.objects.filter(
             parent_organization__url_slug=self.kwargs['url_slug'],
+            project__is_draft=False
         ).order_by('id')
 
 class ListOrganizationMembersAPIView(ListAPIView):

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -1,5 +1,5 @@
 from dateutil.parser import parse
-from rest_framework.generics import ListAPIView
+from rest_framework.generics import ListAPIView,RetrieveUpdateDestroyAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.filters import SearchFilter
 from rest_framework.views import APIView
@@ -10,14 +10,16 @@ from django.contrib.auth.models import User
 
 from organization.models import Project, Organization, ProjectParents, ProjectMember, Post, ProjectComment, ProjectTags, ProjectTagging, ProjectStatus, ProjectCollaborators
 from organization.serializers.project import (
-    ProjectSerializer, ProjectMinimalSerializer, ProjectStubSerializer, ProjectMemberSerializer
+    ProjectSerializer, ProjectMinimalSerializer, ProjectStubSerializer, ProjectMemberSerializer,InsertProjectMemberSerializer
 )
 from organization.serializers.status import ProjectStatusSerializer
 from organization.serializers.content import (PostSerializer, ProjectCommentSerializer)
 from organization.serializers.tags import (ProjectTagsSerializer)
 from organization.utility.project import create_new_project
-from organization.permissions import (OrganizationProjectCreationPermission, ProjectReadWritePermission)
-from organization.pagination import (ProjectsPagination, MembersPagination, ProjectPostPagination, ProjectCommentPagination)
+from organization.permissions import (OrganizationProjectCreationPermission, ProjectReadWritePermission, AddProjectMemberPermission, ProjectMemberReadWritePermission, ChangeProjectCreatorPermission)
+from organization.pagination import (
+    ProjectsPagination, MembersPagination, ProjectPostPagination, ProjectCommentPagination
+)
 from organization.utility.organization import (
     check_organization,
 )
@@ -91,7 +93,6 @@ class CreateProjectView(APIView):
 
         # There are only certain roles user can have. So get all the roles first.
         roles = Role.objects.all()
-        availabilities = Availability.objects.all()
         team_members = request.data['team_members']
             
         if 'project_tags' in request.data:
@@ -109,7 +110,10 @@ class CreateProjectView(APIView):
 
         for member in team_members:
             user_role = roles.filter(id=int(member['role'])).first()
-            user_availability = availabilities.filter(id=int(member['availability'])).first()
+            try:
+                user_availability = Availability.objects.filter(id=int(member['availability'])).first()
+            except Availability.DoesNotExist:
+                raise NotFound(detail="Availability not found.", code=status.HTTP_404_NOT_FOUND)
             try:
                 user = User.objects.get(id=int(member['id']))
             except User.DoesNotExist:
@@ -259,14 +263,10 @@ class ListProjectCommentsView(ListAPIView):
         ).order_by('id')
     
 class AddProjectMembersView(APIView):
-    #TODO: update permission: only admins or creators should be able to call this route
-    permission_classes = [IsAuthenticated]
+    permission_classes = [AddProjectMemberPermission]
 
-    def post(self, request, project_id):
-        try:
-            project = Project.objects.get(id=int(project_id))
-        except Project.DoesNotExist:
-            return Response({'message': 'Project not found'}, status=status.HTTP_404_NOT_FOUND)
+    def post(self, request, url_slug):
+        project = Project.objects.get(url_slug=url_slug)
 
         roles = Role.objects.all()
         if 'team_members' not in request.data:
@@ -276,55 +276,94 @@ class AddProjectMembersView(APIView):
 
         for member in request.data['team_members']:
             try:
-                user = User.objects.get(id=int(member['user_id']))
+                user = User.objects.get(id=int(member['id']))
             except User.DoesNotExist:
-                logger.error("[AddProjectMembersView] Passed user id {} does not exists".format(int(member['user_id'])))
+                logger.error("[AddProjectMembersView] Passed user id {} does not exists".format(int(member['id'])))
                 continue
-
+            if 'permission_type_id' not in member:
+                logger.error("[AddProjectMembersView] Not permissions passed for user id {}.".format(int(member['id'])))
+                continue
             user_role = roles.filter(id=int(member['permission_type_id'])).first()
+            try:
+                user_availability = Availability.objects.filter(id=int(member['availability'])).first()
+            except Availability.DoesNotExist:
+                raise NotFound(detail="Availability not found.", code=status.HTTP_404_NOT_FOUND)
             if user:
                 ProjectMember.objects.create(
-                    project=project, user=user, role=user_role
+                    project=project, user=user, role=user_role, role_in_project=member['role_in_project'], availability=user_availability
                 )
                 logger.info("Project member created for user {}".format(user.id))
 
         return Response({'message': 'Member added to the project'}, status=status.HTTP_201_CREATED)
 
 
-class UpdateProjectMemberView(APIView):
-    permission_classes = [IsAuthenticated]
+class UpdateProjectMemberView(RetrieveUpdateDestroyAPIView):
+    permission_classes = [ProjectMemberReadWritePermission]
+    serializer_class = InsertProjectMemberSerializer
 
-    def confirm_project_and_members(self, project_id, member_id):
-        if not Project.objects.filter(id=int(project_id)).exists():
-            return Response({'message': 'Project not found'}, status=status.HTTP_404_NOT_FOUND)
+    def get_queryset(self):
+        project = Project.objects.get(url_slug=str(self.kwargs['url_slug']))
+        return ProjectMember.objects.filter(id=int(self.kwargs['pk']), project=project)
 
-        try:
-            project_member = ProjectMember.objects.get(id=int(member_id))
-        except ProjectMember.DoesNotExist:
+    def perform_destroy(self, instance):
+        instance.delete()
+        return "Project Member successfully deleted."
+
+    def perform_update(self, serializer):
+        serializer.save()
+        return serializer.data
+
+class ChangeProjectCreator(APIView):
+    permission_classes = [ChangeProjectCreatorPermission]
+
+    def post(self, request, url_slug):
+        if 'user' not in request.data:
             return Response({
-                'message': 'Member not found.'
-            }, status=status.HTTP_404_NOT_FOUND)
+                'message': 'Missing required parameters'
+            }, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            new_creator_user = User.objects.get(id=int(request.data['user']))
+        except User.DoesNotExist:
+            raise NotFound(detail="Profile not found.", code=status.HTTP_404_NOT_FOUND)
+        
+        if request.user.id == new_creator_user.id:
+            return Response({
+                'message': 'Missing required parameters'
+            }, status=status.HTTP_400_BAD_REQUEST)
 
-        return project_member
+        project = Project.objects.get(url_slug=url_slug)
+        roles = Role.objects.all()   
 
-    def get(self, request, project_id, member_id):
-        project_member = self.confirm_project_and_members(project_id, member_id)
-        serializer = ProjectMemberSerializer(project_member, many=False)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        if ProjectMember.objects.filter(user=new_creator_user, project = project).exists():
+            # update old creator profile and new creator profile
+            logger.error('updating new creator')
+            new_creator = ProjectMember.objects.filter(user=request.data['user'], project = project, id = request.data['id'])[0]
+            new_creator.role = roles.filter(role_type=Role.ALL_TYPE)[0]
+            if('role_in_project' in request.data):
+                new_creator.role_in_project = request.data['role_in_project']
+            if('availability' in request.data):
+                try:
+                    user_availability = Availability.objects.filter(id=int(request.data['availability'])).first()
+                except Availability.DoesNotExist:
+                    raise NotFound(detail="Availability not found.", code=status.HTTP_404_NOT_FOUND)
+                new_creator.user_availability = request.data['availability']
+            new_creator.save()
+        else:
+            # create new creator profile and update old creator profile
+            logger.error('adding new creator')
+            new_creator = ProjectMember.objects.create(
+                role = roles.filter(role_type=Role.ALL_TYPE)[0],
+                project = project,
+                user = new_creator_user
+            )
+            if('role_in_project' in request.data):
+                new_creator.role_in_project = request.data['role_in_project']
+            new_creator.save()
+        old_creator = ProjectMember.objects.filter(user=request.user, project = project)[0]
+        old_creator.role = roles.filter(role_type=Role.READ_WRITE_TYPE)[0]
+        old_creator.save()
 
-    def patch(self, request, project_id, member_id):
-        project_member = self.confirm_project_and_members(project_id, member_id)
-        roles = Role.objects.all()
-        # Update user role.
-        user_role = roles.filter(id=int(request.data['permission_type_id'])).first()
-        project_member.role = user_role
-        project_member.save()
-        return Response({'message': 'Member updated'}, status=status.HTTP_200_OK)
-
-    def delete(self, request, project_id, member_id):
-        project_member = self.confirm_project_and_members(project_id, member_id)
-        project_member.delete()
-        return Response({'message': 'Member deleted'}, status=status.HTTP_200_OK)
+        return Response({'message': 'Changed project creator'}, status=status.HTTP_200_OK)
 
 
 class ListProjectMembersView(ListAPIView):

--- a/frontend/app.yaml
+++ b/frontend/app.yaml
@@ -5,7 +5,7 @@ runtime: nodejs12
 handlers:
 - url: /
   secure: always
-  static_dir: pages
+  script: auto
 
 env_variables:
   API_URL: "https://inbound-lexicon-271522.ey.r.appspot.com"

--- a/frontend/app.yaml
+++ b/frontend/app.yaml
@@ -2,5 +2,10 @@ service: frontend
 
 runtime: nodejs12
 
+handlers:
+- url: /
+  secure: always
+  static_dir: pages
+
 env_variables:
   API_URL: "https://inbound-lexicon-271522.ey.r.appspot.com"

--- a/frontend/pages/manageProjectMembers/[projectUrl].js
+++ b/frontend/pages/manageProjectMembers/[projectUrl].js
@@ -1,0 +1,199 @@
+import Layout from "../../src/components/layouts/layout";
+import React from "react";
+import tokenConfig from "../../public/config/tokenConfig";
+import axios from "axios";
+import { useContext } from "react";
+import Cookies from "next-cookies";
+import UserContext from "../../src/components/context/UserContext";
+import WideLayout from "../../src/components/layouts/WideLayout";
+import LoginNudge from "../../src/components/general/LoginNudge";
+import { Typography } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import ManageProjectMembers from "../../src/components/project/ManageProjectMembers";
+
+const useStyles = makeStyles(theme => {
+  return {
+    headline: {
+      textAlign: "center",
+      marginTop: theme.spacing(4)
+    }
+  };
+});
+
+export default function manageProjectMembers({
+  project,
+  members,
+  availabilityOptions,
+  rolesOptions,
+  token
+}) {
+  const { user } = useContext(UserContext);
+  const classes = useStyles();
+  const [currentMembers, setCurrentMembers] = React.useState(
+    members ? [...members.sort((a, b) => b.role.role_type - a.role.role_type)] : []
+  );
+  if (!user)
+    return (
+      <WideLayout
+        title="Please log in to manage the members of this project"
+        hideHeadline={true}
+      >
+        <LoginNudge fullPage whatToDo="manage the members of this project" />
+      </WideLayout>
+    );
+  else if (!members.find(m => m.id === user.id))
+    return (
+      <WideLayout
+        title="Please log in to manage the members of an project"
+        hideHeadline={true}
+      >
+        <Typography variant="h4" color="primary" className={classes.headline}>
+          You are not a member of this project. Go to{" "}
+          <a href={"/projects/" + project.url_slug}>the project page</a> and click
+          join to join it.
+        </Typography>
+      </WideLayout>
+    );
+  else if (
+    members.find(m => m.id === user.id).role.name != "Creator" &&
+    members.find(m => m.id === user.id).role.name != "Administrator"
+  )
+    return (
+      <WideLayout title="No permission to manage members of this project" hideHeadline={true}>
+        <Typography variant="h4" color="primary" className={classes.headline}>
+          You need to be an administrator of the project to manage project members.
+        </Typography>
+      </WideLayout>
+    );
+  else {
+    return (
+      <Layout title="Manage project's members" hideHeadline>
+        <ManageProjectMembers
+          user={user}
+          members={members}
+          currentMembers={currentMembers}
+          setCurrentMembers={setCurrentMembers}
+          rolesOptions={rolesOptions}
+          project={project}
+          token={token}
+          availabilityOptions={availabilityOptions}
+        />
+      </Layout>
+    );
+  }
+}
+
+manageProjectMembers.getInitialProps = async ctx => {
+  const { token } = Cookies(ctx);
+  const projectUrl = encodeURI(ctx.query.projectUrl);
+  return {
+    project: await getProjectByUrlIfExists(projectUrl, token),
+    members: await getMembersByProject(projectUrl, token),
+    rolesOptions: await getRolesOptions(token),
+    availabilityOptions: await getAvailabilityOptions(token),
+    token: token
+  };
+};
+
+async function getProjectByUrlIfExists(projectUrl, token) {
+  try {
+    const resp = await axios.get(
+      process.env.API_URL + "/api/projects/" + projectUrl + "/",
+      tokenConfig(token)
+    );
+    return parseProject(resp.data);
+  } catch (err) {
+    //console.log(err);
+    if (err.response && err.response.data) console.log("Error: " + err.response.data.detail);
+    return null;
+  }
+}
+
+async function getMembersByProject(projectUrl, token) {
+  try {
+    const resp = await axios.get(
+      process.env.API_URL + "/api/projects/" + projectUrl + "/members/",
+      tokenConfig(token)
+    );
+    if (!resp.data) return null;
+    else {
+      return parseProjectMembers(resp.data.results);
+    }
+  } catch (err) {
+    console.log(err);
+    if (err.response && err.response.data) console.log("Error: " + err.response.data.detail);
+    return null;
+  }
+}
+
+function parseProjectMembers(members) {
+  return members.map(m => {
+    const member = m.user;
+    return {
+      ...member,
+      member_id: m.id,
+      id: member.id,
+      image: process.env.API_URL + member.image,
+      name: member.first_name + " " + member.last_name,
+      role: m.role,
+      availability: m.availability,
+      role_in_project: m.role_in_project ? m.role_in_project : "",
+      location: member.city ? member.city + ", " + member.country : member.country,
+      isCreator: m.role.role_type === 2
+    };
+  });
+}
+
+function parseProject(project) {
+  return {
+    name: project.name,
+    id: project.id,
+    url_slug: project.url_slug,
+    image: project.image,
+    status: project.status,
+    location: project.city + ", " + project.country,
+    description: project.description,
+    shortdescription: project.short_description,
+    collaborators_welcome: project.collaborators_welcome,
+    start_date: project.start_date,
+    end_date: project.end_date,
+    creation_date: project.created_at,
+    helpful_skills: project.skills,
+    helpful_connections: project.helpful_connections,
+    creator: project.project_parents[0].parent_organization
+      ? project.project_parents[0].parent_organization
+      : project.project_parents[0].parent_user,
+    isPersonalProject: !project.project_parents[0].parent_organization,
+    tags: project.tags.map(t => t.project_tag.name),
+    collaborating_organizations: project.collaborating_organizations.map(
+      o => o.collaborating_organization
+    )
+  };
+}
+const getRolesOptions = async token => {
+  try {
+    const resp = await axios.get(process.env.API_URL + "/roles/", tokenConfig(token));
+    if (resp.data.results.length === 0) return null;
+    else {
+      return resp.data.results;
+    }
+  } catch (err) {
+    console.log(err);
+    if (err.response && err.response.data) console.log("Error: " + err.response.data.detail);
+    return null;
+  }
+};
+
+const getAvailabilityOptions = async token => {
+  try {
+    const resp = await axios.get(process.env.API_URL + "/availability/", tokenConfig(token));
+    if (resp.data.results.length === 0) return null;
+    else {
+      return resp.data.results;
+    }
+  } catch (err) {
+    console.log(err);
+    if (err.response && err.response.data) console.log("Error: " + err.response.data.detail);
+    return null;
+  }
+};

--- a/frontend/pages/organizations/[organizationUrl].js
+++ b/frontend/pages/organizations/[organizationUrl].js
@@ -228,7 +228,7 @@ async function getMembersByOrganization(organizationUrl, token) {
     );
     if (!resp.data) return null;
     else {
-      return parseProjectMembers(resp.data.results);
+      return parseOrganizationMembers(resp.data.results);
     }
   } catch (err) {
     console.log(err);
@@ -274,7 +274,7 @@ function parseProjectStubs(projects) {
   });
 }
 
-function parseProjectMembers(members) {
+function parseOrganizationMembers(members) {
   return members.map(m => {
     const member = m.user;
     return {

--- a/frontend/pages/profiles/[profileUrl].js
+++ b/frontend/pages/profiles/[profileUrl].js
@@ -42,9 +42,6 @@ const useStyles = makeStyles(theme => {
       },
       padding: 0
     },
-    subtitle: {
-      color: `${theme.palette.secondary.main}`
-    },
     content: {
       paddingTop: theme.spacing(1),
       paddingBottom: theme.spacing(1),
@@ -59,10 +56,6 @@ const useStyles = makeStyles(theme => {
         display: "flex"
       }
     },
-    cardHeadline: {
-      marginTop: theme.spacing(3),
-      marginBottom: theme.spacing(1)
-    },
     noprofile: {
       textAlign: "center",
       padding: theme.spacing(5)
@@ -73,6 +66,17 @@ const useStyles = makeStyles(theme => {
     loginNudge: {
       textAlign: "center",
       margin: "0 auto"
+    },
+    container: {
+      position: "relative"
+    },
+    createButton: {
+      right: theme.spacing(1),
+      position: "absolute",
+      [theme.breakpoints.down("xs")]: {
+        position: "relative",
+        marginTop: theme.spacing(2)
+      }
     }
   };
 });
@@ -123,12 +127,13 @@ ProfilePage.getInitialProps = async ctx => {
 
 function ProfileLayout({ profile, projects, organizations, profileTypes, infoMetadata, user }) {
   const classes = useStyles();
+  const isOwnAccount = user && user.url_slug === profile.url_slug
   return (
     <AccountPage
       account={profile}
       default_background={DEFAULT_BACKGROUND_IMAGE}
       editHref={"/editprofile"}
-      isOwnAccount={user && user.url_slug === profile.url_slug}
+      isOwnAccount={isOwnAccount}
       type="profile"
       possibleAccountTypes={profileTypes}
       infoMetadata={infoMetadata}
@@ -136,30 +141,30 @@ function ProfileLayout({ profile, projects, organizations, profileTypes, infoMet
       {!user && (
         <LoginNudge className={classes.loginNudge} whatToDo="see this user's full information" />
       )}
-      <Container id="projects">
-        <div className={`${classes.subtitle} ${classes.cardHeadline}`}>
-          Projects:{" "}
-          <Button variant="contained" color="primary" href="/share">
+      <Container className={classes.container} id="projects">
+        <h2>
+          {isOwnAccount ? "Your projects:" : "This user's projects:"}
+          <Button variant="contained" color="primary" href="/share" className={classes.createButton}>
             Share a project
           </Button>
-        </div>
+        </h2>        
         {projects && projects.length ? (
           <ProjectPreviews projects={projects} />
         ) : (
-          <Typography>This user is not involved in any projects yet!</Typography>
+          <Typography>{(isOwnAccount ? "You are" : "This user is") + " not involved in any projects yet!"}</Typography>
         )}
       </Container>
-      <Container>
-        <div className={`${classes.subtitle} ${classes.cardHeadline}`}>
-          Organizations:{" "}
-          <Button variant="contained" color="primary" href="/createorganization">
+      <Container className={classes.container}>
+        <h2>
+          {isOwnAccount ? "Your organizations" : "This user's organizations:"}
+          <Button variant="contained" color="primary" href="/createorganization" className={classes.createButton}>
             Create an organization
           </Button>
-        </div>
+        </h2>
         {organizations && organizations.length > 0 ? (
           <OrganizationPreviews organizations={organizations} showOrganizationType />
         ) : (
-          <Typography>This user is not involved in any organizations yet!</Typography>
+          <Typography>{(isOwnAccount ? "You are" : "This user is") + " not involved in any organizations yet!"}</Typography>
         )}
       </Container>
     </AccountPage>

--- a/frontend/pages/projects/[projectId].js
+++ b/frontend/pages/projects/[projectId].js
@@ -109,7 +109,7 @@ function ProjectLayout({ project }) {
           <ProjectContent project={project} />
         </TabContent>
         <TabContent value={tabValue} index={1}>
-          <ProjectTeamContent team={project.team} />
+          <ProjectTeamContent project={project}/>
         </TabContent>
         <TabContent value={tabValue} index={2}>
           <ProjectCommentsContent comments={project.comments} />
@@ -235,7 +235,7 @@ function parseProjectMembers(projectMembers) {
       ...m.user,
       url_slug: m.user.url_slug,
       role: m.role_in_project,
-      permissions: m.role.name,
+      permission: m.role.name,
       availability: m.availability,
       name: m.user.first_name + " " + m.user.last_name,
       location: m.user.city ? m.user.city + ", " + m.user.country : m.user.country

--- a/frontend/public/lib/apiOperations.js
+++ b/frontend/public/lib/apiOperations.js
@@ -1,0 +1,35 @@
+import axios from "axios";
+import tokenConfig from "../config/tokenConfig";
+import Router from "next/router";
+
+
+export async function apiRequest(method, url, token, payload, throwError) {
+  if(payload){
+    axios[method](process.env.API_URL+url, payload, tokenConfig(token))
+    .then(function(response) {
+      return Promise.resolve(response)
+    })
+    .catch(function(error) {
+      console.log(error)
+      if(throwError)
+        throw error;
+    })
+  }else{
+    axios[method](process.env.API_URL+url, tokenConfig(token))
+      .then(function(response) {
+        return Promise.resolve(response)
+      })
+      .catch(function(error) {
+        console.log(error)
+        if(throwError)
+          throw error;
+      })
+  }
+} 
+
+export async function redirect(url, messages) {
+  Router.push({
+    pathname: url,
+    query: messages
+  });
+}

--- a/frontend/src/components/manageMembers/ManageMembers.js
+++ b/frontend/src/components/manageMembers/ManageMembers.js
@@ -1,0 +1,151 @@
+import React from "react"
+import { makeStyles, IconButton } from "@material-ui/core"
+import AutoCompleteSearchBar from "../general/AutoCompleteSearchBar"
+import AddCircleOutlineIcon from "@material-ui/icons/AddCircleOutline";
+import MiniProfileInput from "../profile/MiniProfileInput";
+
+const useStyles = makeStyles(theme => ({
+  searchBarContainer: {
+    marginTop: theme.spacing(4),
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexGrow: 100
+  },
+  searchBar: {
+    width: 800,
+    display: "flex"
+  },
+  block: {
+    marginBottom: theme.spacing(4)
+  },
+  memberContainer: {
+    display: "flex",
+    flexWrap: "wrap",
+    marginBottom: theme.spacing(2)
+  },
+  member: {
+    width: theme.spacing(40),
+    textAlign: "center",
+    marginRight: theme.spacing(4),
+    marginTop: theme.spacing(2)
+  }
+}))
+
+export default function ManageMembers({
+  currentMembers,
+  rolesOptions,
+  setCurrentMembers,
+  availabilityOptions,
+  user,
+  canEdit,
+  user_role,
+  role_property_name,
+  setUserRole,
+  hideHoursPerWeek,
+  isOrganization
+}) {
+  const classes = useStyles()
+  const renderSearchOption = option => {
+    return (
+      <React.Fragment>
+        <IconButton>
+          <AddCircleOutlineIcon />
+        </IconButton>
+        {option.first_name + " " + option.last_name}
+      </React.Fragment>
+    );
+  };
+
+  const handleAddMember = member => {
+    setCurrentMembers([
+      ...currentMembers,
+      {
+        ...member,
+        role: rolesOptions.find(r => r.name === "Member"),
+        [role_property_name]: "",
+        edited: true
+      }
+    ]);
+  };
+
+  const handleChangeMember = m => {
+    if (m.changeCreator) {
+      handleCreatorChange(m)
+    } else {
+      setCurrentMembers([
+        ...currentMembers.map(c => {
+          if (c.url_slug === m.url_slug) return m;
+          else return c;
+        })
+      ]);
+    }
+  };
+
+  const handleCreatorChange = m => {
+    setUserRole(rolesOptions.find(r => r.name === "Administrator"));
+    setCurrentMembers([
+      ...currentMembers.map(c => {
+        if (c.url_slug === m.url_slug) return { ...m, edited: true };
+        else if (c.id === user.id)
+          return { ...c, role: rolesOptions.find(r => r.name === "Administrator"), edited: true };
+        else return c;
+      })
+    ]);
+  }
+
+  const handleRemoveMember = member => {
+    setCurrentMembers([...currentMembers.filter(m => m.id !== member.id)]);
+  };
+
+  return (
+    <div>
+      <div className={classes.searchBarContainer}>
+        <AutoCompleteSearchBar
+          label="Search for your organization's members"
+          className={`${classes.searchBar} ${classes.block}`}
+          baseUrl={process.env.API_URL + "/api/members/?search="}
+          clearOnSelect
+          freeSolo
+          filterOut={[...currentMembers]}
+          onSelect={handleAddMember}
+          renderOption={renderSearchOption}
+          getOptionLabel={option => option.first_name + " " + option.last_name}
+          helperText="Type the name of the team member you want to add next."
+        />
+      </div>
+      <div className={classes.memberContainer}>
+        {currentMembers &&
+          currentMembers.length > 0 &&
+          currentMembers.map((m, index) => {
+            const creatorRole = rolesOptions.find(r => r.name === "Creator");
+            const profile = m.id === user.id ? { ...m, role: user_role } : m;
+            return (
+              <MiniProfileInput
+                key={index}
+                className={classes.member}
+                profile={profile}
+                onDelete={
+                  canEdit(m) && m.role.name !== "Creator" ? () => handleRemoveMember(m) : null
+                }
+                availabilityOptions={availabilityOptions}
+                rolesOptions={
+                  !canEdit(m) || m.id === user.id
+                    ? rolesOptions
+                    : rolesOptions.filter(r => r.role_type < user_role.role_type)
+                }
+                fullRolesOptions={rolesOptions}
+                creatorRole={creatorRole}
+                onChange={handleChangeMember}
+                hideHoursPerWeek={hideHoursPerWeek}
+                editDisabled={!canEdit(m)}
+                isOrganization={isOrganization}
+                allowAppointingCreator={m.id !== user.id && user_role.name === "Creator"}
+              />
+            );
+          })
+        }
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/profile/MiniProfileInput.js
+++ b/frontend/src/components/profile/MiniProfileInput.js
@@ -101,7 +101,8 @@ export default function MiniProfileInput({
       setOptions(fullRolesOptions);
       onChange({
         ...profile,
-        role: creatorRole
+        role: creatorRole,
+        changeCreator: true
       });
     }
   };
@@ -174,7 +175,7 @@ export default function MiniProfileInput({
             className={classes.field}
             options={availabilityOptions}
             onChange={handleChangeAvailability}
-            value={profile.availability}
+            defaultValue={profile.availability}
             required
           />
         </>

--- a/frontend/src/components/project/ManageProjectMembers.js
+++ b/frontend/src/components/project/ManageProjectMembers.js
@@ -1,7 +1,7 @@
-import React from "react";
-import { Typography, Button } from "@material-ui/core";
+import React from "react"
+import ManageMembers from "../manageMembers/ManageMembers"
+import { Typography, Button } from "@material-ui/core"
 import { makeStyles } from "@material-ui/core/styles";
-import ManageMembers from "../manageMembers/ManageMembers";
 import { apiRequest, redirect } from "../../../public/lib/apiOperations";
 
 const useStyles = makeStyles(theme => {
@@ -20,38 +20,35 @@ const useStyles = makeStyles(theme => {
       height: 40,
       width: "100%"
     }
-  };
-});
+  }
+})
 
-export default function ManageOrganizationMembers({
+export default function ManageProjectMembers({
   user,
   members,
   currentMembers,
   setCurrentMembers,
   rolesOptions,
-  organization,
+  project,
   token,
-  availabilityOptions
+  availabilityOptions,
 }) {
   const classes = useStyles();
   const [user_role, setUserRole] = React.useState(members.find(m => m.id === user.id).role);
   if (!user_role) setUserRole(members.find(m => m.id === user.id).role);
 
-  const canEdit = member => {
-    return member.id === user.id || user_role.role_type > member.role.role_type;
-  };
-
   const handleSubmit = (event) => {
-    event.preventDefault();
+    event.preventDefault()
     onSubmit()
-      .then(() => {
-        redirect("/organizations/" + organization.url_slug, {message: "You have successfully updated your organization's members"});
+      .then((ret) => {
+        if(ret !== false)
+          redirect("/projects/" + project.url_slug, {message: "You have successfully updated your project's team"});
       })
       .catch((e) => {
         console.log(e);
-        redirect("/organizations/" + organization.url_slug, {errorMessage: "Not all your updates have worked."});
+        redirect("/projects/" + project.url_slug, {message: "Not all your updates have worked."});
       });
-  };
+  }
 
   const onSubmit = async () => {
     if(!verifyInput())
@@ -62,14 +59,14 @@ export default function ManageOrganizationMembers({
         if (m.operation === "delete") deleteMember(m);
         if (m.operation === "update") updateMember(m);
         if (m.operation === "create") {
-          createMembers(m.organization_members);
+          createMembers(m.team_members);
         }
         if (m.operation === "creator_change") {
           updateCreator(m.new_creator);
         }
       })
     );
-  };
+  }
 
   const getAllChangedMembers = () => {
     const oldCreatorId = members.filter(m => m.role.name === "Creator")[0].id;
@@ -95,7 +92,7 @@ export default function ManageOrganizationMembers({
       ...updatedMembers.map(m => ({ ...m, operation: "update" }))
     ];
     if (createdMembers.length > 0)
-      allChangedMembers.push({ organization_members: [...createdMembers], operation: "create" });
+      allChangedMembers.push({ team_members: [...createdMembers], operation: "create" });
 
     if (creatorChange.length > 0)
       allChangedMembers.push({ new_creator: creatorChange[0], operation: "creator_change" });
@@ -105,7 +102,7 @@ export default function ManageOrganizationMembers({
 
   const verifyInput = () => {
     if (currentMembers.filter(cm => cm.role.name === "Creator").length !== 1) {
-      alert("There must be exactly one creator of an organization.");
+      alert("There must be exactly one creator of a project.");
       return false;
     }
     if (!members.filter(m => m.role.name === "Creator").length === 1) {
@@ -115,10 +112,14 @@ export default function ManageOrganizationMembers({
     return true
   }
 
+  const canEdit = member => {
+    return member.id === user.id || user_role.role_type > member.role.role_type;
+  };
+
   const deleteMember = m => {
     apiRequest(
       "delete", 
-      "/api/organizations/" + organization.url_slug + "/update_member/" + m.member_id + "/",
+      "/api/projects/" + project.url_slug + "/members/" + m.member_id + "/",
       token, 
       null,
       true
@@ -128,19 +129,19 @@ export default function ManageOrganizationMembers({
   const updateMember = m => {
     apiRequest(
       "patch", 
-      "/api/organizations/" + organization.url_slug + "/update_member/" + m.member_id + "/",
+      "/api/projects/" + project.url_slug + "/members/" + m.member_id + "/",
       token, 
-      parseMemberForUpdateRequest(m, organization),
+      parseMemberForUpdateRequest(m, project),
       true
     )
   };
 
-  const createMembers = organization_members => {
+  const createMembers = team_members => {
     apiRequest(
       "post", 
-      "/api/organizations/" + organization.url_slug + "/add_members/",
+      "/api/projects/" + project.url_slug + "/add_members/",
       token, 
-      parseMembersForCreateRequest(organization_members, organization),
+      parseMembersForCreateRequest(team_members, project),
       true
     )
   };
@@ -148,37 +149,34 @@ export default function ManageOrganizationMembers({
   const updateCreator = new_creator => {
     apiRequest(
       "post", 
-      "/api/organizations/" + organization.url_slug + "/change_creator/",
+      "/api/projects/" + project.url_slug + "/change_creator/",
       token, 
-      parseMemberForUpdateRequest(new_creator, organization),
+      parseMemberForUpdateRequest(new_creator, project),
       true
     )
   };
-
   return (
     <>
       <Typography variant="h4" color="primary" className={classes.headline}>
-        Manage members of {organization.name}
+        Manage members of {project.name}
       </Typography>
       <form onSubmit={handleSubmit}>
-        <ManageMembers 
+        <ManageMembers
           currentMembers = {currentMembers}
           rolesOptions = {rolesOptions}
           setCurrentMembers = {setCurrentMembers}
           availabilityOptions = {availabilityOptions}
           user={user}
           canEdit={canEdit}
-          role_property_name="role_in_organization"
+          role_property_name="role_in_project"
           user_role={user_role}
           setUserRole={setUserRole}
-          hideHoursPerWeek
-          isOrganization
-        />  
+        />
         <div className={classes.buttonsContainer}>
           <div className={classes.buttons}>
             <Button
               className={classes.button}
-              href={"/organizations/" + organization.url_slug}
+              href={"/projects/" + project.url_slug}
               variant="contained"
               color="secondary"
             >
@@ -189,27 +187,29 @@ export default function ManageOrganizationMembers({
             </Button>
           </div>
         </div>
-      </form>    
+      </form>
     </>
-  );
+  )
 }
 
 const parseMembersForCreateRequest = members => {
   return {
-    organization_members: members.map(m => ({
+    team_members: members.map(m => ({
       ...m,
       permission_type_id: m.role.id,
-      role_in_organization: m.role_in_organization ? m.role_in_organization : ""
+      role_in_project: m.role_in_project ? m.role_in_project : "",
+      availability: m.availability.id
     }))
   };
 };
 
-const parseMemberForUpdateRequest = (m, organization) => {
+const parseMemberForUpdateRequest = (m, project) => {
   return {
     id: m.member_id,
     user: m.id,
     role: m.role.id,
-    role_in_organization: m.role_in_organization ? m.role_in_organization : "",
-    organization: organization.id
+    role_in_project: m.role_in_project ? m.role_in_project : "",
+    project: project.id,
+    availability: m.availability.id
   };
 };

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -117,15 +117,15 @@ export default function ProjectContent({ project }) {
   const { user } = useContext(UserContext);
   const [showFullDescription, setShowFullDescription] = React.useState(false);
   const handleToggleFullDescriptionClick = () => setShowFullDescription(!showFullDescription);
-  const user_permissions =
+  const user_permission =
     user && project.team && project.team.find(m => m.id === user.id)
-      ? project.team.find(m => m.id === user.id).permissions
+      ? project.team.find(m => m.id === user.id).permission
       : null;
   return (
     <div>
       <div className={classes.contentBlock}>
         <div className={classes.createdBy}>
-          {user_permissions && ["Creator", "Administrator"].includes(user_permissions) && (
+          {user_permission && ["Creator", "Administrator"].includes(user_permission) && (
             <Button
               className={classes.editProjectButton}
               variant="contained"

--- a/frontend/src/components/project/ProjectTeamContent.js
+++ b/frontend/src/components/project/ProjectTeamContent.js
@@ -1,10 +1,16 @@
 import React, { useContext } from "react";
 import ProfilePreviews from "./../profile/ProfilePreviews";
-import { Typography } from "@material-ui/core";
+import { Typography, Button, makeStyles } from "@material-ui/core";
 import UserContext from "../context/UserContext";
 import LoginNudge from "../general/LoginNudge";
 import LocationOnIcon from "@material-ui/icons/LocationOn";
 import AccountBoxIcon from "@material-ui/icons/AccountBox";
+
+const useStyles = makeStyles(theme => ({
+  editButton: {
+    marginBottom: theme.spacing(1)
+  }
+}))
 
 function getTeamWithAdditionalInfo(team) {
   return team.map(m => {
@@ -16,14 +22,14 @@ function getTeamWithAdditionalInfo(team) {
         icon: LocationOnIcon,
         iconName: "LocationOnIcon",
         toolTipText: "Location"
-      });
+      });      
     if (m.role)
       additionalInfo.push({
         text: m.role,
         importance: "high",
         icon: AccountBoxIcon,
         iconName: "AccountBoxIcon",
-        toolTipText: "Role in organization"
+        toolTipText: "Role in project"
       });
     if (m.availability && m.availability !== "not_specified")
       additionalInfo.push({
@@ -34,16 +40,37 @@ function getTeamWithAdditionalInfo(team) {
   });
 }
 
-export default function TeamContent({ team }) {
+export default function TeamContent({ project }) {
   const { user } = useContext(UserContext);
+  const classes = useStyles()
   if (!user) return <LoginNudge whatToDo="see this project's team  members" />;
-  else if (team)
+  else if (project.team)
     return (
-      <ProfilePreviews
-        profiles={getTeamWithAdditionalInfo(team)}
-        allowMessage
-        showAdditionalInfo={true}
-      />
+      <>
+        {user &&
+        !!project.team.find(m => m.id === user.id) &&
+        ["Creator", "Administrator"].includes(
+          project.team.find(m => m.id === user.id).permission
+        ) && 
+          (
+            <div>
+              <Button
+                className={classes.editButton}
+                variant="contained"
+                color="primary"
+                href={"/manageProjectMembers/" + project.url_slug}
+              >
+                Manage members
+              </Button>
+            </div>
+          )
+        }
+        <ProfilePreviews
+          profiles={getTeamWithAdditionalInfo(project.team)}
+          allowMessage
+          showAdditionalInfo={true}
+        />
+      </>
     );
   else return <Typography>We could not find any members of this project.</Typography>;
 }


### PR DESCRIPTION
# Frontend changes
- Make the frontend https only in production
- Create generic `ManageMembers.js` component for managing members
- Add manage project members page by using the generic component
- Add generic lib functions for making requests to the API and for redirecting users within the frontend

# Backend changes
- Whitelist `alpha.climateconnect.earth` in backend CORS settings
- Adapt routes for managing project members

Closes #242 