### PR TITLE
WIP: Make footer show when scrolling up (#196)

### DIFF
--- a/frontend/pages/browse.js
+++ b/frontend/pages/browse.js
@@ -23,6 +23,8 @@ import { getParams } from "../public/lib/generalOperations";
 import WideLayout from "../src/components/layouts/WideLayout";
 import FilterSection from "../src/components/indexPage/FilterSection";
 import MainHeadingContainerMobile from "../src/components/indexPage/MainHeadingContainerMobile";
+import useScrollTrigger from "@material-ui/core/useScrollTrigger";
+import TopOfPage from "../src/components/general/TopOfPage";
 
 const useStyles = makeStyles(theme => {
   return {
@@ -260,6 +262,13 @@ export default function Index({
     }
   };
 
+  const isScrollingUp = !useScrollTrigger({
+    disableHysteresis: false,
+    threshold: 0
+   });
+  const atTopOfPage = TopOfPage({initTopOfPage:true});
+  const showOnScrollUp = isScrollingUp && !atTopOfPage;
+
   return (
     <>
       {process.env.PRE_LAUNCH === "true" ? (
@@ -270,6 +279,7 @@ export default function Index({
           hideHeadline
           message={errorMessage ? errorMessage : message}
           messageType={errorMessage ? "error" : "success"}
+          showOnScrollUp={showOnScrollUp}
         >
           <MainHeadingContainerMobile />
           <Container maxWidth="lg">

--- a/frontend/src/components/general/Footer.js
+++ b/frontend/src/components/general/Footer.js
@@ -20,6 +20,11 @@ const useStyles = makeStyles(theme => ({
     position: "absolute",
     bottom: 0
   },
+  relativePosition: {
+    position: "fixed",
+    bottom: 0,
+    backgroundColor: '#FFFFFF',
+  },
   spacingTop: {
     marginTop: theme.spacing(2)
   },
@@ -66,19 +71,20 @@ const useStyles = makeStyles(theme => ({
 }));
 
 //TODO: make footer stay on bottom on normal layout again
-export default function Footer({ className, noSpacingTop, noAbsolutePosition, large }) {
+export default function Footer({ className, noSpacingTop, noAbsolutePosition, showOnScrollUp, large }) {
   if (!large)
     return (
       <SmallFooter
         className={className}
         noSpacingTop={noSpacingTop}
         noAbsolutePosition={noAbsolutePosition}
+        showOnScrollUp={showOnScrollUp}
       />
     );
   else return <LargeFooter className={className} />;
 }
 
-const SmallFooter = ({ className, noSpacingTop, noAbsolutePosition }) => {
+const SmallFooter = ({ className, noSpacingTop, noAbsolutePosition, showOnScrollUp }) => {
   const classes = useStyles();
   const isNarrowScreen = useMediaQuery(theme => theme.breakpoints.down("xs"));
 
@@ -86,7 +92,8 @@ const SmallFooter = ({ className, noSpacingTop, noAbsolutePosition }) => {
     <Box
       component="footer"
       className={`${className} ${classes.root} ${!noSpacingTop &&
-        classes.spacingTop} ${!noAbsolutePosition && classes.absolutePosition}`}
+        classes.spacingTop} ${!noAbsolutePosition &&
+        (showOnScrollUp === true ? classes.relativePosition : classes.absolutePosition) }`}
     >
       <Box className={classes.flexContainer}>
         <Box className={classes.leftBox}>

--- a/frontend/src/components/general/TopOfPage.js
+++ b/frontend/src/components/general/TopOfPage.js
@@ -1,0 +1,33 @@
+//global imports
+import React, {useState, useEffect } from "react";
+import { Typography, Container } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
+export default function TopOfPage ({
+  initTopOfPage
+}) {
+  const [topOfPage, setTopOfPage] = useState(initTopOfPage);
+
+  useEffect(() => {
+    let ticking = false;
+
+    const updateTopOfPage = () => {
+      const scrollY = window.pageYOffset;
+      setTopOfPage(scrollY === 0.0);
+      ticking = false;
+    };
+
+    const onScroll = () => {
+      if (!ticking) {
+        window.requestAnimationFrame(updateTopOfPage);
+        ticking = true;
+      }
+    };
+
+    window.addEventListener("scroll", onScroll)
+
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [initTopOfPage]);
+
+  return topOfPage;
+};

--- a/frontend/src/components/layouts/WideLayout.js
+++ b/frontend/src/components/layouts/WideLayout.js
@@ -32,6 +32,7 @@ export default function WideLayout({
   isStaticPage,
   noFeedbackButton, //don't display the fixed feedback button on the right border of the screen. Can be useful on mobile
   noSpaceBottom, //display the footer directly under the content without any margin
+  showOnScrollUp, //display the footer when scrolling up, used for "inifinite scroll" pages
   largeFooter,
   description
 }) {
@@ -70,7 +71,7 @@ export default function WideLayout({
           {children}
         </Container>
       )}
-      <Footer noSpacingTop={noSpaceBottom} noAbsolutePosition={noSpaceBottom} large={largeFooter} />
+      <Footer noSpacingTop={noSpaceBottom} noAbsolutePosition={noSpaceBottom} showOnScrollUp={showOnScrollUp} large={largeFooter} />
     </LayoutWrapper>
   );
 }


### PR DESCRIPTION
Use a separate style with "fixed" position when an upwards scroll is triggered,
in order to make the footer visible.

Comments or other suggestions welcome. 

I have only done this in ```frontend/src/components/general/Footer.js``` currently, let me know if ```frontend/src/components/footer/LargeFooter.js``` would require the same.

I am new to react and django, but interested in contributing to this project.