### PR TITLE
fix/added new slug generation to profile, organization and project

### DIFF
--- a/backend/climateconnect_api/views/user_views.py
+++ b/backend/climateconnect_api/views/user_views.py
@@ -27,6 +27,7 @@ from django.contrib.gis.db.models.functions import Distance
 from django.db.models import Count, Q
 from django.utils import timezone
 from django.utils.translation import gettext as _
+from django.utils.text import slugify
 
 from django_filters.rest_framework import DjangoFilterBackend
 from knox.views import LoginView as KnoxLoginView
@@ -98,7 +99,7 @@ class SignUpView(APIView):
         user.set_password(request.data['password'])
         user.save()
 
-        url_slug = (user.first_name + user.last_name).lower() + str(user.id)
+        url_slug = slugify(user.first_name + '-' + user.last_name + str(user.id)) 
         # Get location
         source_language = Language.objects.get(language_code=request.data['source_language'])
         user_profile = UserProfile.objects.create(

--- a/backend/ideas/utility/idea.py
+++ b/backend/ideas/utility/idea.py
@@ -36,7 +36,7 @@ def create_idea(data: dict, language: Optional[Language], creator: User) -> Idea
     
     url_slug = slugify(data['name'])
     if len(url_slug) == 0:
-        url_slug = idea.id
+        url_slug = str(idea.id)
     ideas_with_same_url_slug = Idea.objects.filter(url_slug=url_slug)
     if ideas_with_same_url_slug.exists():
         url_slug = url_slug + str(idea.id)

--- a/backend/organization/utility/project.py
+++ b/backend/organization/utility/project.py
@@ -6,6 +6,7 @@ from climateconnect_api.models.language import Language
 from climateconnect_api.utility.translation import get_translations
 from climateconnect_main.utility.general import get_image_from_data_url
 from location.utility import get_location
+from django.utils.text import slugify
 
 from organization.models import Project
 from organization.models.tags import ProjectTags
@@ -46,7 +47,14 @@ def create_new_project(data: Dict, source_language: Language) -> Project:
     if 'website' in data:
         project.website = data['website']
     project.language = source_language
-    project.url_slug = project.name.replace(" ", "") + str(project.id)
+
+    url_slug = slugify(data['name'])
+    if len(url_slug) == 0:
+        url_slug = str(project.id)
+    projects_with_same_url_slug = Project.objects.filter(url_slug=url_slug)
+    if projects_with_same_url_slug.exists():
+        url_slug = url_slug + str(project.id)
+    project.url_slug = url_slug
 
     if 'skills' in data:
         for skill_id in data['skills']:

--- a/backend/organization/views/organization_views.py
+++ b/backend/organization/views/organization_views.py
@@ -15,6 +15,7 @@ from django.contrib.auth.models import User
 from django.contrib.gis.db.models.functions import Distance
 from django.db.models import Q
 from django.utils.translation import gettext as _
+from django.utils.text import slugify
 from django_filters.rest_framework import DjangoFilterBackend
 from hubs.models.hub import Hub
 from location.models import Location
@@ -175,7 +176,13 @@ class CreateOrganizationView(APIView):
         organization, created = Organization.objects.get_or_create(name=request.data['name'])
 
         if created:
-            organization.url_slug = organization.name.replace(" ", "") + str(organization.id)
+            url_slug = slugify(organization.name)
+            if len(url_slug) == 0:
+                url_slug = str(organization.id)
+            orgas_with_same_url_slug = Organization.objects.filter(url_slug=url_slug)
+            if orgas_with_same_url_slug.exists():
+                url_slug = url_slug + str(organization.id)
+            organization.url_slug = url_slug
             # Add primary language to organization table. 
             source_language = Language.objects.get(language_code=request.data['source_language'])
             organization.language = source_language


### PR DESCRIPTION
## Description

A new slug generation was added to Profile, Organization and Project generation. It's similar to the slug generation in idea. Its implemented straight forward, but also could probably be generalized.  
<!-- Aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. -->
#454
<!-- _Include summary of the change and list any required dependencies or downstream impact._ -->

## Test plan
needs to be tested manually because of the simple implementation
<!-- _Include relevant test configuration details for the reviewer(s), and steps to test and verify new feature._ -->

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
![Screenshot from 2022-03-23 12-49-52](https://user-images.githubusercontent.com/56408063/159694564-8aefc48e-954f-4ad5-923c-1398ccdd6361.png)
![Screenshot from 2022-03-23 12-53-45](https://user-images.githubusercontent.com/56408063/159694565-931ba496-c525-46bc-b739-096209cdb56b.png)

