### PR TITLE
fix: create test data: make users members of their own project

### DIFF
--- a/backend/climateconnect_api/management/commands/create_test_data.py
+++ b/backend/climateconnect_api/management/commands/create_test_data.py
@@ -184,7 +184,7 @@ def create_project_test_data(number_of_rows: int):
             example_availability = random.choice(all_availabilities)
             ProjectMember.objects.create(
                 project=project, user=parent_user, role=admin_role,
-                availability=example_availability, role_in_project='creator'
+                availability=example_availability, role_in_project='Project manager'
             )
 
             number_of_test_project_tags = 5


### PR DESCRIPTION
Before the fix test projects were created without any members. Now the project parent gets added to the project as a member.