### PR TITLE
Fix: Select the correct language for texts (SocialMediaShareButton on the organization page)

### DIFF
--- a/frontend/src/components/account/AccountPage.js
+++ b/frontend/src/components/account/AccountPage.js
@@ -152,7 +152,7 @@ export default function AccountPage({
   const token = new Cookies().get("token");
   const texts = getTexts({ page: "profile", locale: locale });
   const organizationTexts = isOrganization
-    ? getTexts({ page: "organization", organization: account })
+    ? getTexts({ page: "organization", organization: account, locale: locale })
     : "Not an organization";
   const componentDecorator = (href, text, key) => (
     <Link


### PR DESCRIPTION
Follow up to #792 

The organization texts were missing the locale prop and therefore they were always in English. Now the locale is added and the correct language is displayed.