### PR TITLE
Feature/similarprojects

### DIFF
--- a/backend/organization/urls.py
+++ b/backend/organization/urls.py
@@ -164,4 +164,9 @@ urlpatterns = [
         'organizations/<str:url_slug>/set_shared_organization/',
         organization_views.SetOrganisationSharedView.as_view(), name="set-shared-organization-view"
     ),
+    path(
+        'projects/<str:url_slug>/similar/',
+        project_views.SimilarProjects.as_view(),
+        name='similar-projects'
+    ),
 ]

--- a/backend/organization/utility/project.py
+++ b/backend/organization/utility/project.py
@@ -197,10 +197,12 @@ def get_similar_projects(url_slug:str,return_count=5):
 
     #calculate similarity score based on the above calculated features 
     
-    #join the dataframes from above on url_slug index
+    #join the dataframes from above on url_slug index and drop the source project
     df = pd.concat([df[['is_same_parent','is_same_city','is_same_language','is_same_country']]
                      ,skills_df[['skills_match']]
                      ,tags_df[['tags_match']]],axis=1)
+    
+    df = df.drop(url_slug)
     # weights given to each factor. Increase the integer value to strenghten the weight of a particular factor
     weights_mapping = {
     'is_same_parent':3,

--- a/backend/organization/utility/project.py
+++ b/backend/organization/utility/project.py
@@ -10,6 +10,9 @@ from location.utility import get_location
 from organization.models import Project
 from organization.models.tags import ProjectTags
 
+import pandas as pd
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -72,6 +75,7 @@ def get_project_helpful_connections(project: Project, language_code: str) -> str
 
 
 def get_project_name(project: Project, language_code: str) -> str:
+    print(project)
     if project.language and language_code != project.language.language_code and \
             project.translation_project.filter(language__language_code=language_code).exists():
         return project.translation_project.get(
@@ -127,3 +131,94 @@ def get_project_translations(data: Dict):
         )
     except ValueError:
         raise ValueError
+    
+    
+    
+def get_similar_projects(url_slug:str,return_count=5):
+    """Returns a list of similar projects to the given project input
+    Arguments:
+    url_slug (str): url_slug of the source project for which similar projects will returned
+    return_count (int) : Maximum number of similar projects to return. Defaults to 5
+    
+    Returns:
+        List of similar projects url_slug
+    
+    """
+    def sets_match(source_set:set,target_set:set):
+        """returns the % of matching elements from the source set to the target set.
+            eg: source:  {1,2,3,4} / target : {3,4,5,6} ==> output : 0.5 (50%)
+                source: {3,4} / target : {3,4,5,6} ==> output : 1 (100%)
+        
+        """
+        source_set_count = len(source_set)
+        if source_set_count == 0: return 0
+        matching_elements = 0
+        for source_set_element in source_set:
+            if source_set_element in target_set:
+                matching_elements += 1
+                
+        return matching_elements/source_set_count
+        
+    target_projects = Project.objects.filter(is_active=True).values('url_slug','country','city','project_parent__id','tag_project','skills','language') #project_parent__id 'tag_project' 'skills'
+
+    df = pd.DataFrame.from_dict(target_projects)
+
+    #calcaulte skills match %
+    #since skills are 1 to Many to projects, we need to group the skills in a list
+    skills_df = df.groupby(['url_slug']).agg({'skills':set})
+    source_skills =  skills_df.loc[url_slug][0]
+    skills_df['source_skills'] = [source_skills for i in range(0,len(skills_df))]
+    skills_df['skills_match'] = skills_df.apply(lambda x:sets_match(x['source_skills'],x['skills']),axis=1)
+    
+    #calcualte tags match %
+    #since tags are 1 to Many to projects, we need to group the tags in a list
+    tags_df = df.groupby(['url_slug']).agg({'tag_project':set})
+    source_tags =  tags_df.loc[url_slug][0]
+    tags_df['source_tag_project'] = [source_tags for i in range(0,len(tags_df))]
+    tags_df['tags_match'] = tags_df.apply(lambda x:sets_match(x['source_tag_project'],x['tag_project']),axis=1)
+    
+    #calculate parent/country/city/language similarity. It is a binary evaluation where 1 means a match and 0 no match
+    source_proj_country = df.loc[df.url_slug==url_slug].country.iloc[0]
+    source_proj_city = df.loc[df.url_slug==url_slug].city.iloc[0]
+    source_proj_language = df.loc[df.url_slug==url_slug].language.iloc[0]
+    source_proj_parent_id = df.loc[df.url_slug==url_slug].project_parent__id.iloc[0]
+
+
+    df = df.drop(['skills','tag_project'],axis=1).drop_duplicates().set_index('url_slug')
+    
+
+
+    df['is_same_parent'] = df.project_parent__id.apply(lambda x:1 if x==source_proj_parent_id else 0)
+    df['is_same_city'] = df.apply(lambda x:1 if x['city']==source_proj_city and  x['country']==source_proj_country else 0,axis=1)
+    df['is_same_language'] = df.language.apply(lambda x:1 if x==source_proj_language else 0)
+    df['is_same_country'] = df.country.apply(lambda x:1 if x==source_proj_country else 0)
+    
+
+
+    #calculate similarity score based on the above calculated features 
+    
+    #join the dataframes from above on url_slug index
+    df = pd.concat([df[['is_same_parent','is_same_city','is_same_language','is_same_country']]
+                     ,skills_df[['skills_match']]
+                     ,tags_df[['tags_match']]],axis=1)
+    # weights given to each factor. Increase the integer value to strenghten the weight of a particular factor
+    weights_mapping = {
+    'is_same_parent':3,
+    'is_same_city':2,
+    'is_same_language':2,
+    'is_same_country':1,
+    'skills_match':3,
+    'tags_match':3
+    }
+    total_weights = sum(weights_mapping.values())
+    factors = weights_mapping.keys()
+
+    for factor in factors:
+        df[factor] = df[factor] * weights_mapping[factor]
+      
+    #calulate the similarity score  
+    df['similarity_score'] = df.apply(lambda x:sum(x)/total_weights,axis=1,raw=True)
+    
+
+    return df.sort_values(by=['similarity_score'],ascending=False).head(5).index.values
+    

--- a/backend/organization/utility/project.py
+++ b/backend/organization/utility/project.py
@@ -75,7 +75,6 @@ def get_project_helpful_connections(project: Project, language_code: str) -> str
 
 
 def get_project_name(project: Project, language_code: str) -> str:
-    print(project)
     if project.language and language_code != project.language.language_code and \
             project.translation_project.filter(language__language_code=language_code).exists():
         return project.translation_project.get(

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -57,7 +57,8 @@ from organization.utility.notification import (
     get_mentions)
 from organization.utility.organization import check_organization
 from organization.utility.project import (create_new_project,
-                                          get_project_translations)
+                                          get_project_translations,
+                                          get_similar_projects)
 from rest_framework import status
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.filters import SearchFilter
@@ -950,3 +951,13 @@ class SetProjectSharedView(APIView):
             raise NotFound(detail='Project not found.', code=status.HTTP_404_NOT_FOUND)
         save_content_shared(request, project)
         return Response(status=status.HTTP_201_CREATED)
+    
+    
+    
+    
+class SimilarProjects(ListAPIView):
+    permission_classes = [AllowAny]
+    serializer_class = ProjectStubSerializer    
+    def get_queryset(self):
+        similar_projects_url_slugs = get_similar_projects(url_slug=self.kwargs['url_slug'])
+        return Project.objects.filter(url_slug__in=similar_projects_url_slugs)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -81,3 +81,4 @@ watchgod==0.6
 wcwidth==0.2.5
 websockets==9.1
 zope.interface==5.1.0
+pandas==1.4.1


### PR DESCRIPTION
## Description

Aims to add the feature related to [https://github.com/climateconnect/climateconnect/issues/510]

This backend endpoint will return a list of project that are similar to a given project. When frontend sends the url_slug of the visited project, 5 (or another limit) similar projects will be returned so that they can be consumed by the frontend. 

**Endpoint** : `GET`  `projects/<str:url_slug>/similar/` 
No auth is required 

**Returns**: an iterable of projects. Returns the same type/attributes of List Project endpoint


Calculation method: 
1. get all projects stored in a pandas dataframe with the required attribute (city, language, country, parent project, skills, tags)
2. Calculate the matching scores (0to100%) for each of these attributes:

> for city, country and parent project : Binary match 0 if not matching and 100% if matching

> for skills, tags: 0% of none of the source project skills exist in the other project skills, 100% if the all the skills of the source project are contained in the target project 

3. Using weighting schema, calculate the similarity score. The formula is as simple as : 
`score = (weight_factor_1 * score_factor_1 + ... ) / total_weight_sum` 
The output is between 0 and 1. 

The current weights are:
`
    weights_mapping = {
    'is_same_parent':3,
    'is_same_city':2,
    'is_same_language':2,
    'is_same_country':1,
    'skills_match':3,
    'tags_match':3
    }
`

4. return the top 5 projects sorted by the similarity score




## Test plan
No test plans were made yet.

