### PR TITLE
Remove caching to test impact on server

### DIFF
--- a/backend/climateconnect_api/views/user_views.py
+++ b/backend/climateconnect_api/views/user_views.py
@@ -27,8 +27,6 @@ from django.contrib.gis.db.models.functions import Distance
 from django.db.models import Count, Q
 from django.utils import timezone
 from django.utils.translation import gettext as _
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 
 from django_filters.rest_framework import DjangoFilterBackend
 from knox.views import LoginView as KnoxLoginView
@@ -151,10 +149,6 @@ class ListMemberProfilesView(ListAPIView):
     filterset_fields = ['name']
     search_fields = ['name']
     serializer_class = UserProfileStubSerializer
-
-    @method_decorator(cache_page(settings.DEFAULT_CACHE_TIMEOUT))
-    def dispatch(self, *args, **kwargs):
-        return super(ListMemberProfilesView, self).dispatch(*args, **kwargs)
 
     def get_queryset(self):
         user_profiles = UserProfile.objects\

--- a/backend/climateconnect_main/settings.py
+++ b/backend/climateconnect_main/settings.py
@@ -303,16 +303,3 @@ LOGGING = {
         }
     }
 }
-
-# Setting up cache
-CACHES = {
-    'default': {
-        'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': env('REDIS_URL'),
-        'OPTIONS': {
-            'PASSWORD': env('REDIS_PASSWORD')
-        }
-    }
-}
-
-DEFAULT_CACHE_TIMEOUT = 2 * 24 * 3600


### PR DESCRIPTION
## Description

Basically just removing the recently added feature of caching in Django because we're experienced server restarts that we can't really track back to something specific. If this does not cause the problem I'll just re-add it tomorrow.
