### PR TITLE
Optimize Page Titles

### DIFF
--- a/frontend/pages/about.js
+++ b/frontend/pages/about.js
@@ -76,7 +76,7 @@ export default function About({ faqQuestions }) {
 
   return (
     <>
-      <WideLayout title="About Climate Connect" isStaticPage noSpaceBottom>
+      <WideLayout title="About" isStaticPage noSpaceBottom>
         <div className={classes.root}>
           <TopSection
             headline="About"

--- a/frontend/pages/browse.js
+++ b/frontend/pages/browse.js
@@ -122,7 +122,7 @@ export default function Browse({
   return (
     <>
       <WideLayout
-        title="Climate Connect - Global platform for climate change solutions"
+        title="Global Platform for Climate Change Solutions"
         hideHeadline
         showOnScrollUp={showOnScrollUp}
         subHeader={<HubsSubHeader hubs={hubs} />}

--- a/frontend/pages/createorganization.js
+++ b/frontend/pages/createorganization.js
@@ -128,13 +128,13 @@ export default function CreateOrganization({ tagOptions, token, rolesOptions }) 
 
   if (!user)
     return (
-      <WideLayout title="Please log in to create an organization" hideHeadline={true}>
+      <WideLayout title="Please Log In to Create an Organization" hideHeadline={true}>
         <LoginNudge fullPage whatToDo="create an organization" />
       </WideLayout>
     );
   else if (curStep === "basicorganizationinfo")
     return (
-      <Layout title="Create an organization">
+      <Layout title="Create an Organization">
         <EnterBasicOrganizationInfo
           errorMessage={errorMessages.basicOrganizationInfo}
           handleSubmit={handleBasicInfoSubmit}
@@ -144,7 +144,7 @@ export default function CreateOrganization({ tagOptions, token, rolesOptions }) 
     );
   else if (curStep === "detailledorganizationinfo")
     return (
-      <WideLayout title="Create an organization">
+      <WideLayout title="Create an Organization">
         <EnterDetailledOrganizationInfo
           errorMessage={errorMessages.detailledOrganizationInfo}
           handleSubmit={handleDetailledInfoSubmit}

--- a/frontend/pages/donate.js
+++ b/frontend/pages/donate.js
@@ -104,7 +104,7 @@ export default function Donate({ goal_name, goal_amount, current_amount }) {
   const isLargeScreen = useMediaQuery(theme.breakpoints.up("md"));
   const [overlayOpen, setOverlayOpen] = React.useState(false);
   return (
-    <WideLayout title="Your donation counts" isStaticPage noSpaceBottom noFeedbackButton>
+    <WideLayout title="Your Donation Counts" isStaticPage noSpaceBottom noFeedbackButton>
       <div className={classes.root}>
         {isLargeScreen ? (
           <FloatingWidget

--- a/frontend/pages/editOrganization/[organizationUrl].js
+++ b/frontend/pages/editOrganization/[organizationUrl].js
@@ -78,7 +78,7 @@ export default function EditOrganizationPage({ organization, tagOptions, token }
   }
 
   return (
-    <WideLayout title={organization ? organization.name + "'s profile" : "Not found"}>
+    <WideLayout title={organization ? organization.name + "'s Profile" : "Not found"}>
       {organization ? (
         <EditAccountPage
           type="organization"

--- a/frontend/pages/editProject/[projectUrl].js
+++ b/frontend/pages/editProject/[projectUrl].js
@@ -53,13 +53,13 @@ export default function EditProjectPage({
 
   if (!user)
     return (
-      <WideLayout title="Please log in to edit this project" hideHeadline={true}>
+      <WideLayout title="Please Log In to Edit this Climate Solution" hideHeadline={true}>
         <LoginNudge fullPage whatToDo="edit this project" />
       </WideLayout>
     );
   else if (!project)
     return (
-      <Layout className={classes.root} title="Project not found">
+      <Layout className={classes.root} title="Project not Found">
         <Typography className={classes.errorTitle} variant="h3">
           This project does not exist. <Link href="/share">Click here</Link> to create a project
         </Typography>
@@ -67,7 +67,7 @@ export default function EditProjectPage({
     );
   else if (!members.find((m) => m.user && m.user.id === user.id))
     return (
-      <WideLayout title="Please log in to edit an project" hideHeadline={true}>
+      <WideLayout title="Please Log In to Edit a Climate Solution" hideHeadline={true}>
         <Typography variant="h4" color="primary" className={classes.errorTitle}>
           You are not a member of this project. Go to{" "}
           <a href={"/projects/" + project.url_slug}>the project page</a> and ask to be part of the
@@ -80,7 +80,7 @@ export default function EditProjectPage({
     members.find((m) => m.user && m.user.id === user.id).role.name != "Administrator"
   )
     return (
-      <WideLayout title="No permission to edit this project" hideHeadline={true}>
+      <WideLayout title="No Permission to Edit this Climate Solution" hideHeadline={true}>
         <Typography variant="h4" color="primary" cclassName={classes.errorTitle}>
           You need to be an administrator of the project to manage the team.
         </Typography>
@@ -89,7 +89,7 @@ export default function EditProjectPage({
   else {
     const user_role = members.find((m) => m.user && m.user.id === user.id).role;
     return (
-      <WideLayout className={classes.root} title={"Edit project " + project.name} hideHeadline>
+      <WideLayout className={classes.root} title={"Edit Solution " + project.name} hideHeadline>
         <EditProjectRoot
           oldProject={project}
           project={curProject}

--- a/frontend/pages/editprofile.js
+++ b/frontend/pages/editprofile.js
@@ -51,7 +51,7 @@ export default function EditProfilePage({
 
   if (!profile)
     return (
-      <WideLayout title="Please log in to edit your profile" hideHeadline={true}>
+      <WideLayout title="Please Log In to Edit your Profile" hideHeadline={true}>
         <LoginNudge fullPage whatToDo="edit your profile" />
       </WideLayout>
     );

--- a/frontend/pages/hubs.js
+++ b/frontend/pages/hubs.js
@@ -42,7 +42,7 @@ export default function Hubs({ hubs }) {
   const classes = useStyles();
   const isNarrowScreen = useMediaQuery(theme.breakpoints.down("xs"));
   return (
-    <WideLayout largeFooter noSpaceBottom>
+    <WideLayout largeFooter noSpaceBottom title="Climate Solution Hubs">
       <NavigationSubHeader />
       <HubHeaderImage image="/images/hubs_background.jpg" fullWidth />
       <Container>

--- a/frontend/pages/hubs/[hubUrl].js
+++ b/frontend/pages/hubs/[hubUrl].js
@@ -153,7 +153,7 @@ export default function Hub({
   };
 
   return (
-    <WideLayout title={headline + " | Climate Connect"} fixedHeader headerBackground="#FFF">
+    <WideLayout title={headline} fixedHeader headerBackground="#FFF">
       <div className={classes.contentUnderHeader}>
         <NavigationSubHeader hubName={name} />
         {process.env.DONATION_CAMPAIGN_RUNNING === "true" && <DonationCampaignInformation />}

--- a/frontend/pages/imprint.js
+++ b/frontend/pages/imprint.js
@@ -8,7 +8,7 @@ Until we have incorporated a charitable company, I put my name as the responsibl
 */
 const Impressum = () => (
   <div>
-    <Layout title="Imprint/Legal disclosure">
+    <Layout title="Imprint/Legal Disclosure">
       <h1>Legal Disclosure</h1>
       Information in accordance with Section 5 TMG
       <br />

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -93,7 +93,7 @@ export default function Index({ projects, organizations, hubs }) {
 
   return (
     <WideLayout
-      title="Climate Connect - Global platform for climate change solutions"
+      title="Global Platform for Climate Change Solutions"
       hideTitle
       fixedHeader
       transparentHeader={pos === "top"}

--- a/frontend/pages/manageOrganizationMembers/[organizationUrl].js
+++ b/frontend/pages/manageOrganizationMembers/[organizationUrl].js
@@ -36,7 +36,7 @@ export default function manageOrganizationMembers({
   if (!user)
     return (
       <WideLayout
-        title="Please log in to manage the members of this organization"
+        title="Please Log In to Manage the Members of this Organization"
         hideHeadline={true}
       >
         <LoginNudge fullPage whatToDo="manage the members of this organization" />
@@ -45,7 +45,7 @@ export default function manageOrganizationMembers({
   else if (!members.find((m) => m.id === user.id))
     return (
       <WideLayout
-        title="Please log in to manage the members of an organization"
+        title="Please Log In to Manage the Members of an Organization"
         hideHeadline={true}
       >
         <Typography variant="h4" color="primary" className={classes.headline}>
@@ -60,7 +60,7 @@ export default function manageOrganizationMembers({
     members.find((m) => m.id === user.id).role.name != "Administrator"
   )
     return (
-      <WideLayout title="No permission to manage members of this organization" hideHeadline={true}>
+      <WideLayout title="No Permission to Manage Members of this Organization" hideHeadline={true}>
         <Typography variant="h4" color="primary" className={classes.headline}>
           You need to be an administrator of the organization to manage organization members.
         </Typography>
@@ -68,7 +68,7 @@ export default function manageOrganizationMembers({
     );
   else {
     return (
-      <Layout title="Manage organization's members" hideHeadline>
+      <Layout title="Manage organization's Members" hideHeadline>
         <ManageOrganizationMembers
           user={user}
           members={members}

--- a/frontend/pages/manageProjectMembers/[projectUrl].js
+++ b/frontend/pages/manageProjectMembers/[projectUrl].js
@@ -61,7 +61,7 @@ export default function manageProjectMembers({
     );
   else {
     return (
-      <Layout title="Manage Solution Members" hideHeadline>
+      <Layout title="Manage Solution's Members" hideHeadline>
         <ManageProjectMembers
           user={user}
           members={members}

--- a/frontend/pages/manageProjectMembers/[projectUrl].js
+++ b/frontend/pages/manageProjectMembers/[projectUrl].js
@@ -35,13 +35,13 @@ export default function manageProjectMembers({
   );
   if (!user)
     return (
-      <WideLayout title="Please log in to manage the members of this project" hideHeadline={true}>
+      <WideLayout title="Please Log In to Manage the Members of this Climate Solution" hideHeadline={true}>
         <LoginNudge fullPage whatToDo="manage the members of this project" />
       </WideLayout>
     );
   else if (!members.find((m) => m.id === user.id))
     return (
-      <WideLayout title="Please log in to manage the members of an project" hideHeadline={true}>
+      <WideLayout title="Please Log In to Manage the Members of an Climate Solution" hideHeadline={true}>
         <Typography variant="h4" color="primary" className={classes.headline}>
           You are not a member of this project. Go to{" "}
           <a href={"/projects/" + project.url_slug}>the project page</a> and click join to join it.
@@ -53,7 +53,7 @@ export default function manageProjectMembers({
     members.find((m) => m.id === user.id).role.name != "Administrator"
   )
     return (
-      <WideLayout title="No permission to manage members of this project" hideHeadline={true}>
+      <WideLayout title="No Permission to Manage Members of this Climate Solution" hideHeadline={true}>
         <Typography variant="h4" color="primary" className={classes.headline}>
           You need to be an administrator of the project to manage project members.
         </Typography>
@@ -61,7 +61,7 @@ export default function manageProjectMembers({
     );
   else {
     return (
-      <Layout title="Manage project's members" hideHeadline>
+      <Layout title="Manage Solution Members" hideHeadline>
         <ManageProjectMembers
           user={user}
           members={members}

--- a/frontend/pages/organizations/[organizationUrl].js
+++ b/frontend/pages/organizations/[organizationUrl].js
@@ -55,7 +55,7 @@ export default function OrganizationPage({
   const { user } = useContext(UserContext);
   return (
     <WideLayout
-      title={organization ? organization.name : "Not found"}
+      title={organization ? organization.name : "Not Found"}
       description={organization.name + " | " + organization.info.shortdescription}
     >
       {organization ? (

--- a/frontend/pages/profiles/[profileUrl].js
+++ b/frontend/pages/profiles/[profileUrl].js
@@ -93,7 +93,7 @@ export default function ProfilePage({
   const { user } = useContext(UserContext);
   return (
     <WideLayout
-      title={profile ? profile.name + "'s profile" : "Not found"}
+      title={profile ? profile.name + "'s Profile" : "Not Found"}
       description={
         profile.name +
         " | " +

--- a/frontend/pages/projects/[projectId].js
+++ b/frontend/pages/projects/[projectId].js
@@ -92,7 +92,7 @@ export default function ProjectPage({ project, members, posts, comments, token, 
       description={project?.shortdescription}
       message={message?.message}
       messageType={message?.messageType}
-      title={project ? project.name : "Project not found"}
+      title={project ? project.name : "Solution Not Found"}
     >
       {project ? (
         <ProjectLayout

--- a/frontend/pages/reset_password/[uuid].js
+++ b/frontend/pages/reset_password/[uuid].js
@@ -42,7 +42,7 @@ export default function ResetPassword({ uuid }) {
   };
 
   return (
-    <Layout title="Set a new password">
+    <Layout title="Set a New Password">
       <Form
         fields={fields}
         messages={messages}

--- a/frontend/pages/settings.js
+++ b/frontend/pages/settings.js
@@ -24,7 +24,7 @@ export default function Settings({ settings, token }) {
     );
   else
     return (
-      <Layout title="Please log in" hideHeadline>
+      <Layout title="Please Log In" hideHeadline>
         <LoginNudge whatToDo="edit your settings." fullPage />
       </Layout>
     );

--- a/frontend/pages/share.js
+++ b/frontend/pages/share.js
@@ -20,13 +20,13 @@ export default function Share({
   const { user } = useContext(UserContext);
   if (!user)
     return (
-      <WideLayout title="Please Log In to Share a Project" hideHeadline={true}>
+      <WideLayout title="Please Log In to Share your Climate Solution" hideHeadline={true}>
         <LoginNudge fullPage whatToDo="share a project" />
       </WideLayout>
     );
   else {
     return (
-      <WideLayout title="Share a Project" hideHeadline={true}>
+      <WideLayout title="Share your Climate Solution" hideHeadline={true}>
         <ShareProjectRoot
           availabilityOptions={availabilityOptions}
           userOrganizations={userOrganizations}

--- a/frontend/pages/share.js
+++ b/frontend/pages/share.js
@@ -20,13 +20,13 @@ export default function Share({
   const { user } = useContext(UserContext);
   if (!user)
     return (
-      <WideLayout title="Please log in to share a project" hideHeadline={true}>
+      <WideLayout title="Please Log In to Share a Project" hideHeadline={true}>
         <LoginNudge fullPage whatToDo="share a project" />
       </WideLayout>
     );
   else {
     return (
-      <WideLayout title="Share a project" hideHeadline={true}>
+      <WideLayout title="Share a Project" hideHeadline={true}>
         <ShareProjectRoot
           availabilityOptions={availabilityOptions}
           userOrganizations={userOrganizations}

--- a/frontend/src/components/layouts/LayoutWrapper.js
+++ b/frontend/src/components/layouts/LayoutWrapper.js
@@ -56,7 +56,7 @@ export default function LayoutWrapper({
   return (
     <>
       <Head>
-        <title>{title ? title : "Climate Connect"}</title>
+        <title>{title ? (title + " | Climate Connect") : "Climate Connect"}</title>
         <link
           href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700,800"
           rel="stylesheet"


### PR DESCRIPTION
## Description


Standardize page titles for better SEO results. 
- Add "| Climate Connect" to every page title as default.
- Capitalize all headlines of page titles (I hope it's correct)
- Change "project" of page titles to "climate solution" (e.g. Create your Climate Solution vs. Create a Project") for better results

Closes #435 

## Todo

- Go through all pages and check page titles for a default.

