### PR TITLE
feat(*): minor polish of /accountcreated page

### DIFF
--- a/frontend/pages/accountcreated.js
+++ b/frontend/pages/accountcreated.js
@@ -40,21 +40,22 @@ export default function AccountCreated() {
     return (
       <Layout title={texts.account_created} hideHeadline>
         <Paper className={classes.root}>
-          <Typography variant="h5" className={classes.headline}>
-            {texts.congratulations_just_one_more_step_to_complete_your_signup}
+          <Typography variant="h4" className={classes.headline}>
+            {texts.just_one_more_step_to_complete_your_signup}
           </Typography>
-          <Typography variant="h4">
-            <div>{texts.we_have_sent_you_an_email_with_a_link}</div>
-            <div>{texts.please_click_on_the_link_to_activate_your_account}</div>
+          <Typography variant="h5">
+            <div></div>
+            <div>{texts.please_click_on_the_link_we_emailed_you_to_activate_your_account}</div>
+            <br />
+            <Typography component="p" variant="h6">
+              {texts.if_the_email_does_not_arrive_after_5_minutes}
+            </Typography>
             <br />
             <Typography component="p" variant="h6">
               {texts.make_sure_to_also_check_your_spam}
             </Typography>
             <Typography component="p" variant="h6">
-              {texts.if_you_are_experiencing_any_problems_contact_us}
-            </Typography>
-            <Typography component="p" variant="h6">
-              {texts.if_the_email_does_not_arrive_after_5_minutes}
+              {texts.if_you_are_experiencing_any_problems_contact_us}.
             </Typography>
           </Typography>
         </Paper>

--- a/frontend/public/texts/profile_texts.js
+++ b/frontend/public/texts/profile_texts.js
@@ -166,10 +166,6 @@ export default function getProfileTexts({ profile, locale }) {
       en: "One final step to join Climate Connect!",
       de: "Nur noch ein Schritt, um deine Anmeldung abzuschließen!",
     },
-    congratulations_just_one_more_step_to_complete_your_signup: {
-      en: "Congratulations! Just one more step to complete your signup!",
-      de: "Glückwunsch! Nur noch ein Schritt, um deine Anmeldung abzuschließen!",
-    },
     we_have_sent_you_an_email_with_a_link: {
       en: "We have sent you an E-Mail with a link!",
       de: "Wir haben dir eine E-Mail mit einem Bestätigungslink geschickt!",

--- a/frontend/public/texts/profile_texts.js
+++ b/frontend/public/texts/profile_texts.js
@@ -167,7 +167,7 @@ export default function getProfileTexts({ profile, locale }) {
       de: "Nur noch ein Schritt, um deine Anmeldung abzuschließen!",
     },
     congratulations_just_one_more_step_to_complete_your_signup: {
-      en: "Congratulations! Just one more step to complete signing up...",
+      en: "Congratulations! Just one more step to complete your signup!",
       de: "Glückwunsch! Nur noch ein Schritt, um deine Anmeldung abzuschließen!",
     },
     we_have_sent_you_an_email_with_a_link: {
@@ -179,7 +179,7 @@ export default function getProfileTexts({ profile, locale }) {
       de: "Bitte klicke auf den Link, um dein Konto zu aktivieren.",
     },
     please_click_on_the_link_to_activate_your_account: {
-      en: "Please click on the link we just emailed you to activate your account.",
+      en: "Please click on the link to activate your account.",
       de: "Bitte klicke auf den Link, um dein Konto zu aktivieren.",
     },
     make_sure_to_also_check_your_spam: {

--- a/frontend/public/texts/profile_texts.js
+++ b/frontend/public/texts/profile_texts.js
@@ -154,35 +154,47 @@ export default function getProfileTexts({ profile, locale }) {
       en: "Account created",
       de: "Konto erstellt",
     },
+    congratulations: {
+      en: "Congratulations!",
+      de: "Glückwunsch!",
+    },
     congratulations_you_have_created_your_account: {
       en: "Congratulations, you have created your account!",
       de: "Glückwunsch, du hast dein Konto erfolgreich erstellt!",
     },
+    just_one_more_step_to_complete_your_signup: {
+      en: "One final step to join Climate Connect!",
+      de: "Nur noch ein Schritt, um deine Anmeldung abzuschließen!",
+    },
     congratulations_just_one_more_step_to_complete_your_signup: {
-      en: "Congratulations! Just one more step to complete your signup!",
+      en: "Congratulations! Just one more step to complete signing up...",
       de: "Glückwunsch! Nur noch ein Schritt, um deine Anmeldung abzuschließen!",
     },
     we_have_sent_you_an_email_with_a_link: {
       en: "We have sent you an E-Mail with a link!",
       de: "Wir haben dir eine E-Mail mit einem Bestätigungslink geschickt!",
     },
+    please_click_on_the_link_we_emailed_you_to_activate_your_account: {
+      en: "Please click on the link we just emailed you to activate your account.",
+      de: "Bitte klicke auf den Link, um dein Konto zu aktivieren.",
+    },
     please_click_on_the_link_to_activate_your_account: {
-      en: "Please click on the link to activate your account.",
+      en: "Please click on the link we just emailed you to activate your account.",
       de: "Bitte klicke auf den Link, um dein Konto zu aktivieren.",
     },
     make_sure_to_also_check_your_spam: {
-      en: "Make sure to also check your spam/junk folder incase you cannot find the E-Mail.",
+      en: "Make sure to also check your spam/junk folder in case you can't find the link.",
       de: "Bitte überprüfe auch deinen Spam-/Junk-Ordner, falls du die E-Mail nicht finden kannst.",
     },
     if_you_are_experiencing_any_problems_contact_us: {
-      en: "If you are experiencing any problems, contact us at contact@climateconnect.earth",
+      en: "If you are experiencing any problems, email us at contact@climateconnect.earth",
       de:
         "Wenn du Probleme haben solltest, kontaktiere uns einfach unter contact@climateconnect.earth",
     },
     if_the_email_does_not_arrive_after_5_minutes: {
       en: (
         <>
-          If the E-Mail does not arrive after 5 minutes,{" "}
+          If the email does not arrive after 5 minutes,{" "}
           <Link href={getLocalePrefix(locale) + "/resend_verification_email"}>click here</Link> to
           resend it.
         </>

--- a/frontend/public/texts/profile_texts.js
+++ b/frontend/public/texts/profile_texts.js
@@ -166,16 +166,8 @@ export default function getProfileTexts({ profile, locale }) {
       en: "One final step to join Climate Connect!",
       de: "Nur noch ein Schritt, um deine Anmeldung abzuschließen!",
     },
-    we_have_sent_you_an_email_with_a_link: {
-      en: "We have sent you an E-Mail with a link!",
-      de: "Wir haben dir eine E-Mail mit einem Bestätigungslink geschickt!",
-    },
     please_click_on_the_link_we_emailed_you_to_activate_your_account: {
       en: "Please click on the link we just emailed you to activate your account.",
-      de: "Bitte klicke auf den Link, um dein Konto zu aktivieren.",
-    },
-    please_click_on_the_link_to_activate_your_account: {
-      en: "Please click on the link to activate your account.",
       de: "Bitte klicke auf den Link, um dein Konto zu aktivieren.",
     },
     make_sure_to_also_check_your_spam: {


### PR DESCRIPTION
Ran into this during testing #674. Very minor polish and opinionated wording of `/accountcreated`. I think this is a small improvement, but happy to edit, or back out any changes.

## Before
<img width="2560" alt="Screen Shot 2021-08-17 at 6 02 08 PM" src="https://user-images.githubusercontent.com/1530684/129820059-d9e3afdb-2521-4ea7-bcdb-d66f8555d337.png">


## After
<img width="2550" alt="Screen Shot 2021-08-17 at 6 01 54 PM" src="https://user-images.githubusercontent.com/1530684/129820074-802784fc-2240-459e-87c9-8f093e729319.png">
