### PR TITLE
fix: always update state when Followers/Likes are set

### DIFF
--- a/frontend/src/components/project/ProjectPageRoot.js
+++ b/frontend/src/components/project/ProjectPageRoot.js
@@ -304,7 +304,7 @@ export default function ProjectPageRoot({
   const toggleShowFollowers = async () => {
     setShowFollowers(!showFollowers);
     if (!initiallyCaughtFollowers) {
-      updateFollowers();
+      await updateFollowers();
       handleReadNotifications(NOTIFICATION_TYPES.indexOf("project_follower"));
     }
   };

--- a/frontend/src/components/project/ProjectPageRoot.js
+++ b/frontend/src/components/project/ProjectPageRoot.js
@@ -306,12 +306,12 @@ export default function ProjectPageRoot({
     if (!initiallyCaughtFollowers) {
       updateFollowers();
       handleReadNotifications(NOTIFICATION_TYPES.indexOf("project_follower"));
-      setInitiallyCaughtFollowers(true);
     }
   };
   const updateFollowers = async () => {
     const retrievedFollowers = await getFollowers(project, token, locale);
     setFollowers(retrievedFollowers);
+    setInitiallyCaughtFollowers(true);
   };
   const [initiallyCaughtLikes, setInitiallyCaughtLikes] = React.useState(false);
   const [likes, setLikes] = React.useState([]);
@@ -321,12 +321,12 @@ export default function ProjectPageRoot({
     if (!initiallyCaughtLikes) {
       updateLikes();
       handleReadNotifications(NOTIFICATION_TYPES.indexOf("project_like"));
-      setInitiallyCaughtLikes(true);
     }
   };
   const updateLikes = async () => {
     const retrievedLikes = await getLikes(project, token, locale);
     setLikes(retrievedLikes);
+    setInitiallyCaughtLikes(true);
   };
   const [gotParams, setGotParams] = React.useState(false);
   useEffect(() => {

--- a/frontend/src/components/project/ProjectPageRoot.js
+++ b/frontend/src/components/project/ProjectPageRoot.js
@@ -306,12 +306,12 @@ export default function ProjectPageRoot({
     if (!initiallyCaughtFollowers) {
       await updateFollowers();
       handleReadNotifications(NOTIFICATION_TYPES.indexOf("project_follower"));
+      setInitiallyCaughtFollowers(true);
     }
   };
   const updateFollowers = async () => {
     const retrievedFollowers = await getFollowers(project, token, locale);
     setFollowers(retrievedFollowers);
-    setInitiallyCaughtFollowers(true);
   };
   const [initiallyCaughtLikes, setInitiallyCaughtLikes] = React.useState(false);
   const [likes, setLikes] = React.useState([]);
@@ -321,12 +321,12 @@ export default function ProjectPageRoot({
     if (!initiallyCaughtLikes) {
       await updateLikes();
       handleReadNotifications(NOTIFICATION_TYPES.indexOf("project_like"));
+      setInitiallyCaughtLikes(true);
     }
   };
   const updateLikes = async () => {
     const retrievedLikes = await getLikes(project, token, locale);
     setLikes(retrievedLikes);
-    setInitiallyCaughtLikes(true);
   };
   const [gotParams, setGotParams] = React.useState(false);
   useEffect(() => {

--- a/frontend/src/components/project/ProjectPageRoot.js
+++ b/frontend/src/components/project/ProjectPageRoot.js
@@ -319,7 +319,7 @@ export default function ProjectPageRoot({
   const toggleShowLikes = async () => {
     setShowLikes(!showLikes);
     if (!initiallyCaughtLikes) {
-      updateLikes();
+      await updateLikes();
       handleReadNotifications(NOTIFICATION_TYPES.indexOf("project_like"));
     }
   };


### PR DESCRIPTION
When the updateFollowers-/updateLikes-function was called outside of toggleShowFollowers/toggleShowLikes (in this case from within toggleFollowProject/toggleLikeProject) not all corresponding states were updated. This is now fixed.

Closes #761 

## Before landing

1. PR has meaningful title
1. `yarn lint` passes
1. `yarn format` passes
