### PR TITLE
Fix spinner performance with infinte scroll 

### DIFF
--- a/frontend/src/components/browse/BrowseContent.js
+++ b/frontend/src/components/browse/BrowseContent.js
@@ -30,15 +30,15 @@ const useStyles = makeStyles((theme) => {
 });
 
 export default function BrowseContent({
+  applyNewFilters,
+  applySearch,
+  customSearchBarLabels,
+  filterChoices,
+  hideMembers,
   initialMembers,
   initialOrganizations,
   initialProjects,
-  applyNewFilters,
-  filterChoices,
   loadMoreData,
-  applySearch,
-  hideMembers,
-  customSearchBarLabels,
 }) {
   const initialState = {
     items: {

--- a/frontend/src/components/footer/LargeFooter.js
+++ b/frontend/src/components/footer/LargeFooter.js
@@ -144,7 +144,17 @@ const MadeWithLoveForEarth = () => {
   return (
     <div className={classes.madeWith}>
       Made with <FavoriteIcon className={classes.heart} /> for{" "}
-      <img className={classes.earth} src="/images/earth.svg" alt="Picture of our earth" />
+      <img
+        className={classes.earth}
+        // Always include a height and width on image elements
+        // when possible, to rely on default browser UA stylesheets
+        // to set the aspect ratio. This minimizes layout shift:
+        // https://web.dev/optimize-cls/#modern-best-practice
+        width="20"
+        height="20"
+        src="/images/earth.svg"
+        alt="Picture of our earth"
+      />
     </div>
   );
 };

--- a/frontend/src/components/general/Footer.js
+++ b/frontend/src/components/general/Footer.js
@@ -123,8 +123,18 @@ const SmallFooter = ({ className, noSpacingTop, noAbsolutePosition, showOnScroll
         </Box>
         {!isNarrowScreen && (
           <Box component="span" className={classes.centerText}>
-            Made with <FavoriteIcon className={classes.heart} /> for{" "}
-            <img className={classes.earth} src="/images/earth.svg" alt="Picture of our earth" />
+            Made with <FavoriteIcon width="20" height="20" className={classes.heart} /> for{" "}
+            <img
+              alt="Picture of our earth"
+              className={classes.earth}
+              src="/images/earth.svg"
+              // Always include a height and width on image elements
+              // when possible, to rely on default browser UA stylesheets
+              // to set the aspect ratio. This minimizes layout shift:
+              // https://web.dev/optimize-cls/#modern-best-practice
+              height="20"
+              width="20"
+            />
           </Box>
         )}
         <Box component="span" className={classes.rightBox}>

--- a/frontend/src/components/project/ProjectPreviews.js
+++ b/frontend/src/components/project/ProjectPreviews.js
@@ -19,11 +19,17 @@ const useStyles = makeStyles({
 // This component is for display projects with the option to infinitely scroll to get more projects
 export default function ProjectPreviews({ hasMore, loadFunc, parentHandlesGridItems, projects }) {
   const classes = useStyles();
-  const toProjectPreviews = (projects) =>
-    projects.map((p) => <GridItem key={p.url_slug} project={p} />);
+
+  const toProjectPreviews = (projects) => {
+    if (!projects) {
+      return null;
+    }
+
+    return projects.map((p) => <GridItem key={p.url_slug} project={p} />);
+  };
 
   const [gridItems, setGridItems] = useState(toProjectPreviews(projects));
-  const [isFetchingMore, setIsFetchingMore] = React.useState(false);
+  const [isFetchingMore, setIsFetchingMore] = useState(false);
 
   if (!loadFunc) {
     hasMore = false;
@@ -55,7 +61,6 @@ export default function ProjectPreviews({ hasMore, loadFunc, parentHandlesGridIt
         element={Grid}
         // We block subsequent invocations from InfinteScroll until we update local state
         hasMore={hasMore && !isFetchingMore}
-        loader={<LoadingSpinner isLoading key="project-previews-spinner" />}
         loadMore={loadMore}
         pageStart={1}
         spacing={2}
@@ -66,6 +71,7 @@ export default function ProjectPreviews({ hasMore, loadFunc, parentHandlesGridIt
             : "No projects found."
           : gridItems}
       </InfiniteScroll>
+      {isFetchingMore && <LoadingSpinner isLoading key="project-previews-spinner" />}
     </>
   );
 }


### PR DESCRIPTION
## Description

We're diagnosing perf and layout improvements with infite scroll on browse. I've a hunch that the `loader` prop that `infinite-scroller` provides isn't reliable, and we should just mange a spinner based on component state for a better UX. 

Also added explicit width and height to a couple images which is low hanging perf improvement to minimize CLS. 

## Todo

- [x] PR has a meaningful title?
