### PR TITLE
Loading spinner for browse pages, shows up while fetching further content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ __pycache__
 backend/.vscode
 frontend/.vscode
 
+# intellij
+*.iml
+
 #azure
 backend/.azure

--- a/frontend/src/components/organization/OrganizationPreview.js
+++ b/frontend/src/components/organization/OrganizationPreview.js
@@ -43,7 +43,7 @@ const useStyles = makeStyles(theme => {
   };
 });
 
-export default function OrganizationPreview({ organization, showMembers, showOrganizationType }) {
+export default function OrganizationPreview({ organization, showOrganizationType }) {
   const classes = useStyles();
   return (
     <Link href={`/organizations/${organization.url_slug}`} className={classes.noUnderline}>
@@ -61,7 +61,6 @@ export default function OrganizationPreview({ organization, showMembers, showOrg
           </Typography>
           <OrganizationMetaData
             organization={organization}
-            showMembers={showMembers}
             showOrganizationType={showOrganizationType}
           />
         </CardContent>

--- a/frontend/src/components/organization/OrganizationPreviews.js
+++ b/frontend/src/components/organization/OrganizationPreviews.js
@@ -3,6 +3,7 @@ import OrganizationPreview from "./OrganizationPreview";
 import { Grid } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import InfiniteScroll from "react-infinite-scroller";
+import CircularProgress from "@material-ui/core/CircularProgress";
 
 const useStyles = makeStyles({
   reset: {
@@ -11,8 +12,8 @@ const useStyles = makeStyles({
     listStyleType: "none",
     width: "100%"
   },
-  loader: {
-    clear: "both"
+  spinner: {
+    marginTop: '48px'
   }
 });
 
@@ -20,40 +21,40 @@ export default function OrganizationPreviews({
   organizations,
   loadFunc,
   hasMore,
-  showMembers,
   showOrganizationType,
   parentHandlesGridItems
 }) {
+  const toOrganizationPreviews = (organizations) => organizations.map(o => (
+      <GridItem
+          key={o.url_slug}
+          organization={o}
+          showOrganizationType={showOrganizationType}
+      />
+  ));
   const [isLoading, setIsLoading] = React.useState(false);
   const classes = useStyles();
-  const [gridItems, setGridItems] = React.useState(
-    organizations.map((o, index) => (
-      <GridItem
-        key={index}
-        organization={o}
-        showMembers={showMembers}
-        showOrganizationType={showOrganizationType}
-      />
-    ))
-  );
+  const [gridItems, setGridItems] = React.useState(toOrganizationPreviews(organizations));
+
   if (!loadFunc) hasMore = false;
   const loadMore = async page => {
     if (!isLoading) {
       setIsLoading(true);
       const newOrganizations = await loadFunc(page);
       if (!parentHandlesGridItems) {
-        const newGridItems = newOrganizations.map((o, index) => (
-          <GridItem
-            key={(index + 1) * page}
-            organization={o}
-            showMembers={showMembers}
-            showOrganizationType={showOrganizationType}
-          />
-        ));
-        setGridItems([...gridItems, ...newGridItems]);
+        setGridItems([...gridItems, ...toOrganizationPreviews(newOrganizations)]);
       }
       setIsLoading(false);
     }
+  };
+
+  const loadingSpinner = () => {
+    return (
+        isLoading ? (
+            <Grid container justify="center">
+              <CircularProgress className={classes.spinner} />
+            </Grid>
+        ) : null
+    )
   };
 
   // TODO: use `organization.id` instead of index when using real organizations
@@ -62,11 +63,6 @@ export default function OrganizationPreviews({
       pageStart={0}
       loadMore={loadMore}
       hasMore={hasMore && !isLoading}
-      loader={
-        <div className={classes.loader} key={0}>
-          Loading ...
-        </div>
-      }
       element={Grid}
       container
       component="ul"
@@ -75,26 +71,19 @@ export default function OrganizationPreviews({
     >
       {parentHandlesGridItems
         ? organizations && organizations.length > 0
-          ? organizations.map(o => (
-              <GridItem
-                key={o.url_slug}
-                organization={o}
-                showMembers={showMembers}
-                showOrganizationType={showOrganizationType}
-              />
-            ))
+          ? toOrganizationPreviews(organizations)
           : "No Results"
         : gridItems}
+      {loadingSpinner()}
     </InfiniteScroll>
   );
 }
 
-function GridItem({ organization, showMembers, showOrganizationType }) {
+function GridItem({ organization, showOrganizationType }) {
   return (
     <Grid key={organization.url_slug} item xs={12} sm={6} md={4} lg={3} component="li">
       <OrganizationPreview
         organization={organization}
-        showMembers={showMembers}
         showOrganizationType={showOrganizationType}
       />
     </Grid>

--- a/frontend/src/components/profile/ProfilePreviews.js
+++ b/frontend/src/components/profile/ProfilePreviews.js
@@ -3,6 +3,7 @@ import ProfilePreview from "./ProfilePreview";
 import { Grid } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import InfiniteScroll from "react-infinite-scroller";
+import CircularProgress from "@material-ui/core/CircularProgress";
 
 const useStyles = makeStyles({
   reset: {
@@ -11,8 +12,8 @@ const useStyles = makeStyles({
     listStyleType: "none",
     width: "100%"
   },
-  loader: {
-    clear: "both"
+  spinner: {
+    marginTop: '48px'
   }
 });
 
@@ -24,26 +25,33 @@ export default function ProfilePreviews({
   parentHandlesGridItems
 }) {
   const classes = useStyles();
+  const toProfilePreviews = (profiles) => profiles
+      .map(p => <GridItem key={p.url_slug} profile={p} showAdditionalInfo={showAdditionalInfo} />);
   const [isLoading, setIsLoading] = React.useState(false);
-  const [gridItems, setGridItems] = React.useState(
-    profiles.map(p => (
-      <GridItem key={p.url_slug} profile={p} showAdditionalInfo={showAdditionalInfo} />
-    ))
-  );
+  const [gridItems, setGridItems] = React.useState(toProfilePreviews(profiles));
+
   if (!loadFunc) hasMore = false;
   const loadMore = async page => {
     if (!isLoading) {
       setIsLoading(true);
       const newProfiles = await loadFunc(page);
       if (!parentHandlesGridItems) {
-        const newGridItems = newProfiles.map(p => (
-          <GridItem key={p.url_slug} profile={p} showAdditionalInfo={showAdditionalInfo} />
-        ));
-        setGridItems([...gridItems, ...newGridItems]);
+        setGridItems([...gridItems, ...toProfilePreviews(newProfiles)]);
       }
       setIsLoading(false);
     }
   };
+
+  const loadingSpinner = () => {
+    return (
+        isLoading ? (
+            <Grid container justify="center">
+              <CircularProgress className={classes.spinner} />
+            </Grid>
+        ) : null
+    )
+  };
+
 
   // TODO: use `profile.id` instead of index when using real profiles
   return (
@@ -51,11 +59,6 @@ export default function ProfilePreviews({
       pageStart={0}
       loadMore={loadMore}
       hasMore={hasMore && !isLoading}
-      loader={
-        <div className={classes.loader} key={1000}>
-          Loading ...
-        </div>
-      }
       element={Grid}
       container
       component="ul"
@@ -64,11 +67,10 @@ export default function ProfilePreviews({
     >
       {parentHandlesGridItems
         ? profiles && profiles.length > 0
-          ? profiles.map(p => (
-              <GridItem key={p.url_slug} profile={p} showAdditionalInfo={showAdditionalInfo} />
-            ))
+          ? toProfilePreviews(profiles)
           : "No Results"
         : gridItems}
+      {loadingSpinner()}
     </InfiniteScroll>
   );
 }


### PR DESCRIPTION
Interesting is that the InfiniteScroll component takes the loader component as a prop, but it doesn't show it immediately or sometimes at all, so I am not using it. CircularProgress will show up when **isLoading** is set to true. 