### PR TITLE
Urgent Bugfixes in share project and edit project

### DIFF
--- a/frontend/src/components/dialogs/MultiLevelSelectDialog.js
+++ b/frontend/src/components/dialogs/MultiLevelSelectDialog.js
@@ -26,8 +26,7 @@ export default function MultiLevelSelectDialog({
   const texts = getTexts({ page: "general", locale: locale });
 
   const applySkills = () => {
-    if(onSave)
-      onSave(selectedItems);
+    if (onSave) onSave(selectedItems);
     onClose(selectedItems);
   };
 

--- a/frontend/src/components/dialogs/MultiLevelSelectDialog.js
+++ b/frontend/src/components/dialogs/MultiLevelSelectDialog.js
@@ -26,8 +26,9 @@ export default function MultiLevelSelectDialog({
   const texts = getTexts({ page: "general", locale: locale });
 
   const applySkills = () => {
-    onSave(selectedItems);
-    onClose();
+    if(onSave)
+      onSave(selectedItems);
+    onClose(selectedItems);
   };
 
   const itemNamePlural = texts[type];

--- a/frontend/src/components/editProject/EditProjectContent.js
+++ b/frontend/src/components/editProject/EditProjectContent.js
@@ -5,7 +5,7 @@ import {
   Switch,
   TextField,
   Typography,
-  useMediaQuery
+  useMediaQuery,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import React, { useContext } from "react";

--- a/frontend/src/components/editProject/EditProjectContent.js
+++ b/frontend/src/components/editProject/EditProjectContent.js
@@ -5,7 +5,7 @@ import {
   Switch,
   TextField,
   Typography,
-  useMediaQuery,
+  useMediaQuery
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import React, { useContext } from "react";
@@ -245,7 +245,7 @@ export default function EditProjectContent({
             <DatePicker
               className={classes.datePicker}
               label={texts.end_date}
-              date={project.start_date}
+              date={project.end_date}
               handleChange={(newDate) => handleChangeProject(newDate, "end_date")}
               required
               minDate={project.start_date && new Date(project.start_date)}

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -132,8 +132,8 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   finishedDate: {
-    marginTop: theme.spacing(0.5)
-  }
+    marginTop: theme.spacing(0.5),
+  },
 }));
 
 export default function ProjectContent({

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -131,6 +131,9 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: theme.palette.error.main,
     },
   },
+  finishedDate: {
+    marginTop: theme.spacing(0.5)
+  }
 }));
 
 export default function ProjectContent({
@@ -199,6 +202,15 @@ export default function ProjectContent({
                 className={classes.creator}
                 organization={project.creator}
               />
+            )}
+            {project.end_date && (
+              <Typography className={classes.finishedDate}>
+                {texts.finished + " "}
+                <TimeAgo
+                  date={new Date(project.end_date)}
+                  formatter={locale === "de" ? germanYearAndDayFormatter : yearAndDayFormatter}
+                />{" "}
+              </Typography>
             )}
             {project.collaborating_organizations && project.collaborating_organizations.length > 0 && (
               <div>


### PR DESCRIPTION
This addresses 2 bugs, one of the major.
1. [Major] It wasn't possible to share a project anymore if you tried to select skills. The page literally crashed if you tried to select helpful skills. This was caused by MultiLevelSelectDialog expecting an onSave function but the share project code only providing an onClose function which works both for closing the dialog and saving. I fixed this by only using the onSave function if it exists.
2. [moderate] Users were not able to set the end date of a project because the end_date dateselect was configured to show the start_date. Also the end date of a project was not shown anywhere on the project page. Now you can edit the end date again and can see when a project was finished on the project page.

## Before landing

1. PR has meaningful title
1. `yarn lint` passes
1. `yarn format` passes
