### PR TITLE
Setting up caching and cache frequently fetched and unchanged APIs. 

### DIFF
--- a/backend/climateconnect_api/views/user_views.py
+++ b/backend/climateconnect_api/views/user_views.py
@@ -152,7 +152,7 @@ class ListMemberProfilesView(ListAPIView):
     search_fields = ['name']
     serializer_class = UserProfileStubSerializer
 
-    @method_decorator(cache_page(60*60))
+    @method_decorator(cache_page(settings.DEFAULT_CACHE_TIMEOUT))
     def dispatch(self, *args, **kwargs):
         return super(ListMemberProfilesView, self).dispatch(*args, **kwargs)
 

--- a/backend/climateconnect_api/views/user_views.py
+++ b/backend/climateconnect_api/views/user_views.py
@@ -1,4 +1,3 @@
-
 from ideas.serializers.idea import IdeaFromIdeaSupporterSerializer
 from ideas.models.support import IdeaSupporter
 
@@ -22,13 +21,15 @@ from climateconnect_api.utility.translation import (edit_translations)
 from climateconnect_main.utility.general import get_image_from_data_url
 from django.conf import settings
 from django.contrib.auth import authenticate, login
-# Backend imports
+
 from django.contrib.auth.models import User
 from django.contrib.gis.db.models.functions import Distance
 from django.db.models import Count, Q
 from django.utils import timezone
 from django.utils.translation import gettext as _
-# Rest imports
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
+
 from django_filters.rest_framework import DjangoFilterBackend
 from knox.views import LoginView as KnoxLoginView
 from location.models import Location
@@ -151,6 +152,10 @@ class ListMemberProfilesView(ListAPIView):
     search_fields = ['name']
     serializer_class = UserProfileStubSerializer
 
+    @method_decorator(cache_page(60*60))
+    def dispatch(self, *args, **kwargs):
+        return super(ListMemberProfilesView, self).dispatch(*args, **kwargs)
+
     def get_queryset(self):
         user_profiles = UserProfile.objects\
             .filter(is_profile_verified=True)\
@@ -256,6 +261,7 @@ class ListMemberProjectsView(ListAPIView):
                 is_active=True
             ).order_by('-id')
 
+
 class ListMemberIdeasView(ListAPIView):
     permission_classes = [AllowAny]
     filter_backends = [SearchFilter]
@@ -268,6 +274,7 @@ class ListMemberIdeasView(ListAPIView):
         return IdeaSupporter.objects.filter(
             user=searched_user
         ).order_by('-id')
+
 
 class ListMemberOrganizationsView(ListAPIView):
     permission_classes = [AllowAny]

--- a/backend/climateconnect_main/settings.py
+++ b/backend/climateconnect_main/settings.py
@@ -299,3 +299,11 @@ LOGGING = {
         }
     }
 }
+
+# Setting up cache
+CACHES = {
+    'default': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': env('REDIS_URL')
+    }
+}

--- a/backend/climateconnect_main/settings.py
+++ b/backend/climateconnect_main/settings.py
@@ -307,3 +307,5 @@ CACHES = {
         'LOCATION': env('REDIS_URL')
     }
 }
+
+DEFAULT_CACHE_TIMEOUT = 2 * 24 * 3600

--- a/backend/climateconnect_main/settings.py
+++ b/backend/climateconnect_main/settings.py
@@ -304,7 +304,10 @@ LOGGING = {
 CACHES = {
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': env('REDIS_URL')
+        'LOCATION': env('REDIS_URL'),
+        'OPTIONS': {
+            'PASSWORD': env('REDIS_PASSWORD')
+        }
     }
 }
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,7 @@ cffi==1.15.0
 channels==2.4.0
 channels-redis==2.4.2
 chardet==3.0.4
+charset-normalizer==2.0.7
 click==7.1.2
 click-didyoumean==0.0.3
 click-plugins==1.1.1
@@ -27,6 +28,7 @@ Django==2.2.24
 django-cors-headers==3.2.1
 django-debug-toolbar==3.2.1
 django-filter==2.3.0
+django-redis==5.1.0
 django-rest-knox==4.1.0
 django-storages==1.9.1
 djangorestframework==3.11.2
@@ -46,7 +48,7 @@ mccabe==0.6.1
 msgpack==0.6.0
 Pillow==8.3.2
 prompt-toolkit==3.0.14
-protobuf==3.19.1
+protobuf==3.12.2
 psycopg2-binary==2.8.6
 pyasn1==0.4.8
 pyasn1-modules==0.2.8


### PR DESCRIPTION
## Description

We have few APIs that we use very frequently, but the response data does not change very often in our system. These are very database heavy operations that takes long timer to fetch in the frontend. This PR is to cache those frequently used APIs. 

Note: You need to run redis server for this. You can run it using docker. We have docker file configured in our system. 

## Test plan
* You need to setup `REDIS_URL` in `.backup_env` file. Example: `REDIS_URL="redis://127.0.0.1:6379/0"`.
* The go to /browse page on frontend and look for members tab. First time you load the page it will make a database call but later if you visit them same page it will render data from the cache file. 
* You can check if the cache is set properly or not by opening django shell. Run following commands.
```
python manage.py shell
>>> from django.core.cache import cache
>>> cache.keys('*')
```
This will return cache keys that we store for APIs. You should also test filters and searches to make sure it works as expected. 

## Before landing

1. PR has meaningful title
1. `yarn lint` passes
1. `yarn format` passes
