### PR TITLE
Fix extraneous network fetches in Previews components 

### DIFF
--- a/frontend/src/components/communication/chat/ChatPreviews.js
+++ b/frontend/src/components/communication/chat/ChatPreviews.js
@@ -7,7 +7,7 @@ import {
   Divider,
   Badge,
   Typography,
-  useMediaQuery
+  useMediaQuery,
 } from "@material-ui/core";
 import Truncate from "react-truncate";
 import { makeStyles } from "@material-ui/core/styles";

--- a/frontend/src/components/project/ProjectPreviews.js
+++ b/frontend/src/components/project/ProjectPreviews.js
@@ -50,7 +50,8 @@ export default function ProjectPreviews({ hasMore, loadFunc, parentHandlesGridIt
         className={classes.reset}
         component="ul"
         container
-        // TODO: fix this element; InfiniteScroll is throwing a React error
+        // TODO: fix this: InfiniteScroll is throwing a React error:
+        // Failed prop type: Invalid prop `element` supplied to `InfiniteScroll`, expected a ReactNode.
         element={Grid}
         // We block subsequent invocations from InfinteScroll until we update local state
         hasMore={hasMore && !isFetchingMore}

--- a/frontend/src/components/project/ProjectPreviews.js
+++ b/frontend/src/components/project/ProjectPreviews.js
@@ -23,6 +23,7 @@ export default function ProjectPreviews({ hasMore, loadFunc, parentHandlesGridIt
     projects.map((p) => <GridItem key={p.url_slug} project={p} />);
 
   const [gridItems, setGridItems] = useState(toProjectPreviews(projects));
+  const [isFetchingMore, setIsFetchingMore] = React.useState(false);
 
   if (!loadFunc) {
     hasMore = false;
@@ -30,12 +31,15 @@ export default function ProjectPreviews({ hasMore, loadFunc, parentHandlesGridIt
 
   const loadMore = async () => {
     // Sometimes InfiniteScroll calls loadMore twice really fast. Therefore
-    // we're aiming to cache to improve performance
-    if (hasMore) {
+    // to improve performance, we aim to guard against subsequent
+    // fetches to the API by maintaining a local state flag.
+    if (!isFetchingMore) {
+      setIsFetchingMore(true);
       const newProjects = await loadFunc();
       if (!parentHandlesGridItems) {
         setGridItems([...gridItems, ...toProjectPreviews(newProjects)]);
       }
+      setIsFetchingMore(false);
     }
   };
 
@@ -46,8 +50,10 @@ export default function ProjectPreviews({ hasMore, loadFunc, parentHandlesGridIt
         className={classes.reset}
         component="ul"
         container
+        // TODO: fix this element; InfiniteScroll is throwing a React error
         element={Grid}
-        hasMore={hasMore}
+        // We block subsequent invocations from InfinteScroll until we update local state
+        hasMore={hasMore && !isFetchingMore}
         loader={<LoadingSpinner isLoading key="project-previews-spinner" />}
         loadMore={loadMore}
         pageStart={1}


### PR DESCRIPTION
## Description

Re-introducing local state to guard against duplicate network calls. This mitigates a known limitation with [`react-infinite-scroller`](https://github.com/danbovey/react-infinite-scroller#props)'s `hasMore` prop. This should throttle the number of requests. In the future, we might consider debouncing using something like [`_.debounce`](https://lodash.com/docs/4.17.15#debounce).

Also added a TODO comment to fix the React warning that InfiniteScroll is throwing.

## Todo

- [x] PR has a meaningful title?
