### PR TITLE
fix duplicate project bug, add feedback while publishing project

### DIFF
--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -1,27 +1,28 @@
-from climateconnect_api.utility.translation import edit_translation, edit_translations, translate_text
 import logging
 import traceback
 
 from climateconnect_api.models import Availability, Role, Skill, UserProfile
 from climateconnect_api.models.language import Language
+from climateconnect_api.utility.translation import (edit_translation,
+                                                    edit_translations,
+                                                    translate_text)
 from climateconnect_main.utility.general import get_image_from_data_url
 from dateutil.parser import parse
 from django.contrib.auth.models import User
 from django.contrib.gis.db.models.functions import Distance
 from django.contrib.gis.geos.geometry import GEOSGeometry
+from django.db import transaction
 from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend, OrderingFilter
 from hubs.models.hub import Hub
 from location.models import Location
 from location.utility import get_location, get_location_with_range
-from organization.models import (
-    Organization, OrganizationTagging,
-    OrganizationTags, Post, Project,
-    ProjectCollaborators, ProjectComment,
-    ProjectFollower, ProjectMember,
-    ProjectParents, ProjectStatus, ProjectTagging,
-    ProjectTags
-)
+from organization.models import (Organization, OrganizationTagging,
+                                 OrganizationTags, Post, Project,
+                                 ProjectCollaborators, ProjectComment,
+                                 ProjectFollower, ProjectMember,
+                                 ProjectParents, ProjectStatus, ProjectTagging,
+                                 ProjectTags)
 from organization.models.translations import ProjectTranslation
 from organization.pagination import (MembersPagination,
                                      ProjectCommentPagination,
@@ -33,16 +34,14 @@ from organization.permissions import (AddProjectMemberPermission,
                                       ReadSensibleProjectDataPermission)
 from organization.serializers.content import (PostSerializer,
                                               ProjectCommentSerializer)
-from organization.serializers.project import (
-    EditProjectSerializer,
-    InsertProjectMemberSerializer,
-    ProjectFollowerSerializer,
-    ProjectMemberSerializer,
-    ProjectMinimalSerializer,
-    ProjectSerializer,
-    ProjectSitemapEntrySerializer,
-    ProjectStubSerializer
-)
+from organization.serializers.project import (EditProjectSerializer,
+                                              InsertProjectMemberSerializer,
+                                              ProjectFollowerSerializer,
+                                              ProjectMemberSerializer,
+                                              ProjectMinimalSerializer,
+                                              ProjectSerializer,
+                                              ProjectSitemapEntrySerializer,
+                                              ProjectStubSerializer)
 from organization.serializers.status import ProjectStatusSerializer
 from organization.serializers.tags import ProjectTagsSerializer
 from organization.utility.notification import (
@@ -188,6 +187,7 @@ class ListProjectsView(ListAPIView):
 class CreateProjectView(APIView):
     permission_classes = [IsAuthenticated]
 
+    @transaction.atomic()
     def post(self, request):
         if 'parent_organization' in request.data:
             organization = check_organization(int(request.data['parent_organization']))

--- a/frontend/public/texts/project_texts.js
+++ b/frontend/public/texts/project_texts.js
@@ -834,5 +834,24 @@ export default function getProjectTexts({ project, user, url_slug, locale }) {
       en: "Please log in or sign up to share a project",
       de: "Bitte logge dich ein oder registriere dich, um ein Projekt zu teilen",
     },
+    internal_server_error: {
+      en: "Internal Server Error",
+      de: "Interner Serverfehler",
+    },
+    error_when_publishing_project: {
+      en: (
+        <>
+          There has been an error when publishing your project.
+          <br />
+          Please contact contact@climateconnect.earth for support
+        </>
+      ),
+      de: (
+        <>
+          Beim Veröffentlichen deines Projektes gab es einen Fehler.
+          <br /> Bitte wende dich an contact@climateconnect.earth.
+        </>
+      ),
+    },
   };
 }

--- a/frontend/src/components/general/BottomNavigation.js
+++ b/frontend/src/components/general/BottomNavigation.js
@@ -1,4 +1,4 @@
-import { Button } from "@material-ui/core";
+import { Button, CircularProgress } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import React, { useContext } from "react";
 import getTexts from "../../../public/texts/texts";
@@ -23,6 +23,9 @@ const useStyles = makeStyles((theme) => {
     draftButton: {
       marginRight: theme.spacing(2),
     },
+    translationLoader: {
+      color: "white",
+    },
   };
 });
 
@@ -34,6 +37,8 @@ export default function BottomNavigation({
   onClickNextStep,
   saveAsDraft,
   additionalButtons,
+  loadingSubmit,
+  loadingSubmitDraft,
 }) {
   const classes = useStyles();
   const [open, setOpen] = React.useState(false);
@@ -94,21 +99,35 @@ export default function BottomNavigation({
             variant="contained"
             onClick={saveAsDraft}
             className={`${classes.backButton} ${classes.draftButton}`}
+            disabled={loadingSubmitDraft || loadingSubmit}
           >
-            {texts.save_as_draft}
+            {loadingSubmitDraft ? (
+              <CircularProgress className={classes.translationLoader} size={23} />
+            ) : (
+              texts.save_as_draft
+            )}
           </Button>
         )}
         <NextButtons
           nextStepButtonType={nextStepButtonType}
           onClickNextStep={onClickNextStep}
           texts={texts}
+          loadingSubmit={loadingSubmit}
+          loadingSubmitDraft={loadingSubmitDraft}
         />
       </div>
     </div>
   );
 }
 
