### PR TITLE
Feat: New section for the project page 'DiscussionPreview'

### DIFF
--- a/frontend/src/components/communication/Post.js
+++ b/frontend/src/components/communication/Post.js
@@ -123,7 +123,6 @@ export default function Post({
             />
           </Link>
           <span className={classes.messageWithMetaData}>
-            {type !== "preview" && (
               <div className={classes.metadata}>
                 <Link
                   color="inherit"
@@ -144,7 +143,6 @@ export default function Post({
                   <DateDisplay date={new Date(post.created_at)} />
                 </Typography>
               </div>
-            )}
             {type === "preview" ? (
               <Typography>
                 <Truncate lines={truncate} ellipsis={"..."}>

--- a/frontend/src/components/communication/Post.js
+++ b/frontend/src/components/communication/Post.js
@@ -118,7 +118,7 @@ export default function Post({
             />
           </Link>
           <span className={classes.messageWithMetaData}>
-            {type != "preview" && (
+            {type !== "preview" && (
               <div className={classes.metadata}>
                 <Link
                   color="inherit"

--- a/frontend/src/components/communication/Post.js
+++ b/frontend/src/components/communication/Post.js
@@ -3,6 +3,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import ExpandLessIcon from "@material-ui/icons/ExpandLess";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import React, { useContext } from "react";
+import Truncate from "react-truncate";
 import { getLocalePrefix } from "../../../public/lib/apiOperations";
 import { getImageUrl } from "../../../public/lib/imageOperations";
 import getTexts from "../../../public/texts/texts";
@@ -17,9 +18,10 @@ const useStyles = makeStyles((theme) => ({
   postDate: {
     color: theme.palette.grey[700],
   },
-  commentFlexBox: {
+  commentFlexBox: (props) => ({
     display: "flex",
-  },
+    alignItems: props.preview ? "center" : "stretch",
+  }),
   messageWithMetaData: {
     display: "flex",
     flexDirection: "column",
@@ -69,8 +71,9 @@ export default function Post({
   onSendComment,
   onDeletePost,
   infoTextSize,
+  truncate,
 }) {
-  const classes = useStyles();
+  const classes = useStyles({ preview: type === "preview" ? true : false });
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "communication", locale: locale });
   const [open, setOpen] = React.useState(false);
@@ -115,28 +118,39 @@ export default function Post({
             />
           </Link>
           <span className={classes.messageWithMetaData}>
-            <div className={classes.metadata}>
-              <Link
-                color="inherit"
-                href={getLocalePrefix(locale) + "/profiles/" + post.author_user.url_slug}
-                target="_blank"
-              >
-                <Typography variant="body2" className={classes.username}>
-                  {post.author_user.first_name + " " + post.author_user.last_name}
+            {type != "preview" && (
+              <div className={classes.metadata}>
+                <Link
+                  color="inherit"
+                  href={getLocalePrefix(locale) + "/profiles/" + post.author_user.url_slug}
+                  target="_blank"
+                >
+                  <Typography variant="body2" className={classes.username}>
+                    {post.author_user.first_name + " " + post.author_user.last_name}
+                  </Typography>
+                </Link>
+                <Typography variant="body2" className={classes.postDate}>
+                  {post.unconfirmed && (
+                    <Tooltip title={texts.sending_message + "..."}>
+                      <CircularProgress size={10} color="inherit" className={classes.loader} />
+                    </Tooltip>
+                  )}
+                  <DateDisplay date={new Date(post.created_at)} />
                 </Typography>
-              </Link>
-              <Typography variant="body2" className={classes.postDate}>
-                {post.unconfirmed && (
-                  <Tooltip title={texts.sending_message + "..."}>
-                    <CircularProgress size={10} color="inherit" className={classes.loader} />
-                  </Tooltip>
-                )}
-                <DateDisplay date={new Date(post.created_at)} />
+              </div>
+            )}
+            {type === "preview" ? (
+              <Typography>
+                <Truncate lines={truncate} ellipsis={"..."}>
+                  <MessageContent content={post.content} maxLines={maxLines} />
+                </Truncate>
               </Typography>
-            </div>
-            <MessageContent content={post.content} maxLines={maxLines} />
+            ) : (
+              <MessageContent content={post.content} maxLines={maxLines} />
+            )}
             <div>
               {type != "reply" &&
+                type != "preview" &&
                 (replyInterfaceExpanded ? (
                   <CommentInput
                     user={user}
@@ -150,12 +164,12 @@ export default function Post({
                     {texts.reply}
                   </Button>
                 ))}
-              {user && user.id === post.author_user.id && (
+              {user && user.id === post.author_user.id && type != "preview" && (
                 <Button onClick={toggleDeleteDialogOpen}>Delete</Button>
               )}
             </div>
             <div>
-              {type != "reply" && !!post.replies && post.replies.length > 0 && (
+              {type != "reply" && !!post.replies && post.replies.length > 0 && type != "preview" && (
                 <Link className={classes.toggleReplies} onClick={handleViewRepliesClick}>
                   {!displayReplies ? (
                     <>
@@ -178,7 +192,8 @@ export default function Post({
         {post.replies &&
           post.replies.length > 0 &&
           displayReplies &&
-          (type === "openingpost" || type === "progresspost") && (
+          (type === "openingpost" || type === "progresspost") &&
+          type != "preview" && (
             <Posts
               posts={post.replies}
               type="reply"

--- a/frontend/src/components/communication/Post.js
+++ b/frontend/src/components/communication/Post.js
@@ -72,6 +72,7 @@ export default function Post({
   onDeletePost,
   infoTextSize,
   truncate,
+  noLink,
 }) {
   const classes = useStyles({ preview: type === "preview" });
   const { locale } = useContext(UserContext);
@@ -96,6 +97,9 @@ export default function Post({
     setOpen(false);
     if (confirmed) onDeletePost(post);
   };
+
+  const handleClick = (element) => noLink && element.preventDefault();
+
   return (
     <div className={className}>
       {type === "progresspost" ? (
@@ -107,6 +111,7 @@ export default function Post({
           <Link
             href={getLocalePrefix(locale) + "/profiles/" + post.author_user.url_slug}
             target="_blank"
+            onClick={handleClick}
           >
             <Avatar
               src={
@@ -124,6 +129,7 @@ export default function Post({
                   color="inherit"
                   href={getLocalePrefix(locale) + "/profiles/" + post.author_user.url_slug}
                   target="_blank"
+                  onClick={handleClick}
                 >
                   <Typography variant="body2" className={classes.username}>
                     {post.author_user.first_name + " " + post.author_user.last_name}

--- a/frontend/src/components/communication/Post.js
+++ b/frontend/src/components/communication/Post.js
@@ -73,7 +73,7 @@ export default function Post({
   infoTextSize,
   truncate,
 }) {
-  const classes = useStyles({ preview: type === "preview" ? true : false });
+  const classes = useStyles({ preview: type === "preview" });
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "communication", locale: locale });
   const [open, setOpen] = React.useState(false);

--- a/frontend/src/components/communication/Post.js
+++ b/frontend/src/components/communication/Post.js
@@ -149,8 +149,8 @@ export default function Post({
               <MessageContent content={post.content} maxLines={maxLines} />
             )}
             <div>
-              {type != "reply" &&
-                type != "preview" &&
+              {type !== "reply" &&
+                type !== "preview" &&
                 (replyInterfaceExpanded ? (
                   <CommentInput
                     user={user}
@@ -164,12 +164,12 @@ export default function Post({
                     {texts.reply}
                   </Button>
                 ))}
-              {user && user.id === post.author_user.id && type != "preview" && (
+              {user && user.id === post.author_user.id && type !== "preview" && (
                 <Button onClick={toggleDeleteDialogOpen}>Delete</Button>
               )}
             </div>
             <div>
-              {type != "reply" && !!post.replies && post.replies.length > 0 && type != "preview" && (
+              {type !== "reply" && !!post.replies && post.replies.length > 0 && type !== "preview" && (
                 <Link className={classes.toggleReplies} onClick={handleViewRepliesClick}>
                   {!displayReplies ? (
                     <>
@@ -193,7 +193,7 @@ export default function Post({
           post.replies.length > 0 &&
           displayReplies &&
           (type === "openingpost" || type === "progresspost") &&
-          type != "preview" && (
+          type !== "preview" && (
             <Posts
               posts={post.replies}
               type="reply"

--- a/frontend/src/components/communication/Posts.js
+++ b/frontend/src/components/communication/Posts.js
@@ -58,6 +58,7 @@ export default function Posts({
   onDeletePost,
   infoTextSize,
   truncate,
+  noLink,
 }) {
   const classes = useStyles();
   const classNames = {
@@ -82,6 +83,7 @@ export default function Posts({
             onDeletePost={onDeletePost}
             infoTextSize={infoTextSize}
             truncate={truncate}
+            noLink={noLink}
           />
         ))}
     </div>

--- a/frontend/src/components/communication/Posts.js
+++ b/frontend/src/components/communication/Posts.js
@@ -48,7 +48,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-//@type: possible values are "openingpost", "reply", "progresspost"
+//@type: possible values are "openingpost", "reply", "progresspost", "preview"
 export default function Posts({
   posts,
   type,
@@ -57,6 +57,7 @@ export default function Posts({
   onSendComment,
   onDeletePost,
   infoTextSize,
+  truncate,
 }) {
   const classes = useStyles();
   const classNames = {
@@ -80,6 +81,7 @@ export default function Posts({
             onSendComment={onSendComment}
             onDeletePost={onDeletePost}
             infoTextSize={infoTextSize}
+            truncate={truncate}
           />
         ))}
     </div>

--- a/frontend/src/components/project/DiscussionPreview.js
+++ b/frontend/src/components/project/DiscussionPreview.js
@@ -57,6 +57,7 @@ export default function DiscussionPreview({
           type="preview"
           user={latestParentComment.author_user}
           truncate={3}
+          noLink={true}
         />
       </div>
     </ButtonBase>

--- a/frontend/src/components/project/DiscussionPreview.js
+++ b/frontend/src/components/project/DiscussionPreview.js
@@ -35,15 +35,13 @@ export default function DiscussionPreview({
   discussionTabLabel,
   handleTabChange,
   typesByTabValue,
-  projectTabsSpaceToTop,
+  projectTabsRef,
 }) {
   const classes = useStyles();
 
   function switchToDiscussionTab(event) {
     handleTabChange(event, typesByTabValue.indexOf("comments"));
-    if (scrollY > projectTabsSpaceToTop.page) {
-      window.scrollTo({top: projectTabsSpaceToTop.page, left: 0});
-    }
+    projectTabsRef.current.scrollIntoView();
   }
 
   return (

--- a/frontend/src/components/project/DiscussionPreview.js
+++ b/frontend/src/components/project/DiscussionPreview.js
@@ -35,11 +35,15 @@ export default function DiscussionPreview({
   discussionTabLabel,
   handleTabChange,
   typesByTabValue,
+  projectTabsSpaceToTop,
 }) {
   const classes = useStyles();
 
   function switchToDiscussionTab(event) {
     handleTabChange(event, typesByTabValue.indexOf("comments"));
+    if (scrollY > projectTabsSpaceToTop.page) {
+      window.scrollTo({top: projectTabsSpaceToTop.page, left: 0});
+    }
   }
 
   return (

--- a/frontend/src/components/project/DiscussionPreview.js
+++ b/frontend/src/components/project/DiscussionPreview.js
@@ -27,7 +27,6 @@ const useStyles = makeStyles((theme) => ({
   },
   headingDiscussionPreview: {
     fontWeight: "bold",
-    marginBottom: theme.spacing(0.5),
   },
 }));
 

--- a/frontend/src/components/project/DiscussionPreview.js
+++ b/frontend/src/components/project/DiscussionPreview.js
@@ -1,0 +1,61 @@
+import { Link, Typography } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import UnfoldMoreIcon from "@material-ui/icons/UnfoldMore";
+import { getLocalePrefix } from "../../../public/lib/apiOperations";
+import Posts from "../communication/Posts";
+
+const useStyles = makeStyles((theme) => ({
+    linkDiscussionPreview: {
+        color: theme.palette.secondary.main,
+      },
+      discussionPreview: {
+        borderBottom: `1px solid ${theme.palette.grey[500]}`,
+        borderTop: `1px solid ${theme.palette.grey[500]}`,
+        marginBottom: theme.spacing(4),
+        paddingTop: theme.spacing(1),
+        paddingBottom: theme.spacing(1),
+      },
+      topSectionDiscussionPreview: {
+        display: "flex",
+        justifyContent: "space-between",
+      },
+      headingDiscussionPreview: {
+        fontWeight: "bold",
+        marginBottom: theme.spacing(0.5),
+      },
+      iconDiscussionPreview: {
+        marginRight: theme.spacing(2),
+      },
+    }));
+
+export default function DiscussionPreview({ latestParentComment, discussionTabLabel, locale, project }) {
+    const classes = useStyles();
+    return (
+      <>
+        <Link
+          href={`${getLocalePrefix(locale)}/projects/${project.url_slug}#comments`}
+          underline="none"
+          className={classes.linkDiscussionPreview}
+        >
+          <div className={classes.discussionPreview}>
+            <div className={classes.topSectionDiscussionPreview}>
+              <Typography
+                display="inline"
+                color="primary"
+                className={classes.headingDiscussionPreview}
+              >
+                {discussionTabLabel}
+              </Typography>
+              <UnfoldMoreIcon color="secondary" className={classes.iconDiscussionPreview} />
+            </div>
+            <Posts
+              posts={latestParentComment}
+              type="preview"
+              user={latestParentComment.author_user}
+              truncate={3}
+            />
+          </div>
+        </Link>
+      </>
+    );
+  }

--- a/frontend/src/components/project/DiscussionPreview.js
+++ b/frontend/src/components/project/DiscussionPreview.js
@@ -4,54 +4,55 @@ import UnfoldMoreIcon from "@material-ui/icons/UnfoldMore";
 import Posts from "../communication/Posts";
 
 const useStyles = makeStyles((theme) => ({
-      discussionPreview: {
-        borderBottom: `1px solid ${theme.palette.grey[500]}`,
-        borderTop: `1px solid ${theme.palette.grey[500]}`,
-        marginBottom: theme.spacing(4),
-        paddingTop: theme.spacing(1),
-        paddingBottom: theme.spacing(1),
-        "&:hover": {
-          cursor: "pointer",
-        },
-      },
-      topSectionDiscussionPreview: {
-        display: "flex",
-        justifyContent: "space-between",
-      },
-      headingDiscussionPreview: {
-        fontWeight: "bold",
-        marginBottom: theme.spacing(0.5),
-      },
-      iconDiscussionPreview: {
-        marginRight: theme.spacing(2),
-      },
-    }));
+  discussionPreview: {
+    borderBottom: `1px solid ${theme.palette.grey[500]}`,
+    borderTop: `1px solid ${theme.palette.grey[500]}`,
+    marginBottom: theme.spacing(4),
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+    "&:hover": {
+      cursor: "pointer",
+    },
+  },
+  topSectionDiscussionPreview: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  headingDiscussionPreview: {
+    fontWeight: "bold",
+    marginBottom: theme.spacing(0.5),
+  },
+  iconDiscussionPreview: {
+    marginRight: theme.spacing(2),
+  },
+}));
 
-export default function DiscussionPreview({ latestParentComment, discussionTabLabel, handleTabChange, typesByTabValue }) {
-    const classes = useStyles();
+export default function DiscussionPreview({
+  latestParentComment,
+  discussionTabLabel,
+  handleTabChange,
+  typesByTabValue,
+}) {
+  const classes = useStyles();
 
-    function switchToDiscussionTab(event) {
-      handleTabChange(event, typesByTabValue.indexOf("comments"));
-    }
-    
-    return (
-          <div className={classes.discussionPreview} onClick={switchToDiscussionTab}>
-            <div className={classes.topSectionDiscussionPreview}>
-              <Typography
-                display="inline"
-                color="primary"
-                className={classes.headingDiscussionPreview}
-              >
-                {discussionTabLabel}
-              </Typography>
-              <UnfoldMoreIcon color="secondary" className={classes.iconDiscussionPreview} />
-            </div>
-            <Posts
-              posts={latestParentComment}
-              type="preview"
-              user={latestParentComment.author_user}
-              truncate={3}
-            />
-          </div>
-    );
+  function switchToDiscussionTab(event) {
+    handleTabChange(event, typesByTabValue.indexOf("comments"));
   }
+
+  return (
+    <div className={classes.discussionPreview} onClick={switchToDiscussionTab}>
+      <div className={classes.topSectionDiscussionPreview}>
+        <Typography display="inline" color="primary" className={classes.headingDiscussionPreview}>
+          {discussionTabLabel}
+        </Typography>
+        <UnfoldMoreIcon color="secondary" className={classes.iconDiscussionPreview} />
+      </div>
+      <Posts
+        posts={latestParentComment}
+        type="preview"
+        user={latestParentComment.author_user}
+        truncate={3}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/project/DiscussionPreview.js
+++ b/frontend/src/components/project/DiscussionPreview.js
@@ -1,18 +1,25 @@
-import { Typography } from "@material-ui/core";
+import { ButtonBase, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import UnfoldMoreIcon from "@material-ui/icons/UnfoldMore";
 import Posts from "../communication/Posts";
 
 const useStyles = makeStyles((theme) => ({
+  buttonBase: {
+    width: "100%",
+    textAlign: "start",
+    marginBottom: theme.spacing(4),
+    "&:hover": {
+      backgroundColor: "#f5f5f5",
+    },
+  },
   discussionPreview: {
     borderBottom: `1px solid ${theme.palette.grey[500]}`,
     borderTop: `1px solid ${theme.palette.grey[500]}`,
-    marginBottom: theme.spacing(4),
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(1),
-    "&:hover": {
-      cursor: "pointer",
-    },
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(2),
+    width: "100%",
   },
   topSectionDiscussionPreview: {
     display: "flex",
@@ -21,9 +28,6 @@ const useStyles = makeStyles((theme) => ({
   headingDiscussionPreview: {
     fontWeight: "bold",
     marginBottom: theme.spacing(0.5),
-  },
-  iconDiscussionPreview: {
-    marginRight: theme.spacing(2),
   },
 }));
 
@@ -40,19 +44,21 @@ export default function DiscussionPreview({
   }
 
   return (
-    <div className={classes.discussionPreview} onClick={switchToDiscussionTab}>
-      <div className={classes.topSectionDiscussionPreview}>
-        <Typography display="inline" color="primary" className={classes.headingDiscussionPreview}>
-          {discussionTabLabel}
-        </Typography>
-        <UnfoldMoreIcon color="secondary" className={classes.iconDiscussionPreview} />
+    <ButtonBase className={classes.buttonBase}>
+      <div className={classes.discussionPreview} onClick={switchToDiscussionTab}>
+        <div className={classes.topSectionDiscussionPreview}>
+          <Typography display="inline" color="primary" className={classes.headingDiscussionPreview}>
+            {discussionTabLabel}
+          </Typography>
+          <UnfoldMoreIcon color="secondary" />
+        </div>
+        <Posts
+          posts={latestParentComment}
+          type="preview"
+          user={latestParentComment.author_user}
+          truncate={3}
+        />
       </div>
-      <Posts
-        posts={latestParentComment}
-        type="preview"
-        user={latestParentComment.author_user}
-        truncate={3}
-      />
-    </div>
+    </ButtonBase>
   );
 }

--- a/frontend/src/components/project/DiscussionPreview.js
+++ b/frontend/src/components/project/DiscussionPreview.js
@@ -1,19 +1,18 @@
-import { Link, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import UnfoldMoreIcon from "@material-ui/icons/UnfoldMore";
-import { getLocalePrefix } from "../../../public/lib/apiOperations";
 import Posts from "../communication/Posts";
 
 const useStyles = makeStyles((theme) => ({
-    linkDiscussionPreview: {
-        color: theme.palette.secondary.main,
-      },
       discussionPreview: {
         borderBottom: `1px solid ${theme.palette.grey[500]}`,
         borderTop: `1px solid ${theme.palette.grey[500]}`,
         marginBottom: theme.spacing(4),
         paddingTop: theme.spacing(1),
         paddingBottom: theme.spacing(1),
+        "&:hover": {
+          cursor: "pointer",
+        },
       },
       topSectionDiscussionPreview: {
         display: "flex",
@@ -28,16 +27,15 @@ const useStyles = makeStyles((theme) => ({
       },
     }));
 
-export default function DiscussionPreview({ latestParentComment, discussionTabLabel, locale, project }) {
+export default function DiscussionPreview({ latestParentComment, discussionTabLabel, handleTabChange, typesByTabValue }) {
     const classes = useStyles();
+
+    function switchToDiscussionTab(event) {
+      handleTabChange(event, typesByTabValue.indexOf("comments"));
+    }
+    
     return (
-      <>
-        <Link
-          href={`${getLocalePrefix(locale)}/projects/${project.url_slug}#comments`}
-          underline="none"
-          className={classes.linkDiscussionPreview}
-        >
-          <div className={classes.discussionPreview}>
+          <div className={classes.discussionPreview} onClick={switchToDiscussionTab}>
             <div className={classes.topSectionDiscussionPreview}>
               <Typography
                 display="inline"
@@ -55,7 +53,5 @@ export default function DiscussionPreview({ latestParentComment, discussionTabLa
               truncate={3}
             />
           </div>
-        </Link>
-      </>
     );
   }

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -1,4 +1,4 @@
-import { Button, Link, Typography } from "@material-ui/core";
+import { Button, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import ExpandLessIcon from "@material-ui/icons/ExpandLess";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
@@ -16,7 +16,7 @@ import MiniProfilePreview from "../profile/MiniProfilePreview";
 import Posts from "./../communication/Posts.js";
 import DateDisplay from "./../general/DateDisplay";
 import ProjectStatus from "./ProjectStatus";
-import UnfoldMoreIcon from "@material-ui/icons/UnfoldMore";
+import DiscussionPreview from "./DiscussionPreview";
 
 const MAX_DISPLAYED_DESCRIPTION_LENGTH = 500;
 
@@ -134,27 +134,6 @@ const useStyles = makeStyles((theme) => ({
   },
   finishedDate: {
     marginTop: theme.spacing(0.5),
-  },
-  linkDiscussionPreview: {
-    color: theme.palette.secondary.main,
-  },
-  discussionPreview: {
-    borderBottom: `1px solid ${theme.palette.grey[500]}`,
-    borderTop: `1px solid ${theme.palette.grey[500]}`,
-    marginBottom: theme.spacing(4),
-    paddingTop: theme.spacing(1),
-    paddingBottom: theme.spacing(1),
-  },
-  topSectionDiscussionPreview: {
-    display: "flex",
-    justifyContent: "space-between",
-  },
-  headingDiscussionPreview: {
-    fontWeight: "bold",
-    marginBottom: theme.spacing(0.5),
-  },
-  iconDiscussionPreview: {
-    marginRight: theme.spacing(2),
   },
 }));
 
@@ -390,34 +369,3 @@ function CollaborateContent({ project, texts }) {
   );
 }
 
-function DiscussionPreview({ latestParentComment, discussionTabLabel, locale, project }) {
-  const classes = useStyles();
-  return (
-    <>
-      <Link
-        href={`${getLocalePrefix(locale)}/projects/${project.url_slug}#comments`}
-        underline="none"
-        className={classes.linkDiscussionPreview}
-      >
-        <div className={classes.discussionPreview}>
-          <div className={classes.topSectionDiscussionPreview}>
-            <Typography
-              display="inline"
-              color="primary"
-              className={classes.headingDiscussionPreview}
-            >
-              {discussionTabLabel}
-            </Typography>
-            <UnfoldMoreIcon color="secondary" className={classes.iconDiscussionPreview} />
-          </div>
-          <Posts
-            posts={latestParentComment}
-            type="preview"
-            user={latestParentComment.author_user}
-            truncate={3}
-          />
-        </div>
-      </Link>
-    </>
-  );
-}

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -135,6 +135,9 @@ const useStyles = makeStyles((theme) => ({
   finishedDate: {
     marginTop: theme.spacing(0.5),
   },
+  linkDiscussionPreview: {
+    color: theme.palette.secondary.main,
+  },
   discussionPreview: {
     borderBottom: `1px solid ${theme.palette.grey[500]}`,
     borderTop: `1px solid ${theme.palette.grey[500]}`,
@@ -152,9 +155,6 @@ const useStyles = makeStyles((theme) => ({
   },
   iconDiscussionPreview: {
     marginRight: theme.spacing(2),
-  },
-  linkDiscussionPreview: {
-    color: theme.palette.secondary.main,
   },
 }));
 
@@ -412,8 +412,9 @@ function DiscussionPreview({ latestParentComment, discussionTabLabel, locale, pr
           </div>
           <Posts
             posts={latestParentComment}
-            type="openingpost"
+            type="preview"
             user={latestParentComment.author_user}
+            truncate={3}
           />
         </div>
       </Link>

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -146,7 +146,7 @@ export default function ProjectContent({
   latestParentComment,
   handleTabChange,
   typesByTabValue,
-  projectTabsSpaceToTop,
+  projectTabsRef,
 }) {
   const classes = useStyles();
   const { user, locale } = useContext(UserContext);
@@ -299,7 +299,7 @@ export default function ProjectContent({
           project={project}
           handleTabChange={handleTabChange}
           typesByTabValue={typesByTabValue}
-          projectTabsSpaceToTop={projectTabsSpaceToTop}
+          projectTabsRef={projectTabsRef}
         />
       )}
       <div className={classes.contentBlock} ref={collaborationSectionRef}>

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -1,14 +1,12 @@
-import { Avatar, Button, Link, Typography } from "@material-ui/core";
+import { Button, Link, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import ExpandLessIcon from "@material-ui/icons/ExpandLess";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import humanizeDuration from "humanize-duration";
 import React, { useContext } from "react";
 import TimeAgo from "react-timeago";
-import Truncate from "react-truncate";
 import ROLE_TYPES from "../../../public/data/role_types";
 import { getLocalePrefix } from "../../../public/lib/apiOperations";
-import { getImageUrl } from "../../../public/lib/imageOperations";
 import getTexts from "../../../public/texts/texts";
 import { germanYearAndDayFormatter, yearAndDayFormatter } from "../../utils/formatting";
 import MessageContent from "../communication/MessageContent";
@@ -155,18 +153,8 @@ const useStyles = makeStyles((theme) => ({
   iconDiscussionPreview: {
     marginRight: theme.spacing(2),
   },
-  commentDiscussionPreview: {
-    display: "flex",
-    alignItems: "center",
-  },
-  commentAvatarDiscussionPreview: {
-    margin: theme.spacing(1),
-    marginRight: theme.spacing(2),
-  },
-  commentTextDiscussionPreview: {
+  linkDiscussionPreview: {
     color: theme.palette.secondary.main,
-    overflow: "hidden",
-    marginRight: theme.spacing(2),
   },
 }));
 
@@ -409,6 +397,7 @@ function DiscussionPreview({ latestParentComment, discussionTabLabel, locale, pr
       <Link
         href={`${getLocalePrefix(locale)}/projects/${project.url_slug}#comments`}
         underline="none"
+        className={classes.linkDiscussionPreview}
       >
         <div className={classes.discussionPreview}>
           <div className={classes.topSectionDiscussionPreview}>
@@ -421,21 +410,11 @@ function DiscussionPreview({ latestParentComment, discussionTabLabel, locale, pr
             </Typography>
             <UnfoldMoreIcon color="secondary" className={classes.iconDiscussionPreview} />
           </div>
-          <div className={classes.commentDiscussionPreview}>
-            <Avatar
-              className={classes.commentAvatarDiscussionPreview}
-              src={
-                latestParentComment.author_user.image
-                  ? getImageUrl(latestParentComment.author_user.image)
-                  : getImageUrl(latestParentComment.author_user.thumbnail_image)
-              }
-            />
-            <Typography className={classes.commentTextDiscussionPreview}>
-              <Truncate lines={3} ellipsis={"..."}>
-                {latestParentComment.content}
-              </Truncate>
-            </Typography>
-          </div>
+          <Posts
+            posts={latestParentComment}
+            type="openingpost"
+            user={latestParentComment.author_user}
+          />
         </div>
       </Link>
     </>

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -1,12 +1,14 @@
-import { Button, Typography } from "@material-ui/core";
+import { Avatar, Button, Link, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import ExpandLessIcon from "@material-ui/icons/ExpandLess";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import humanizeDuration from "humanize-duration";
 import React, { useContext } from "react";
 import TimeAgo from "react-timeago";
+import Truncate from "react-truncate";
 import ROLE_TYPES from "../../../public/data/role_types";
 import { getLocalePrefix } from "../../../public/lib/apiOperations";
+import { getImageUrl } from "../../../public/lib/imageOperations";
 import getTexts from "../../../public/texts/texts";
 import { germanYearAndDayFormatter, yearAndDayFormatter } from "../../utils/formatting";
 import MessageContent from "../communication/MessageContent";
@@ -16,6 +18,7 @@ import MiniProfilePreview from "../profile/MiniProfilePreview";
 import Posts from "./../communication/Posts.js";
 import DateDisplay from "./../general/DateDisplay";
 import ProjectStatus from "./ProjectStatus";
+import UnfoldMoreIcon from "@material-ui/icons/UnfoldMore";
 
 const MAX_DISPLAYED_DESCRIPTION_LENGTH = 500;
 
@@ -134,6 +137,37 @@ const useStyles = makeStyles((theme) => ({
   finishedDate: {
     marginTop: theme.spacing(0.5),
   },
+  discussionPreview: {
+    borderBottom: `1px solid ${theme.palette.grey[500]}`,
+    borderTop: `1px solid ${theme.palette.grey[500]}`,
+    marginBottom: theme.spacing(4),
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+  },
+  topSectionDiscussionPreview: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  headingDiscussionPreview: {
+    fontWeight: "bold",
+    marginBottom: theme.spacing(0.5),
+  },
+  iconDiscussionPreview: {
+    marginRight: theme.spacing(2),
+  },
+  commentDiscussionPreview: {
+    display: "flex",
+    alignItems: "center",
+  },
+  commentAvatarDiscussionPreview: {
+    margin: theme.spacing(1),
+    marginRight: theme.spacing(2),
+  },
+  commentTextDiscussionPreview: {
+    color: theme.palette.secondary.main,
+    overflow: "hidden",
+    marginRight: theme.spacing(2),
+  },
 }));
 
 export default function ProjectContent({
@@ -141,6 +175,8 @@ export default function ProjectContent({
   leaveProject,
   projectDescriptionRef,
   collaborationSectionRef,
+  discussionTabLabel,
+  latestParentComment,
 }) {
   const classes = useStyles();
   const { user, locale } = useContext(UserContext);
@@ -285,6 +321,14 @@ export default function ProjectContent({
           </Button>
         )}
       </div>
+      {latestParentComment && (
+        <DiscussionPreview
+          latestParentComment={latestParentComment}
+          discussionTabLabel={discussionTabLabel}
+          locale={locale}
+          project={project}
+        />
+      )}
       <div className={classes.contentBlock} ref={collaborationSectionRef}>
         <Typography component="h2" variant="h6" color="primary" className={classes.subHeader}>
           {texts.collaboration}
@@ -354,6 +398,46 @@ function CollaborateContent({ project, texts }) {
           </div>
         )}
       </div>
+    </>
+  );
+}
+
+function DiscussionPreview({ latestParentComment, discussionTabLabel, locale, project }) {
+  const classes = useStyles();
+  return (
+    <>
+      <Link
+        href={`${getLocalePrefix(locale)}/projects/${project.url_slug}#comments`}
+        underline="none"
+      >
+        <div className={classes.discussionPreview}>
+          <div className={classes.topSectionDiscussionPreview}>
+            <Typography
+              display="inline"
+              color="primary"
+              className={classes.headingDiscussionPreview}
+            >
+              {discussionTabLabel}
+            </Typography>
+            <UnfoldMoreIcon color="secondary" className={classes.iconDiscussionPreview} />
+          </div>
+          <div className={classes.commentDiscussionPreview}>
+            <Avatar
+              className={classes.commentAvatarDiscussionPreview}
+              src={
+                latestParentComment.author_user.image
+                  ? getImageUrl(latestParentComment.author_user.image)
+                  : getImageUrl(latestParentComment.author_user.thumbnail_image)
+              }
+            />
+            <Typography className={classes.commentTextDiscussionPreview}>
+              <Truncate lines={3} ellipsis={"..."}>
+                {latestParentComment.content}
+              </Truncate>
+            </Typography>
+          </div>
+        </div>
+      </Link>
     </>
   );
 }

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -146,6 +146,7 @@ export default function ProjectContent({
   latestParentComment,
   handleTabChange,
   typesByTabValue,
+  projectTabsSpaceToTop,
 }) {
   const classes = useStyles();
   const { user, locale } = useContext(UserContext);
@@ -298,6 +299,7 @@ export default function ProjectContent({
           project={project}
           handleTabChange={handleTabChange}
           typesByTabValue={typesByTabValue}
+          projectTabsSpaceToTop={projectTabsSpaceToTop}
         />
       )}
       <div className={classes.contentBlock} ref={collaborationSectionRef}>

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -144,6 +144,8 @@ export default function ProjectContent({
   collaborationSectionRef,
   discussionTabLabel,
   latestParentComment,
+  handleTabChange,
+  typesByTabValue,
 }) {
   const classes = useStyles();
   const { user, locale } = useContext(UserContext);
@@ -294,6 +296,8 @@ export default function ProjectContent({
           discussionTabLabel={discussionTabLabel}
           locale={locale}
           project={project}
+          handleTabChange={handleTabChange}
+          typesByTabValue={typesByTabValue}
         />
       )}
       <div className={classes.contentBlock} ref={collaborationSectionRef}>
@@ -368,4 +372,3 @@ function CollaborateContent({ project, texts }) {
     </>
   );
 }
-

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -290,7 +290,7 @@ export default function ProjectContent({
           </Button>
         )}
       </div>
-      {latestParentComment && (
+      {latestParentComment[0] && (
         <DiscussionPreview
           latestParentComment={latestParentComment}
           discussionTabLabel={discussionTabLabel}

--- a/frontend/src/components/project/ProjectPageRoot.js
+++ b/frontend/src/components/project/ProjectPageRoot.js
@@ -343,7 +343,7 @@ export default function ProjectPageRoot({
   const bindFollow = useLongPress(() => {
     toggleShowFollowers();
   });
-  const latestParentComment = project.comments[0];
+  const latestParentComment = [project.comments[0]];
   return (
     <div className={classes.root}>
       <ProjectOverview

--- a/frontend/src/components/project/ProjectPageRoot.js
+++ b/frontend/src/components/project/ProjectPageRoot.js
@@ -343,7 +343,7 @@ export default function ProjectPageRoot({
   const bindFollow = useLongPress(() => {
     toggleShowFollowers();
   });
-
+  const latestParentComment = project.comments[0];
   return (
     <div className={classes.root}>
       <ProjectOverview
@@ -395,6 +395,8 @@ export default function ProjectPageRoot({
             leaveProject={requestLeaveProject}
             projectDescriptionRef={projectDescriptionRef}
             collaborationSectionRef={collaborationSectionRef}
+            discussionTabLabel={discussionTabLabel()}
+            latestParentComment={latestParentComment}
           />
         </TabContent>
         <TabContent value={tabValue} index={1}>

--- a/frontend/src/components/project/ProjectPageRoot.js
+++ b/frontend/src/components/project/ProjectPageRoot.js
@@ -397,6 +397,8 @@ export default function ProjectPageRoot({
             collaborationSectionRef={collaborationSectionRef}
             discussionTabLabel={discussionTabLabel()}
             latestParentComment={latestParentComment}
+            handleTabChange={handleTabChange}
+            typesByTabValue={typesByTabValue}
           />
         </TabContent>
         <TabContent value={tabValue} index={1}>

--- a/frontend/src/components/project/ProjectPageRoot.js
+++ b/frontend/src/components/project/ProjectPageRoot.js
@@ -98,8 +98,6 @@ export default function ProjectPageRoot({
   const contactProjectCreatorButtonRef = useRef(null);
   const projectTabsRef = useRef(null);
 
-  const projectTabsSpaceToTop = ElementSpaceToTop({el: projectTabsRef.current});
-  
   const messageButtonIsVisible = ElementOnScreen({ el: contactProjectCreatorButtonRef.current });
 
   const handleClickContact = async (event) => {
@@ -402,7 +400,7 @@ export default function ProjectPageRoot({
             latestParentComment={latestParentComment}
             handleTabChange={handleTabChange}
             typesByTabValue={typesByTabValue}
-            projectTabsSpaceToTop={projectTabsSpaceToTop}
+            projectTabsRef={projectTabsRef}
           />
         </TabContent>
         <TabContent value={tabValue} index={1}>

--- a/frontend/src/components/project/ProjectPageRoot.js
+++ b/frontend/src/components/project/ProjectPageRoot.js
@@ -20,6 +20,7 @@ import ProjectOverview from "./ProjectOverview";
 import ProjectTeamContent from "./ProjectTeamContent";
 import { useLongPress } from "use-long-press";
 import { NOTIFICATION_TYPES } from "../communication/notifications/Notification";
+import ElementSpaceToTop from "../hooks/ElementSpaceToTop";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -97,6 +98,8 @@ export default function ProjectPageRoot({
   const contactProjectCreatorButtonRef = useRef(null);
   const projectTabsRef = useRef(null);
 
+  const projectTabsSpaceToTop = ElementSpaceToTop({el: projectTabsRef.current});
+  
   const messageButtonIsVisible = ElementOnScreen({ el: contactProjectCreatorButtonRef.current });
 
   const handleClickContact = async (event) => {
@@ -399,6 +402,7 @@ export default function ProjectPageRoot({
             latestParentComment={latestParentComment}
             handleTabChange={handleTabChange}
             typesByTabValue={typesByTabValue}
+            projectTabsSpaceToTop={projectTabsSpaceToTop}
           />
         </TabContent>
         <TabContent value={tabValue} index={1}>


### PR DESCRIPTION
Closes #505 

# Description #505 #

The DiscussionPreview is now implemented and added to the project page. Its heading is the same as for the discussion tab and it displays the latest parent comment (including profile picture and name of the commenting user, date of the comment).

## Design ##
* visual indication when the user is hovering over or clicking on the section

## Functionality ##
* clicking anywhere on the preview section takes the user to the discussion tab on the project page

## Before landing

1. PR has meaningful title
1. `yarn lint` passes
1. `yarn format` passes
