### PR TITLE
Properly display the about section of organizations

### DIFF
--- a/frontend/src/components/account/DetailledDescription.js
+++ b/frontend/src/components/account/DetailledDescription.js
@@ -1,5 +1,6 @@
 import { makeStyles, Typography } from "@material-ui/core";
 import React from "react";
+import MessageContent from "../communication/MessageContent";
 
 const useStyles = makeStyles((theme) => ({
   headline: {
@@ -16,7 +17,7 @@ export default function DetailledDescription({ title, value, className }) {
       <Typography color="primary" variant="h2" className={classes.headline}>
         {title}
       </Typography>
-      <Typography>{value}</Typography>
+      <MessageContent content={value}/>
     </div>
   );
 }


### PR DESCRIPTION
## Description

We used <Typography> for displaying the about text of organizations. Instead we're now using the <MessageContent> component which respects line breaks and converts link texts to actual links.

## Todo

- [ ] PR has a meaningful title?
- [ ] `yarn lint` passes in frontend?
- [ ] Ran `yarn format` in frontend?
