### PR TITLE
Fix error when not logged in, finish user email settings, don't catch unnecessary data

### DIFF
--- a/backend/chat_messages/utility/email.py
+++ b/backend/chat_messages/utility/email.py
@@ -33,7 +33,6 @@ def send_private_chat_message_notification_email(user, message_content, chat_uui
             }
         ]
     }
-
     try:
         mail = mailjet.send.create(data=data)
         return mail

--- a/backend/climateconnect_api/views/user_views.py
+++ b/backend/climateconnect_api/views/user_views.py
@@ -76,7 +76,7 @@ class SignUpView(APIView):
     def post(self, request):
         required_params = [
             'email', 'password', 'first_name', 'last_name',
-            'country', 'city', 'email_project_suggestions', 'email_updates_on_projects'
+            'country', 'city'
         ]
         for param in required_params:
             if param not in request.data:
@@ -100,9 +100,7 @@ class SignUpView(APIView):
             user=user, country=request.data['country'],
             city=request.data['city'],
             url_slug=url_slug, name=request.data['first_name']+" "+request.data['last_name'],
-            verification_key=uuid.uuid4(),
-            email_project_suggestions=request.data['email_project_suggestions'],
-            email_updates_on_projects=request.data['email_updates_on_projects']
+            verification_key=uuid.uuid4()
         )
 
         if settings.AUTO_VERIFY == True:

--- a/backend/organization/utility/email.py
+++ b/backend/organization/utility/email.py
@@ -60,10 +60,10 @@ def send_project_comment_email(user, project, comment, sender):
                 "TemplateLanguage": True,
                 "Subject": "Somebody left a comment on your project '"+project.name+"' on Climate Connect",
                 "Variables": {
+                    "ProjectName": project.name,
                     "CommentText": comment,
                     "FirstName": user.first_name,
                     "CommenterName": sender.first_name + " " + sender.last_name,
-                    "ProjectName": project.name,
                     "url": settings.FRONTEND_URL+"/projects/"+project.url_slug+"#comments"
                 }
             }

--- a/frontend/pages/_document.js
+++ b/frontend/pages/_document.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Document, { Head, Main, NextScript } from "next/document";
+import Document, { Head, Main, NextScript, Html } from "next/document";
 import { ServerStyleSheets } from "@material-ui/core/styles";
 import theme from "../src/themes/theme";
 