-function NextButtons({ nextStepButtonType, onClickNextStep, texts }) {
+function NextButtons({
+  nextStepButtonType,
+  onClickNextStep,
+  texts,
+  loadingSubmit,
+  loadingSubmitDraft,
+}) {
+  const classes = useStyles();
   if (nextStepButtonType === "submit")
     return (
       <Button variant="contained" color="primary" type="submit">
@@ -123,8 +142,17 @@ function NextButtons({ nextStepButtonType, onClickNextStep, texts }) {
     );
   else if (nextStepButtonType === "publish")
     return (
-      <Button variant="contained" color="primary" type="submit">
-        {texts.publish}
+      <Button
+        variant="contained"
+        color="primary"
+        type="submit"
+        disabled={loadingSubmit || loadingSubmitDraft}
+      >
+        {loadingSubmit ? (
+          <CircularProgress className={classes.translationLoader} size={23} />
+        ) : (
+          texts.publish
+        )}
       </Button>
     );
   else

--- a/frontend/src/components/shareProject/AddTeam.js
+++ b/frontend/src/components/shareProject/AddTeam.js
@@ -42,6 +42,8 @@ export default function AddTeam({
   onSubmit,
   saveAsDraft,
   isLastStep,
+  loadingSubmit,
+  loadingSubmitDraft,
 }) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
@@ -152,6 +154,8 @@ export default function AddTeam({
             onClickPreviousStep={onClickPreviousStep}
             nextStepButtonType="publish"
             saveAsDraft={saveAsDraft}
+            loadingSubmit={loadingSubmit}
+            loadingSubmitDraft={loadingSubmitDraft}
           />
         ) : (
           <BottomNavigation

--- a/frontend/src/components/shareProject/ShareProjectRoot.js
+++ b/frontend/src/components/shareProject/ShareProjectRoot.js
@@ -7,6 +7,7 @@ import { apiRequest } from "../../../public/lib/apiOperations";
 import { blobFromObjectUrl } from "../../../public/lib/imageOperations";
 import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
+import GenericDialog from "../dialogs/GenericDialog";
 import TranslateTexts from "../general/TranslateTexts";
 import StepsTracker from "./../general/StepsTracker";
 import AddTeam from "./AddTeam";
@@ -98,6 +99,7 @@ export default function ShareProjectRoot({
   };
 
   const [sourceLanguage, setSourceLanguage] = useState(locale);
+  const [errorDialogOpen, setErrorDialogOpen] = useState(false);
   const [targetLanguage, setTargetLanguage] = useState(locales.find((l) => l !== locale));
   const [translations, setTranslations] = React.useState({});
   const [curStep, setCurStep] = React.useState(getStep(0));
@@ -173,13 +175,13 @@ export default function ShareProjectRoot({
       setFinished(true);
     } catch (error) {
       console.log(error);
+      setErrorDialogOpen(true);
       setProject({ ...project, error: true });
       setLoadingSubmit(false);
       console.log(error?.response?.data);
       if (error) console.log(error.response);
     }
   };
-
   const saveAsDraft = async (event) => {
     event.preventDefault();
     setLoadingSubmitDraft(true);
@@ -193,18 +195,23 @@ export default function ShareProjectRoot({
       .then(function (response) {
         setProject({ ...project, url_slug: response.data.url_slug, is_draft: true });
         setLoadingSubmitDraft(false);
+        setFinished(true);
       })
       .catch(function (error) {
         console.log(error);
+        setErrorDialogOpen(true);
         setProject({ ...project, error: true });
-        setLoadingSubmit(false);
+        setLoadingSubmitDraft(false);
         if (error) console.log(error.response);
       });
-    setFinished(true);
   };
 
   const handleSetProject = (newProjectData) => {
     setProject({ ...project, ...newProjectData });
+  };
+
+  const handleCloseErrorDialog = () => {
+    setErrorDialogOpen(false);
   };
 
   const textsToTranslate = [
@@ -283,6 +290,8 @@ export default function ShareProjectRoot({
               onSubmit={submitProject}
               saveAsDraft={saveAsDraft}
               isLastStep={steps[steps.length - 1].key === "addTeam"}
+              loadingSubmit={loadingSubmit}
+              loadingSubmitDraft={loadingSubmitDraft}
             />
           )}
           {curStep.key === "translate" && (
@@ -314,6 +323,15 @@ export default function ShareProjectRoot({
             hasError={project.error}
           />
         </>
+      )}
+      {project.error && (
+        <GenericDialog
+          open={errorDialogOpen}
+          onClose={handleCloseErrorDialog}
+          title={texts.internal_server_error}
+        >
+          <Typography>{texts.error_when_publishing_project}</Typography>
+        </GenericDialog>
       )}
     </>
   );


### PR DESCRIPTION
## Description
We had a bug where sometimes a project would be created multiple times. @FnayouSeif found out that this occurs when there is an error when publishing the project. In this case the user can click the "publish" button multiple times and the project will always be published to the point where the error occurs. However, the expected behavior would be that a project only gets created if there are no errors on creation.
- Make "Create project" transaction atomic to prevent having a "half-created" project
- Add loading feedback when clicking on "publish project" or "Save project as draft"
- Give feedback in a popup window if there is an error during the creation of a project
-
## Todo

- [x] PR has a meaningful title?
- [ ] Lint passes?
- [x] Ran `yarn format` in frontend?
