### PR TITLE
Fix unexpected error in chat

### DIFF
--- a/backend/chat_messages/utility/chat_setup.py
+++ b/backend/chat_messages/utility/chat_setup.py
@@ -26,15 +26,17 @@ def set_read(messages, user, is_private_message):
     # Here we are assuming that all messages passed to this function are from the same chat
     message_notifications = Notification.objects.filter(chat=messages[0].message_participant)
     if message_notifications.exists():
-        unread_user_notifications = UserNotification.objects.filter(
-            notification__in=message_notifications,
-            read_at=None,
-            user=user
-        )
-        if unread_user_notifications.exists():
-            user_notification = unread_user_notifications[0]
+        try:
+            unread_user_notification = UserNotification.objects.get(
+                notification__in=message_notifications,
+                read_at=None,
+                user=user
+            )
+            user_notification = unread_user_notification
             user_notification.read_at = datetime.now()
             user_notification.save()
+        except UserNotification.DoesNotExist:
+            print("there is no user notification for "+user.first_name)
 
 
 def create_private_or_group_chat(

--- a/backend/chat_messages/utility/chat_setup.py
+++ b/backend/chat_messages/utility/chat_setup.py
@@ -36,7 +36,7 @@ def set_read(messages, user, is_private_message):
             user_notification.read_at = datetime.now()
             user_notification.save()
         except UserNotification.DoesNotExist:
-            print("there is no user notification for "+user.first_name)
+            logger.error("there is no user notification for "+user.first_name)
 
 
 def create_private_or_group_chat(

--- a/backend/climateconnect_api/utility/badges.py
+++ b/backend/climateconnect_api/utility/badges.py
@@ -12,7 +12,6 @@ def get_badges(user_profile):
         today = datetime.datetime.today()
         time_donated = time_donated = today - d.date_first_received.replace(tzinfo=None)
         if d:
-            print(d.date_first_received)
             highest_donations_in_streak = all_donations.filter(
                 date_first_received__gte=d.date_first_received
             ).order_by(

--- a/frontend/pages/chat/[chatUUID].js
+++ b/frontend/pages/chat/[chatUUID].js
@@ -1,7 +1,6 @@
 import NextCookies from "next-cookies";
 import React, { useContext, useEffect } from "react";
 import Cookies from "universal-cookie";
-
 import { apiRequest, redirect, sendToLogin } from "../../public/lib/apiOperations";
 import { getMessageFromServer } from "../../public/lib/messagingOperations";
 import getTexts from "../../public/texts/texts";
@@ -79,16 +78,23 @@ export default function Chat({
   useEffect(() => {
     if (chatSocket) {
       chatSocket.onmessage = async (rawData) => {
-        const data = JSON.parse(rawData.data);
-        if (data.chat_uuid === chatUUID) {
-          const message = await getMessageFromServer(data.message_id, token, locale);
-          setState({
-            ...state,
-            messages: [
-              ...state.messages.filter((m) => !(m.content === message.content && m.unconfirmed)),
-              message,
-            ],
-          });
+        if (rawData) {
+          const data = JSON.parse(rawData.data);
+          if (data.chat_uuid === chatUUID) {
+            const message = await getMessageFromServer(data.message_id, token, locale);
+            setState((state) => {
+              return {
+                ...state,
+                messages: [
+                  ...state.messages.filter(
+                    (m) =>
+                      !((m.content === message.content && m.unconfirmed) || m.id === message.id)
+                  ),
+                  message,
+                ],
+              };
+            });
+          }
         }
       };
     } else console.log("now there is no chat socket");

--- a/frontend/src/components/communication/chat/MessagingLayout.js
+++ b/frontend/src/components/communication/chat/MessagingLayout.js
@@ -68,7 +68,7 @@ export default function MessagingLayout({
   const [alertMessage, setAlertMessage] = useState({});
   const [showAlertMessage, setShowAlertMessage] = useState(false);
   const [showSendHelper, setShowSendHelper] = useState(false);
-  const user_role = participants.filter((p) => p.id === user.id)[0].role;
+  const user_role = participants.filter((p) => p.id === user?.id)[0].role;
   //TODO show user when socket has closed
   const onSendMessage = (event) => {
     sendMessage(curMessage);

--- a/frontend/src/components/header/Header.js
+++ b/frontend/src/components/header/Header.js
@@ -17,7 +17,7 @@ import {
   Paper,
   Popper,
   SwipeableDrawer,
-  Typography
+  Typography,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import useMediaQuery from "@material-ui/core/useMediaQuery";

--- a/frontend/src/components/layouts/layout.js
+++ b/frontend/src/components/layouts/layout.js
@@ -16,11 +16,11 @@ const useStyles = makeStyles((theme) => ({
     textAlign: "center",
     margin: `${theme.spacing(4)}px 0`,
   },
-  alert: {
+  alert: props => ({
     width: "100%",
     zIndex: 100,
-    marginTop: theme.spacing(-2),
-  },
+    marginTop: !props.donationCampaignRunning && theme.spacing(-2),
+  }),
 }));
 
 export default function Layout({
@@ -32,7 +32,7 @@ export default function Layout({
   isLoading,
   isStaticPage,
 }) {
-  const classes = useStyles();
+  const classes = useStyles({donationCampaignRunning: process.env.DONATION_CAMPAIGN_RUNNING});
   const [hideAlertMessage, setHideAlertMessage] = React.useState(false);
   const [initialMessageType, setInitialMessageType] = React.useState(null);
   const [initialMessage, setInitialMessage] = React.useState("");

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -174,7 +174,9 @@ export default function ProjectContent({
       return MAX_DISPLAYED_DESCRIPTION_LENGTH;
     }
   };
-  const maxDisplayedDescriptionLength = project.description ? CalculateMaxDisplayedDescriptionLength(project.description) : null;
+  const maxDisplayedDescriptionLength = project.description
+    ? CalculateMaxDisplayedDescriptionLength(project.description)
+    : null;
   return (
     <div>
       <div className={classes.contentBlock}>


### PR DESCRIPTION
## Description

- Fixed index out of bound error in backend which through a 500 error. 
- For some reason the websocket sends each chat message twice. Fixed frontend implications of that by only showing a message once per id. 
- Fixed the unexpected error when logging out while in the chat window. This was caused by trying to access a property of the user object which is obv. null if you log out.

Closes #830 

## Test plan

1. Open a private chat (ideally with 2 accounts in 2 browsers)
2. Write a message
3. Make sure there is no error on either browser and the message arrives exactly once. 

Fixes were made to websocket mode, so you shouldn't be using the fallback HTTP requests
