### PR TITLE
Fix: Position of ContactCreatorButton in ProjectOverview

### DIFF
--- a/frontend/src/components/project/Buttons/ContactCreatorButton.js
+++ b/frontend/src/components/project/Buttons/ContactCreatorButton.js
@@ -9,6 +9,7 @@ import UserContext from "../../context/UserContext";
 
 const useStyles = makeStyles({
   root: (props) => ({
+    height: props.collapsable ? 40 : "auto",
     position: "relative",
     width: props.customCardWidth ? props.customCardWidth : 220,
     zIndex: 1,


### PR DESCRIPTION
## Description

Follow up to #859 
When refactoring I removed the height from the root container because it seemed duplicate to me. That introduced a visual bug for projects with likes or followers: The button aligns with the likes- / followers-link instead of with the other buttons. This PR fixes that by defining the height of the root container for the collapsable version of the ContactCreatorButton.

## Test plan

Check the button position of the ContactCreatorButton in ProjectOverview on a project which does have likes or followers. Without this fix, the positioning of the button is wrong.