### PR TITLE
Fix: Make ProjectFollowers- and ProjectLikesDialog show avatar instead of placeholder

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -164,7 +164,9 @@ export default function Index() {
           <HubsBox isLoading={isLoading} hubs={elements.hubs} />
           <JoinCommunityBox h1ClassName={classes.h1ClassName} />
           <OrganizationsSharedBox isLoading={isLoading} organizations={elements.organizations} />
-          {process.env.DONATION_CAMPAIGN_RUNNING && <DonationsBanner h1ClassName={classes.h1ClassName} />}
+          {process.env.DONATION_CAMPAIGN_RUNNING && (
+            <DonationsBanner h1ClassName={classes.h1ClassName} />
+          )}
           <OurTeamBox h1ClassName={classes.h1ClassName} />
           <StartNowBanner h1ClassName={classes.h1ClassName} />
         </div>

--- a/frontend/src/components/dialogs/ProjectFollowersDialog.js
+++ b/frontend/src/components/dialogs/ProjectFollowersDialog.js
@@ -112,7 +112,7 @@ const ProjectFollowers = ({ followers, texts, locale }) => {
                   >
                     <Avatar
                       className={classes.avatar}
-                      src={getImageUrl(f.user_profile.image)}
+                      src={getImageUrl(f.user_profile.thumbnail_image)}
                       alt={f.user_profile.first_name + " " + f.user_profile.last_name}
                     />
                     <Typography component="span" color="secondary" className={classes.username}>

--- a/frontend/src/components/dialogs/ProjectLikesDialog.js
+++ b/frontend/src/components/dialogs/ProjectLikesDialog.js
@@ -97,7 +97,7 @@ const ProjectLikes = ({ likes, texts, locale }) => {
                   >
                     <Avatar
                       className={classes.avatar}
-                      src={getImageUrl(l.user_profile.image)}
+                      src={getImageUrl(l.user_profile.thumbnail_image)}
                       alt={l.user_profile.first_name + " " + l.user_profile.last_name}
                     />
                     <Typography component="span" color="secondary" className={classes.username}>

--- a/frontend/src/components/header/Header.js
+++ b/frontend/src/components/header/Header.js
@@ -17,7 +17,7 @@ import {
   Paper,
   Popper,
   SwipeableDrawer,
-  Typography
+  Typography,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import useMediaQuery from "@material-ui/core/useMediaQuery";

--- a/frontend/src/components/layouts/LayoutWrapper.js
+++ b/frontend/src/components/layouts/LayoutWrapper.js
@@ -3,7 +3,7 @@ import {
   Snackbar,
   SnackbarContent,
   Typography,
-  useMediaQuery
+  useMediaQuery,
 } from "@material-ui/core";
 import { makeStyles, ThemeProvider } from "@material-ui/core/styles";
 import Head from "next/head";

--- a/frontend/src/components/staticpages/donate/DonationCampaignInformation.js
+++ b/frontend/src/components/staticpages/donate/DonationCampaignInformation.js
@@ -117,7 +117,7 @@ export default function DonationCampaignInformation() {
   const handleToggleExpanded = () => {
     setExpanded(!expanded);
   };
-  console.log(donationGoal)
+  console.log(donationGoal);
   if (!donationGoal?.goal_amount) return <></>;
   return (
     <>

--- a/frontend/src/components/staticpages/donate/DonationCampaignInformation.js
+++ b/frontend/src/components/staticpages/donate/DonationCampaignInformation.js
@@ -117,7 +117,6 @@ export default function DonationCampaignInformation() {
   const handleToggleExpanded = () => {
     setExpanded(!expanded);
   };
-  console.log(donationGoal);
   if (!donationGoal?.goal_amount) return <></>;
   return (
     <>


### PR DESCRIPTION
## Description

Closes #882 
This makes sure the ProjectFollowers- and ProjectLikesDialog show the user's avatar instead of the placeholder when the user profile contains a profile picture.

## Test plan

Click on a project with followers and likes and click on the link showing their count for followers and likes. Make sure both show the user's profile pictures instead of the placeholder avatar.
