### PR TITLE
Don't return empty object in getServerSideProps on "/"

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -77,12 +77,12 @@ export async function getServerSideProps(ctx) {
   console.log("getting serverside props");
   if (ctx.resolvedUrl === "/" && token) {
     console.log("redirecting!!!");
-    ctx.res.writeHead(302, {
-      Location: getLocalePrefix(ctx.locale) + "/browse",
-      "Content-Type": "text/html; charset=utf-8",
-    });
-    ctx.res.end();
-    return;
+    return {
+      redirect: {
+        permanent: false,
+        destination: `${getLocalePrefix(ctx.locale)}/browse`
+      }
+    }
   }
   return {
     props: {},


### PR DESCRIPTION
## Description

We sometimes had the following error: 
`error - Error: Your `getServerSideProps` function did not return an object. Did you forget to add a `return`?
    at Object.renderToHTML (/Users/ddhanesha/repos/climateconnect_env/climateconnect/frontend/node_modules/next/dist/server/render.js:453:23)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async doRender (/Users/ddhanesha/repos/climateconnect_env/climateconnect/frontend/node_modules/next/dist/server/next-server.js:1149:38)
    at async /Users/ddhanesha/repos/climateconnect_env/climateconnect/frontend/node_modules/next/dist/server/next-server.js:1241:28
    at async /Users/ddhanesha/repos/climateconnect_env/climateconnect/frontend/node_modules/next/dist/server/response-cache.js:64:36 {
  page: '/'`
  
 The reason for this was that getServerSideProps returned nothing if you were redirected. Now we're using the recommended way of redirecting by returning a redirect object. This should fix this issue.