### PR TITLE
Preventing state update in a loop

### DIFF
--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -181,10 +181,13 @@ export default function MyApp({
       //
       // Revisit this code after the most recent state testing from
       // https://github.com/climateconnect/climateconnect/pull/709
-      setSocketConnectionState("closed");
+      if (socketConnectionState !== "closed") {
+        setSocketConnectionState("closed");
+      }
+
       if (process.env.SOCKET_URL) {
         setTimeout(function () {
-          connect();
+          connect(client);
         }, 1000);
       }
     };


### PR DESCRIPTION
State of the main page component is constantly getting updated when the WebSocket connection keeps failing. This causes an infinite loop of re-rendering, which contains sending some Web Requests to our backend from the child components – these two variables are propagated into children that rely on them. 
I think we should avoid this state and let the WebSocket connection keep failing more silently (if it has to happen). 