### PR TITLE
feature: renamed Comment section to Discussion

### DIFF
--- a/frontend/pages/projects/[projectId].js
+++ b/frontend/pages/projects/[projectId].js
@@ -182,19 +182,19 @@ function ProjectLayout({
   };
 
   // pagination will only return 10 comments
-  const commentsTabLabel = () => {
-    let commentsLabel = texts.comments;
+  const discussionTabLabel = () => {
+    let discussionLabel = texts.discussion;
     const number_of_parent_comments = project.comments.length;
     const number_of_replies = project.comments.reduce((total, p) => total + p?.replies?.length, 0);
     const number_of_coments = number_of_parent_comments + number_of_replies;
     if (project && project.comments) {
       if (project.comments.length === 10) {
-        commentsLabel += ` (${number_of_coments}+)`;
+        discussionLabel += ` (${number_of_coments}+)`;
       } else if (project?.team?.length < 10 && number_of_coments > 0) {
-        commentsLabel += ` (${number_of_coments})`;
+        discussionLabel += ` (${number_of_coments})`;
       }
     }
-    return commentsLabel;
+    return discussionLabel;
   };
 
   const handleTabChange = (event, newValue) => {
@@ -310,7 +310,7 @@ function ProjectLayout({
           >
             <Tab label={texts.project} className={classes.tab} />
             <Tab label={teamTabLabel()} className={classes.tab} />
-            <Tab label={commentsTabLabel()} className={classes.tab} />
+            <Tab label={discussionTabLabel()} className={classes.tab} />
           </Tabs>
         </div>
       </Container>

--- a/frontend/public/texts/project_texts.js
+++ b/frontend/public/texts/project_texts.js
@@ -124,9 +124,9 @@ export default function getProjectTexts({ project, user, url_slug, locale }) {
       en: "Team",
       de: "Team",
     },
-    comments: {
-      en: "Comments",
-      de: "Kommentare",
+    discussion: {
+      en: "Discussion",
+      de: "Diskussion",
     },
     you_have_successfully_left_the_project: {
       en: "You have successfully left the project.",


### PR DESCRIPTION
The Comment (de: Kommentare) section is now renamed to Discussion (de: Diskussion) on the project page.
I also updated the corresponding function and variable names to match the new section name.
Closes #501 

## Before landing

1. PR has meaningful title
1. `yarn lint` passes
1. `yarn format` passes
