### PR TITLE
Serving WebP images in lieu of JPEG when applicable

### DIFF
--- a/backend/climateconnect_main/utility/general.py
+++ b/backend/climateconnect_main/utility/general.py
@@ -1,7 +1,6 @@
 # python standard lib
 import base64
 import io
-from os import path
 import secrets
 
 from django.core.files.base import ContentFile

--- a/backend/climateconnect_main/utility/general.py
+++ b/backend/climateconnect_main/utility/general.py
@@ -1,15 +1,17 @@
 # python standard lib
 import base64
 import io
+from os import path
 import secrets
 
 from django.core.files.base import ContentFile
 # django and pillow lib
 from PIL import Image
+import pathlib
 
 
 #source: https://dev.to/ageumatheus/creating-image-from-dataurl-base64-with-pyhton-django-454g
-def get_image_from_data_url( data_url, resize=False, base_width=500 ):
+def get_image_from_data_url( data_url, resize=False, base_width=500):
     # getting the file format and the necessary dataURl for the file
     _format, _dataurl       = data_url.split(';base64,')
     # file name and extension
@@ -54,3 +56,23 @@ def get_allowed_hosts(ALLOWED_HOSTS_ENV):
             if not host in allowed_hosts:
                 allowed_hosts.append(host)
     return allowed_hosts
+
+
+def convert_image_to_webp(source):
+    """Convert image to WebP.
+
+    Args:
+        source (pathlib.Path): Path to source image
+
+    Returns:
+        pathlib.Path: path to new image
+    """
+    source = pathlib.Path(source)
+    
+    destination = source.with_suffix(".webp")
+
+    image = Image.open(source)  # Open image
+    image.save(destination, format="webp")  # Convert image to webp
+
+
+    return destination

--- a/backend/organization/models/project.py
+++ b/backend/organization/models/project.py
@@ -5,7 +5,7 @@ from django.contrib.postgres.fields import ArrayField
 from organization.models import (Organization,)
 from climateconnect_api.models import (Skill,)
 from climateconnect_api.models.language import Language
-
+from climateconnect_main.utility.general import convert_image_to_webp
 
 def project_image_path(instance, filename):
     return "projects/{}/{}".format(instance.id, filename)
@@ -179,6 +179,19 @@ class Project(models.Model):
         null=True, blank=True,
         on_delete=models.SET_NULL
     )
+    
+    def save(self,*args,**kwargs):
+        super().save(*args,**kwargs)
+        self.post_processing()
+        
+    def post_processing(self):
+        try:
+            convert_image_to_webp(source=self.image.path)
+            convert_image_to_webp(source=self.thumbnail_image.path)
+            
+        except:
+            pass
+            #log errros. Make sure that saving process does not fail because of post processing
 
     class Meta:
         app_label = "organization"

--- a/frontend/public/lib/imageOperations.js
+++ b/frontend/public/lib/imageOperations.js
@@ -2,7 +2,15 @@ const DEVELOPMENT = ["development", "develop", "test"].includes(process.env.ENVI
 import imageCompression from "browser-image-compression";
 
 export function getImageUrl(url) {
+
+  var IsWebPCompatibleBrowser = false;
   if (!url) return;
+
+
+  if (IsWebPCompatibleBrowser===true) {
+    url = url.replace('.jpeg','.webp')
+  }
+  console.log(url);
   if (DEVELOPMENT && !url.includes("http:") && !url.includes("https:")) {
     return process.env.API_URL + url;
   } else {


### PR DESCRIPTION
## Description

This PR introduces a new feature that converts uploaded images to webp. For every image that is uploaded, a file will be created normally with a `.jpeg` extension. In addition, a new file with the same name will be created with a `.webp` extension.

As webp is not supported by all browser versions, we need to provide .jpeg in case of incompatibility. The logic will be handled on the node side. It servers webp or jpeg based on the compatibility check.  

##TODO 

1. Add a function in imageOperations.js that detects webp browser compatibility. More info is found here https://developers.google.com/speed/webp/faq#how_can_i_detect_browser_support_for_webp. We have 2 options: Client side and Server side detection (using headers). 
2. Write a script that will convert already existing images in Azure Storage to their webp equivalent.

## Test plan

_Include relevant test configuration details for the reviewer(s), and steps to test and verify new feature._

## Before landing

1. PR has meaningful title
1. `yarn lint` passes
1. `yarn format` passes
