### PR TITLE
Fixed: only calculate length when there is a description

### DIFF
--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -174,7 +174,7 @@ export default function ProjectContent({
       return MAX_DISPLAYED_DESCRIPTION_LENGTH;
     }
   };
-  const maxDisplayedDescriptionLength = CalculateMaxDisplayedDescriptionLength(project.description);
+  const maxDisplayedDescriptionLength = project.description ? CalculateMaxDisplayedDescriptionLength(project.description) : null;
   return (
     <div>
       <div className={classes.contentBlock}>


### PR DESCRIPTION
Follow up to #833 
The `maxDescriptionLength` was calculated even if there was no description which caused a 'properties of null' error. This is now fixed.