### PR TITLE
fix: minor project creation flow polish

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,7 @@
-## Description
+<!-- Aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. -->
 
-<!-- Short description of the change. Aim to reference the issue number of the GitHub issue. -->
+## Before landing
 
-## Todo
-
-- [ ] PR has a meaningful title?
-- [ ] `yarn lint` passes in frontend?
-- [ ] Ran `yarn format` in frontend?
+1. PR has meaningful title
+1. `yarn lint` passes
+1. `yarn format` passes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Over time, we can scope specific pieces of the project
+# to owners with more context (e.g. backend vs. frontend), but
+# for now we use this to rely on tagging teammates during
+# pull request review
+* @positiveimpact @ddhanesha @FnayouSeif @samschaevitz @piperchester

--- a/frontend/public/texts/project_texts.js
+++ b/frontend/public/texts/project_texts.js
@@ -263,7 +263,7 @@ export default function getProjectTexts({ project, user, url_slug, locale }) {
     to_fight_climate_change_we_all_need_to_work_together: {
       en: `To fight climate change, we all need to work together! If you like the project, offer to
       work with the team to make it a success!`,
-      de: `Um den Klimawandel zu bekämpfen, müssen wir alle zusammenarbeiten! Wenn dir das Projekt gefällt, 
+      de: `Um den Klimawandel zu bekämpfen, müssen wir alle zusammenarbeiten! Wenn dir das Projekt gefällt,
       biete einfach deine Mitarbeit im Team an, um es zu einem Erfolg zu machen!`,
     },
     this_project_is_open_to_collaborators: {
@@ -365,8 +365,8 @@ export default function getProjectTexts({ project, user, url_slug, locale }) {
       de: "Persönlich",
     },
     personal_project: {
-      en: "Personal Project",
-      de: "Persönliches Projekt",
+      en: "Personal project",
+      de: "Persönliches projekt",
     },
     organizations_project: {
       en: "Organization's project",
@@ -743,9 +743,9 @@ export default function getProjectTexts({ project, user, url_slug, locale }) {
       de: "Du kannst nur bis zu 3 Kategorien auswählen",
     },
     you_can_combine_categories_text: {
-      en: `You can combine categories. For example if you fund treeplanting, select both 
+      en: `You can combine categories. For example if you fund treeplanting, select both
       Afforestation/Reforestration and Funding`,
-      de: `Du kannst Kategorien kombinieren. Wenn du zum Beispiel Baumpflanzungen finanzierst, kannst du sowohl 
+      de: `Du kannst Kategorien kombinieren. Wenn du zum Beispiel Baumpflanzungen finanzierst, kannst du sowohl
       Aufforstung/Wiederaufforstung, als auch Finanzierung wählen`,
     },
     this_way_you_can_specify_what_you_are_doing_and_in_which_field: {

--- a/frontend/public/texts/project_texts.js
+++ b/frontend/public/texts/project_texts.js
@@ -773,7 +773,7 @@ export default function getProjectTexts({ project, user, url_slug, locale }) {
       ),
     },
     title_with_explanation_and_example: {
-      en: "Title (Use a short, english title, e.g. 'Generating energy from ocean waves')",
+      en: "Title (Use a short, English title, e.g. 'Generating energy from ocean waves')",
       de: "Titel (Verwende einen kurzen Titel, z. B. 'Energiegewinnung aus Meereswellen')",
     },
     use_a_title_that_makes_people_curious_to_learn_more_about_your_project: {

--- a/frontend/public/texts/project_texts.js
+++ b/frontend/public/texts/project_texts.js
@@ -773,7 +773,7 @@ export default function getProjectTexts({ project, user, url_slug, locale }) {
       ),
     },
     title_with_explanation_and_example: {
-      en: "Title (Use a short, English title, e.g. 'Generating energy from ocean waves')",
+      en: "Title (Use a short, compelling title, e.g. 'Generating energy from ocean waves')",
       de: "Titel (Verwende einen kurzen Titel, z. B. 'Energiegewinnung aus Meereswellen')",
     },
     use_a_title_that_makes_people_curious_to_learn_more_about_your_project: {

--- a/frontend/src/components/general/Form.js
+++ b/frontend/src/components/general/Form.js
@@ -12,6 +12,8 @@ import { makeStyles } from "@material-ui/core/styles";
 import KeyboardBackspaceIcon from "@material-ui/icons/KeyboardBackspace";
 import Link from "next/link";
 import React from "react";
+
+// Relative imports
 import AutoCompleteSearchBar from "../search/AutoCompleteSearchBar";
 import LocationSearchBar from "../search/LocationSearchBar";
 import SelectField from "./SelectField";

--- a/frontend/src/components/shareProject/ShareProject.js
+++ b/frontend/src/components/shareProject/ShareProject.js
@@ -1,7 +1,8 @@
 import { Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import React, { useContext, useRef } from "react";
+
+// Relative imports
 import {
   getLocationFields,
   getLocationValue,
@@ -18,15 +19,20 @@ const useStyles = makeStyles((theme) => ({
     textAlign: "center",
     marginTop: theme.spacing(0.5),
   },
-  BottomLinkFlex: {
+
+  bottomLinkFlex: {
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
     marginTop: theme.spacing(0.5),
   },
+
+  bold: {
+    fontWeight: "bold",
+  },
+
   appealText: {
     textAlign: "center",
-    fontWeight: "bold",
   },
   appealBox: {
     marginTop: theme.spacing(2),
@@ -107,14 +113,6 @@ export default function Share({
       type: "text",
       key: "name",
       value: project.name,
-      bottomLink: (
-        <Typography className={classes.BottomLinkFlex}>
-          <InfoOutlinedIcon className={classes.infoIcon} />
-          <Typography component="span">
-            {texts.use_a_title_that_makes_people_curious_to_learn_more_about_your_project}
-          </Typography>
-        </Typography>
-      ),
     },
     ...getLocationFields({
       locationInputRef: locationInputRef,
@@ -170,11 +168,15 @@ export default function Share({
       {locale === "en" && (
         <div className={classes.appealBox}>
           <Typography color="secondary" className={classes.appealText}>
-            Please make sure to only use English when sharing a project.
+            Please make sure to{" "}
+            <Typography component="span" className={classes.bold}>
+              only use English when sharing a project
+            </Typography>
+            .
           </Typography>
-          <Typography color="secondary" className={classes.appealText}>
-            This way most people can benefit from your ideas and experiences to fight climate change
-            together!
+          <Typography className={classes.appealText}>
+            This enables more people to contribute to your ideas and experiences to fight climate
+            change together!
           </Typography>
         </div>
       )}

--- a/frontend/src/themes/theme.js
+++ b/frontend/src/themes/theme.js
@@ -9,7 +9,10 @@ const coreTheme = createMuiTheme({
       lightHover: "#7dd1ca",
       extraLight: "#D7F7F5",
     },
-    secondary: { main: "#484848" },
+    secondary: {
+      main: "#484848",
+      light: "#484848c2",
+    },
     yellow: {
       main: "#FFDE0A",
     },


### PR DESCRIPTION
This is some very minor polish I wanted to contribute when working on #669. I simplified the title flow, result:

<img width="851" alt="Screen Shot 2021-07-25 at 11 43 36 AM" src="https://user-images.githubusercontent.com/1530684/126909883-1653d454-f691-4f3d-9cd1-f5ec3384c7f5.png">

Also added a `CODEOWNERS` file so we can start scoping / tagging areas of the project for context and review.