### PR TITLE
Fix errors when logging out on different pages

### DIFF
--- a/frontend/pages/chat/[chatUUID].js
+++ b/frontend/pages/chat/[chatUUID].js
@@ -244,7 +244,7 @@ export default function Chat({
           : title
       }
     >
-      {chat_id ? (
+      {user && chat_id ? (
         <MessagingLayout
           chatting_partner={chatting_partner}
           messages={state.messages}

--- a/frontend/pages/inbox.js
+++ b/frontend/pages/inbox.js
@@ -71,7 +71,7 @@ export async function getServerSideProps(ctx) {
   if (ctx.req && !token) {
     const texts = getTexts({ page: "chat", locale: ctx.locale });
     const message = texts.you_have_to_log_in_to_see_your_inbox;
-    return sendToLogin(ctx, message);
+    return sendToLogin(ctx, message, ctx.locale, ctx.resolvedUrl);
   }
   const chatData = await getChatsOfLoggedInUser(token, null, ctx.locale);
   return {

--- a/frontend/pages/manageProjectMembers/[projectUrl].js
+++ b/frontend/pages/manageProjectMembers/[projectUrl].js
@@ -25,7 +25,7 @@ export async function getServerSideProps(ctx) {
   const texts = getTexts({ page: "project", locale: ctx.locale });
   if (ctx.req && !token) {
     const message = texts.you_have_to_log_in_to_manage_a_projects_members;
-    return sendToLogin(ctx, message);
+    return sendToLogin(ctx, message, ctx.locale, ctx.resolvedUrl);
   }
   const projectUrl = encodeURI(ctx.query.projectUrl);
   const [project, members, rolesOptions, availabilityOptions] = await Promise.all([

--- a/frontend/src/components/communication/chat/MessagingLayout.js
+++ b/frontend/src/components/communication/chat/MessagingLayout.js
@@ -68,7 +68,8 @@ export default function MessagingLayout({
   const [alertMessage, setAlertMessage] = useState({});
   const [showAlertMessage, setShowAlertMessage] = useState(false);
   const [showSendHelper, setShowSendHelper] = useState(false);
-  const user_role = participants.filter((p) => p.id === user?.id)[0].role;
+  const userParticipant = participants.find((p) => p.id === user?.id)
+  const user_role = userParticipant && userParticipant.role;
   //TODO show user when socket has closed
   const onSendMessage = (event) => {
     sendMessage(curMessage);
@@ -76,8 +77,8 @@ export default function MessagingLayout({
     if (event) event.preventDefault();
   };
   const canEditMembers =
-    user_role.role_type === ROLE_TYPES.all_type ||
-    user_role.role_type === ROLE_TYPES.read_write_type;
+    user_role?.role_type === ROLE_TYPES.all_type ||
+    user_role?.role_type === ROLE_TYPES.read_write_type;
 
   const handleMessageKeydown = (event) => {
     if (event.key === "Enter")


### PR DESCRIPTION
## Description

The following pages were throwing errors when you logged out while being on the page:
- `/inbox`
- `/chat/[chatUUID]`
- `/manageProjectMembers/[projectUrl]

These should now not throw errors anymore when logging out.

## Test plan

- Go to each of the 3 mentioned pages while logged in and log out
- Make sure there is no error