@@ -8,32 +8,16 @@ import theme from "../src/themes/theme";
 export default class MyDocument extends Document {
   render() {
     return (
-      <html lang="en">
+      <Html lang="en">
         <Head>
           <meta charSet="utf-8" />
           <meta name="theme-color" content={theme.palette.primary.main} />
-          <script
-            async
-            src={`https://www.googletagmanager.com/gtag/js?id=${process.env.GOOGLE_ANALYTICS_CODE}`}
-          />
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '${process.env.GOOGLE_ANALYTICS_CODE}', {
-              page_path: window.location.pathname,
-            });
-          `
-            }}
-          />
         </Head>
         <body>
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 }

--- a/frontend/pages/activate_email/[uuid].js
+++ b/frontend/pages/activate_email/[uuid].js
@@ -1,17 +1,21 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { Typography } from "@material-ui/core";
 import Layout from "../../src/components/layouts/layout";
 import axios from "axios";
 import tokenConfig from "../../public/config/tokenConfig";
-import Cookies from "universal-cookie";
-import UserContext from "../../src/components/context/UserContext";
-import LoginNudge from "../../src/components/general/LoginNudge";
-import { redirect } from "../../public/lib/apiOperations";
+import { redirect, sendToLogin } from "../../public/lib/apiOperations";
+import cookies from "next-cookies";
 
-ProfileVerified.getInitialProps = async ctx => {
+ActivateEmail.getInitialProps = async ctx => {
   const uuid = encodeURI(ctx.query.uuid);
+  const { token } = cookies(ctx)
+  if (ctx.req && !token) {
+    const message = "You have to log in to verify your new email.";
+    return sendToLogin(ctx, message)
+  }
   return {
-    uuid: uuid
+    uuid: uuid,
+    token: token
   };
 };
 
@@ -45,22 +49,18 @@ async function newEmailVerification(uuid, token) {
   }
 }
 
-export default function ProfileVerified({ uuid }) {
-  const { user } = useContext(UserContext);
-  if (user) {
-    const cookies = new Cookies();
-    const token = cookies.get("token");
-    newEmailVerification(uuid, token);
-    return (
-      <Layout title="New Email Verification">
-        <Typography>Verifying your new E-Mail address...</Typography>
-      </Layout>
-    );
-  } else {
-    return (
-      <Layout title="New Email Verification">
-        <LoginNudge whatTodo=" verify your new E-Mail address" />
-      </Layout>
-    );
-  }
+export default function ActivateEmail({ uuid, token }) {
+  const [sentRequest, setSentRequest] = React.useState(false)
+  useEffect(function(){
+    if(!sentRequest){
+      console.log("sending new email verification request!")
+      newEmailVerification(uuid, token);
+      setSentRequest(true)
+    }
+  })
+  return (
+    <Layout title="New Email Verification">
+      <Typography>Verifying your new E-Mail address...</Typography>
+    </Layout>
+  );
 }

--- a/frontend/pages/chat/[chatUUID].js
+++ b/frontend/pages/chat/[chatUUID].js
@@ -13,6 +13,7 @@ import { getMessageFromServer } from "../../public/lib/messagingOperations";
 import UserContext from "../../src/components/context/UserContext";
 import ChatTitle from "../../src/components/communication/chat/ChatTitle";
 import PageNotFound from "../../src/components/general/PageNotFound";
+import { sendToLogin } from "../../public/lib/apiOperations";
 
 const useStyles = makeStyles(theme => {
   return {
@@ -205,6 +206,10 @@ export default function Chat({
 
 Chat.getInitialProps = async ctx => {
   const { token } = Cookies(ctx);
+  if (ctx.req && !token) {
+    const message = "You have to log in to see your chats.";
+    return sendToLogin(ctx, message)
+  }
   const [chat, messages_object] = await Promise.all([
     getChat(ctx.query.chatUUID, token),
     getChatMessagesByUUID(ctx.query.chatUUID, token, 1)

--- a/frontend/pages/editOrganization/[organizationUrl].js
+++ b/frontend/pages/editOrganization/[organizationUrl].js
@@ -9,6 +9,7 @@ import tokenConfig from "../../public/config/tokenConfig";
 import { getImageUrl } from "./../../public/lib/imageOperations";
 import { getOrganizationTagsOptions } from "./../../public/lib/getOptions";
 import PageNotFound from "../../src/components/general/PageNotFound";
+import { sendToLogin } from "../../public/lib/apiOperations";
 
 //This route should only be accessible to admins of the organization
 
@@ -99,6 +100,10 @@ export default function EditOrganizationPage({ organization, tagOptions, token }
 
 EditOrganizationPage.getInitialProps = async ctx => {
   const { token } = Cookies(ctx);
+  if (ctx.req && !token) {
+    const message = "You have to log in to edit an organization.";
+    return sendToLogin(ctx, message)
+  }
   const url = encodeURI(ctx.query.organizationUrl);
   const [organization, tagOptions] = await Promise.all([
     getOrganizationByUrlIfExists(url, token),

--- a/frontend/pages/editProject/[projectUrl].js
+++ b/frontend/pages/editProject/[projectUrl].js
@@ -15,6 +15,7 @@ import {
   getStatusOptions,
   getProjectTagsOptions
 } from "../../public/lib/getOptions";
+import { sendToLogin } from "../../public/lib/apiOperations";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -108,6 +109,10 @@ export default function EditProjectPage({
 
 EditProjectPage.getInitialProps = async ctx => {
   const { token } = Cookies(ctx);
+  if (ctx.req && !token) {
+    const message = "You have to log in to edit a project.";
+    return sendToLogin(ctx, message)
+  }
   const projectUrl = encodeURI(ctx.query.projectUrl);
   const [
     project,

--- a/frontend/pages/inbox.js
+++ b/frontend/pages/inbox.js
@@ -13,6 +13,7 @@ import AutoCompleteSearchBar from "../src/components/general/AutoCompleteSearchB
 import AddCircleOutlineIcon from "@material-ui/icons/AddCircleOutline";
 import MiniProfilePreview from "../src/components/profile/MiniProfilePreview";
 import Router from "next/router";
+import { sendToLogin } from "../public/lib/apiOperations";
 
 const useStyles = makeStyles(theme => {
   return {
@@ -233,6 +234,10 @@ const parseChats = (chats, user) =>
 
 Inbox.getInitialProps = async ctx => {
   const { token } = Cookies(ctx);
+  if (ctx.req && !token) {
+    const message = "You have to log in to see your inbox.";
+    return sendToLogin(ctx, message)
+  }
   return {
     chatData: await getChatsOfLoggedInUser(token),
     token: token

--- a/frontend/pages/manageOrganizationMembers/[organizationUrl].js
+++ b/frontend/pages/manageOrganizationMembers/[organizationUrl].js
@@ -10,6 +10,7 @@ import LoginNudge from "../../src/components/general/LoginNudge";
 import { Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import ManageOrganizationMembers from "../../src/components/organization/ManageOrganizationMembers";
+import { sendToLogin } from "../../public/lib/apiOperations";
 
 const useStyles = makeStyles(theme => {
   return {
@@ -85,6 +86,10 @@ export default function manageOrganizationMembers({
 
 manageOrganizationMembers.getInitialProps = async ctx => {
   const { token } = Cookies(ctx);
+  if (ctx.req && !token) {
+    const message = "You have to log in to manage an organization's members.";
+    return sendToLogin(ctx, message)
+  }
   const organizationUrl = encodeURI(ctx.query.organizationUrl);
   const [organization, members, rolesOptions, availabilityOptions] = await Promise.all([
     getOrganizationByUrlIfExists(organizationUrl, token),

--- a/frontend/pages/manageProjectMembers/[projectUrl].js
+++ b/frontend/pages/manageProjectMembers/[projectUrl].js
@@ -10,6 +10,7 @@ import LoginNudge from "../../src/components/general/LoginNudge";
 import { Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import ManageProjectMembers from "../../src/components/project/ManageProjectMembers";
+import { sendToLogin } from "../../public/lib/apiOperations";
 
 const useStyles = makeStyles(theme => {
   return {
@@ -78,6 +79,10 @@ export default function manageProjectMembers({
 
 manageProjectMembers.getInitialProps = async ctx => {
   const { token } = Cookies(ctx);
+  if (ctx.req && !token) {
+    const message = "You have to log in to manage a project's members.";
+    return sendToLogin(ctx, message)
+  }
   const projectUrl = encodeURI(ctx.query.projectUrl);
   const [project, members, rolesOptions, availabilityOptions] = await Promise.all([
     getProjectByUrlIfExists(projectUrl, token),

--- a/frontend/pages/projects/[projectId].js
+++ b/frontend/pages/projects/[projectId].js
@@ -119,7 +119,7 @@ ProjectPage.getInitialProps = async ctx => {
     token ? getProjectMembersByIdIfExists(projectUrl, token) : [],
     getPostsByProject(projectUrl, token),
     getCommentsByProject(projectUrl, token),
-    getIsUserFollowing(projectUrl, token)
+    token ? getIsUserFollowing(projectUrl, token) : false
   ]);
   return {
     project: project,

--- a/frontend/pages/signin.js
+++ b/frontend/pages/signin.js
@@ -38,6 +38,7 @@ export default function Signin() {
   };
 
   const [errorMessage, setErrorMessage] = React.useState(null);
+  const [message, setMessage] = React.useState(null);
   const [isLoading, setIsLoading] = React.useState(false);
 
   const { user, signIn, API_URL } = useContext(UserContext);
@@ -48,14 +49,14 @@ export default function Signin() {
     if (!initialized) {
       const params = getParams(window.location.href);
       if (params.redirect) setRedirectUrl(decodeURIComponent(params.redirect));
+      if (params.message) setMessage(params.message);
       setInitialized(true);
-    }
-    //TODO: remove router
+      //TODO: remove router
+    } 
     if (user) {
       redirectOnLogin(user, redirectUrl);
-    }
+    }   
   });
-
   const handleSubmit = async (event, values) => {
     //don't redirect to the post url
     event.preventDefault();
@@ -89,7 +90,13 @@ export default function Signin() {
   };
 
   return (
-    <Layout title="Log In" isLoading={isLoading}>
+    <Layout
+      title="Log In"
+      isLoading={isLoading}
+      message={message}
+      noSpacingBottom={!!message}
+      messageType="error"
+    >
       <Form
         fields={fields}
         messages={messages}

--- a/frontend/public/lib/apiOperations.js
+++ b/frontend/public/lib/apiOperations.js
@@ -49,3 +49,11 @@ export async function redirect(url, messages) {
     query: messages
   });
 }
+
+export async function sendToLogin(ctx, message) {
+  const pathName = ctx.asPath.substr(1, ctx.asPath.length);
+  const url = "/signin?redirect=" + pathName + "&message=" + message;
+  ctx.res.writeHead(302, { Location: url });
+  ctx.res.end();
+  return
+}

--- a/frontend/public/lib/generalOperations.js
+++ b/frontend/public/lib/generalOperations.js
@@ -8,10 +8,3 @@ export function getParams(url) {
     return obj;
   }, {});
 }
-
-export function getPath(url) {
-  if(!url) return ""
-  const url_without_protocol = url.split("//")[1]
-  const paramsIndex = url_without_protocol.indexOf("?")
-  return url_without_protocol.substr(url_without_protocol.indexOf("/")+1, paramsIndex>=0 ? paramsIndex : url_without_protocol.length)
-}

--- a/frontend/public/lib/profileOperations.js
+++ b/frontend/public/lib/profileOperations.js
@@ -32,7 +32,7 @@ export function parseProfile(profile, detailledSkills, keepOldProps) {
 const SIGN_UP_MESSAGE =
   "You are now a Climate Connect member. On this page you can customize your profile.";
 
-export function redirectOnLogin(user, redirectUrl) {  
+export function redirectOnLogin(user, redirectUrl) {
   if (user.has_logged_in < 2) {
     Router.push({
       pathname: "/editprofile",
@@ -40,8 +40,6 @@ export function redirectOnLogin(user, redirectUrl) {
         message: SIGN_UP_MESSAGE
       }
     });
-  }else if (redirectUrl) 
-    Router.push("/" + redirectUrl)
-  else 
-    Router.push("/browse");
+  } else if (redirectUrl) Router.push("/" + redirectUrl);
+  else Router.push("/browse");
 }

--- a/frontend/src/components/dialogs/ProjectFollowersDialog.js
+++ b/frontend/src/components/dialogs/ProjectFollowersDialog.js
@@ -73,13 +73,11 @@ export default function ProjectFollowersDialog({
               </Button>
             </Container>
           </>
-        ) :
-          followers && followers.length > 0 ? (
-            <ProjectFollowers followers={followers} />
-          ) : (
-            <Typography>This project does not have any followers yet.</Typography>
-          )
-        }
+        ) : followers && followers.length > 0 ? (
+          <ProjectFollowers followers={followers} />
+        ) : (
+          <Typography>This project does not have any followers yet.</Typography>
+        )}
       </div>
     </GenericDialog>
   );

--- a/frontend/src/components/general/CookieBanner.js
+++ b/frontend/src/components/general/CookieBanner.js
@@ -89,7 +89,11 @@ export default function CookieBanner({ closeBanner }) {
 
   const enableAll = () => {
     cookies.set("acceptedNecessary", true, { path: "/", sameSite: "lax", expires: oneYearFromNow });
-    cookies.set("acceptedStatistics", true, { path: "/", sameSite: "lax", expires: oneYearFromNow });
+    cookies.set("acceptedStatistics", true, {
+      path: "/",
+      sameSite: "lax",
+      expires: oneYearFromNow
+    });
     closeBanner();
   };
 

--- a/frontend/src/components/general/Header.js
+++ b/frontend/src/components/general/Header.js
@@ -42,7 +42,6 @@ import NotificationsBox from "../communication/notifications/NotificationsBox";
 import Notification from "../communication/notifications/Notification";
 import HomeIcon from "@material-ui/icons/Home";
 import theme from "../../themes/theme";
-import { getParams, getPath } from "../../../public/lib/generalOperations";
 
 const useStyles = makeStyles(theme => {
   return {
@@ -162,7 +161,7 @@ const useStyles = makeStyles(theme => {
   };
 });
 
-const getLinks = (path_to_redirect) => [
+const getLinks = path_to_redirect => [
   {
     href: "/browse",
     text: "Home",
@@ -205,7 +204,7 @@ const getLinks = (path_to_redirect) => [
     onlyShowLoggedIn: true
   },
   {
-    href: "/signin?redirect="+path_to_redirect,
+    href: "/signin?redirect=" + path_to_redirect,
     text: "Log in",
     iconForDrawer: AccountCircleIcon,
     isOutlinedInHeader: true,
@@ -281,11 +280,10 @@ export default function Header({
   transparentHeader
 }) {
   const classes = useStyles({ fixedHeader: fixedHeader, transparentHeader: transparentHeader });
-  const { user, signOut, notifications } = useContext(UserContext);
+  const { user, signOut, notifications, pathName } = useContext(UserContext);
   const [anchorEl, setAnchorEl] = React.useState(false);
   const isNarrowScreen = useMediaQuery(theme => theme.breakpoints.down("xs"));
-  const path = getPath(window.location.href)
-  const LINKS = getLinks(path)
+  const LINKS = getLinks(pathName);
   const toggleShowNotifications = event => {
     if (!anchorEl) setAnchorEl(event.currentTarget);
     else setAnchorEl(null);

--- a/frontend/src/components/layouts/LayoutWrapper.js
+++ b/frontend/src/components/layouts/LayoutWrapper.js
@@ -39,52 +39,26 @@ export default function LayoutWrapper({
   const classes = useStyles();
   const isSmallerThanMediumScreen = useMediaQuery(theme => theme.breakpoints.down("md"));
   const cookies = new Cookies();
-  const [loading, setLoading] = React.useState(true);
   const [bannerOpen, setBannerOpen] = React.useState(true);
   const { trackPageView } = useMatomo();
   const acceptedNecessary = cookies.get("acceptedNecessary");
-  useEffect(() => {
-    if (loading) setLoading(false);
-    trackPageView();
-  });
   const closeBanner = () => setBannerOpen(false);
-  if (loading)
-    return (
-      <>
-        <Head>
-          <title>Climate Connect</title>
-          <link
-            href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700,800"
-            rel="stylesheet"
-          />
-        </Head>
-        <ThemeProvider theme={theme}>
-          <div className={classes.spinnerContainer}>
-            <div>
-              <img className={classes.spinner} src="/images/logo.png" />
-            </div>
-            <Typography component="div">Loading...</Typography>
-          </div>
-        </ThemeProvider>
-      </>
-    );
-  else
-    return (
-      <>
-        <Head>
-          <title>{title}</title>
-          <link
-            href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700,800"
-            rel="stylesheet"
-          />
-        </Head>
-        <ThemeProvider theme={theme}>
-          <div className={`${!fixedHeight && !noSpaceForFooter && classes.leaveSpaceForFooter}`}>
-            {children}
-            {!acceptedNecessary && bannerOpen && <CookieBanner closeBanner={closeBanner} />}
-            {!noFeedbackButton && !isSmallerThanMediumScreen && <FeedbackButton />}
-          </div>
-        </ThemeProvider>
-      </>
-    );
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+        <link
+          href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700,800"
+          rel="stylesheet"
+        />
+      </Head>
+      <ThemeProvider theme={theme}>
+        <div className={`${!fixedHeight && !noSpaceForFooter && classes.leaveSpaceForFooter}`}>
+          {children}
+          {!acceptedNecessary && bannerOpen && <CookieBanner closeBanner={closeBanner} />}
+          {!noFeedbackButton && !isSmallerThanMediumScreen && <FeedbackButton />}
+        </div>
+      </ThemeProvider>
+    </>
+  );
 }

--- a/frontend/src/components/layouts/layout.js
+++ b/frontend/src/components/layouts/layout.js
@@ -30,6 +30,7 @@ export default function Layout({
 }) {
   const classes = useStyles();
   const [hideAlertMessage, setHideAlertMessage] = React.useState(false);
+
   return (
     <LayoutWrapper theme={theme} title={title}>
       <Header noSpacingBottom={noSpacingBottom} isStaticPage={isStaticPage} />
@@ -37,7 +38,7 @@ export default function Layout({
         <LoadingContainer headerHeight={113} footerHeight={80} />
       ) : (
         <Container maxWidth="lg" component="main">
-          {message && !hideAlertMessage === message && (
+          {message && !(hideAlertMessage === message) && (
             <Alert
               className={classes.alert}
               severity={messageType ? messageType : "success"}

--- a/frontend/src/components/project/ProjectCommentsContent.js
+++ b/frontend/src/components/project/ProjectCommentsContent.js
@@ -53,6 +53,7 @@ export default function CommentsContent({ user, project, token, setCurComments }
       replies: [],
       unconfirmed: true
     });
+    clearInput();
     if (parent_comment) payload.parent_comment = parent_comment;
     try {
       const resp = await axios.post(
@@ -62,7 +63,6 @@ export default function CommentsContent({ user, project, token, setCurComments }
       );
       handleAddComment(resp.data.comment);
       if (setDisplayReplies) setDisplayReplies(true);
-      clearInput();
     } catch (err) {
       console.log(err);
       if (err.response && err.response.data) console.log("Error: " + err.response.data.detail);

--- a/frontend/src/components/project/ProjectOverview.js
+++ b/frontend/src/components/project/ProjectOverview.js
@@ -319,8 +319,8 @@ function FollowButton({
           onClick={toggleShowFollowers}
         >
           <Typography className={classes.followersText}>
-            <span className={classes.followerNumber}>{project.number_of_followers}</span>{" "}
-            Follower{project.number_of_followers > 1 && "s"}
+            <span className={classes.followerNumber}>{project.number_of_followers}</span> Follower
+            {project.number_of_followers > 1 && "s"}
           </Typography>
         </Link>
       )}


### PR DESCRIPTION
- Respect users' email settings
- Don't require email parameters on signup in the backend
- Only try to connect WebSocket when there is a login `token`.
- Remove warning by using `Html` component from nextjs rather than `html` element
- Remove Google Analytics from Head --> will use react-ga
- Prevent making multiple requests to activate your new email on the `/activate_email` page by using the `useEffect()` hook
- Add `sendToLogin()` function to redirect user to login if they try to access a page which requires you to be logged in while not being logged in. Before this update users were seeing an internal server error in this case
- Only try to make a request to `is_user_following` if the user is actually logged in
- Allow displaying message on signin page
- Don't display a loading icon anymore when you load the page. This was done so you wouldn't see a sudden change in the header once the data about the logged in user was caught. Now that's being done on server side.
- Clear Input on comment directly after sending a comment, not just after it's confirmed