### PR TITLE
fix: show list of liking users when clicking the link below the LikeButton

### DIFF
--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -888,10 +888,13 @@ class ListProjectLikesView(ListAPIView):
     serializer_class = ProjectLikeSerializer
 
     def get_queryset(self):
-        project = Project.objects.filter(url_slug=self.kwargs['url_slug'])
-        if not project.exists():
+        try:
+            project = Project.objects.get(url_slug=self.kwargs['url_slug'])
+        except Project.DoesNotExist:
             return None
-        likes = ProjectLike.objects.filter(project=project[0])
+            
+        
+        likes = ProjectLike.objects.filter(project=project)
         return likes        
 
 class LeaveProject(RetrieveUpdateAPIView):

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -888,10 +888,10 @@ class ListProjectLikesView(ListAPIView):
     serializer_class = ProjectLikeSerializer
 
     def get_queryset(self):
-        project = Project.objects.get(url_slug=self.kwargs['url_slug'])
+        project = Project.objects.filter(url_slug=self.kwargs['url_slug'])
         if not project.exists():
             return None
-        likes = ProjectLike.objects.filter(project=project)
+        likes = ProjectLike.objects.filter(project=project[0])
         return likes        
 
 class LeaveProject(RetrieveUpdateAPIView):

--- a/frontend/pages/hubs.js
+++ b/frontend/pages/hubs.js
@@ -55,7 +55,7 @@ export default function Hubs({ hubs }) {
   const texts = getTexts({ page: "hub", locale: locale });
   return (
     <WideLayout largeFooter noSpaceBottom title={texts.climate_action_hubs}>
-      <NavigationSubHeader allHubs={hubs}/>
+      <NavigationSubHeader allHubs={hubs} />
       <HubHeaderImage
         image="/images/hubs_background.jpg"
         alt={texts.hubs_overview_image_alt}

--- a/frontend/pages/hubs/[hubUrl].js
+++ b/frontend/pages/hubs/[hubUrl].js
@@ -9,7 +9,7 @@ import {
   getOrganizationTagsOptions,
   getProjectTagsOptions,
   getSkillsOptions,
-  getStatusOptions
+  getStatusOptions,
 } from "../../public/lib/getOptions";
 import { getAllHubs } from "../../public/lib/hubOperations";
 import { getImageUrl } from "../../public/lib/imageOperations";
@@ -46,12 +46,11 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-
 const DESCRIPTION_WEBFLOW_LINKS = {
-  "energy": {
-    en: "energy-hub"
-  }
-}
+  energy: {
+    en: "energy-hub",
+  },
+};
 
 //potentially switch back to getinitialprops here?!
 export async function getServerSideProps(ctx) {
@@ -66,7 +65,7 @@ export async function getServerSideProps(ctx) {
     project_statuses,
     location_filtered_by,
     allHubs,
-    hubDescription
+    hubDescription,
   ] = await Promise.all([
     getHubData(hubUrl, ctx.locale),
     getProjectTagsOptions(hubUrl, ctx.locale),
@@ -75,7 +74,7 @@ export async function getServerSideProps(ctx) {
     getStatusOptions(ctx.locale),
     getLocationFilteredBy(ctx.query),
     getAllHubs(ctx.locale, false),
-    retrieveDescriptionFromWebflow(ctx.query, ctx.locale)
+    retrieveDescriptionFromWebflow(ctx.query, ctx.locale),
   ]);
 
   return {
@@ -102,7 +101,7 @@ export async function getServerSideProps(ctx) {
       sectorHubs: allHubs.filter((h) => h.hub_type === "sector hub"),
       allHubs: allHubs,
       initialIdeaUrlSlug: ideaToOpen ? encodeURIComponent(ideaToOpen) : null,
-      hubDescription: hubDescription
+      hubDescription: hubDescription,
     },
   };
 }
@@ -219,10 +218,9 @@ export default function Hub({
     });
   };
 
-
   return (
     <>
-      {(hubDescription && hubDescription.headContent) && (
+      {hubDescription && hubDescription.headContent && (
         <Head>{parseHtml(hubDescription.headContent)}</Head>
       )}
       <WideLayout title={headline} fixedHeader headerBackground="#FFF">
@@ -244,11 +242,13 @@ export default function Hub({
             statBoxTitle={statBoxTitle}
             stats={stats}
             scrollToSolutions={scrollToSolutions}
-            detailledInfo={(hubDescription?.bodyContent) ? (
-              <div dangerouslySetInnerHTML={{ __html: hubDescription.bodyContent }} />
-            ) : (
-              <HubDescription hub={hubUrl} texts={texts} />
-            )}
+            detailledInfo={
+              hubDescription?.bodyContent ? (
+                <div dangerouslySetInnerHTML={{ __html: hubDescription.bodyContent }} />
+              ) : (
+                <HubDescription hub={hubUrl} texts={texts} />
+              )
+            }
             subHeadline={subHeadline}
             hubProjectsButtonRef={hubProjectsButtonRef}
             isLocationHub={isLocationHub}
@@ -299,15 +299,20 @@ const HubDescription = ({ hub, texts }) => {
   );
 };
 
-const WEBFLOW_BASE_LINK = "https://climateconnect.webflow.io/"
+const WEBFLOW_BASE_LINK = "https://climateconnect.webflow.io/";
 
 const retrieveDescriptionFromWebflow = async (query, locale) => {
-  if(DESCRIPTION_WEBFLOW_LINKS[query?.hubUrl] && DESCRIPTION_WEBFLOW_LINKS[query?.hubUrl][locale]) {
-    const props = await retrievePage(WEBFLOW_BASE_LINK + DESCRIPTION_WEBFLOW_LINKS[query.hubUrl][locale]);
-    return props
+  if (
+    DESCRIPTION_WEBFLOW_LINKS[query?.hubUrl] &&
+    DESCRIPTION_WEBFLOW_LINKS[query?.hubUrl][locale]
+  ) {
+    const props = await retrievePage(
+      WEBFLOW_BASE_LINK + DESCRIPTION_WEBFLOW_LINKS[query.hubUrl][locale]
+    );
+    return props;
   }
-  return null
-}
+  return null;
+};
 
 const getHubData = async (url_slug, locale) => {
   console.log("getting data for hub " + url_slug);

--- a/frontend/pages/projects/[projectId].js
+++ b/frontend/pages/projects/[projectId].js
@@ -75,7 +75,7 @@ export default function ProjectPage({ project, members, posts, comments, followi
     setFollowingChangePending(pending);
   };
 
-//We only update the count once the frontend received a response from the backend. This is what the updateCount variable is for
+  //We only update the count once the frontend received a response from the backend. This is what the updateCount variable is for
   const handleLike = (userLikes, updateCount, pending) => {
     setIsUserLiking(userLikes);
     if (updateCount) {


### PR DESCRIPTION
Closes #756 

When clicking the link below the LikeButton, it didn't show the list of users who are liking the project. This is now fixed.

## Before landing

1. PR has meaningful title
1. `yarn lint` passes
1. `yarn format` passes
