### PR TITLE
fix: update lint GitHub action to run lint across frontend code

### DIFF
--- a/.github/workflows/pull_request-lint-frontend.yml
+++ b/.github/workflows/pull_request-lint-frontend.yml
@@ -1,24 +1,24 @@
 name: Lint frontend
 on: [pull_request]
-workflow_dispatch:
-  jobs:
-    run-linters:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v2
 
-        - name: Check out Git repository
-          uses: actions/setup-node@v1
-          with:
-            node-version: 12
-        - name: Set up Node.js
+jobs:
+  run-linters:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
-        # ESLint and Prettier must be in `package.json`
-        - name: Install Node.js dependencies
-          run: yarn
+      - name: Check out Git repository
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Set up Node.js
 
-        - name: Lint frontend
-          uses: yarn lint
-          with:
-            eslint: true
-            prettier: true
+      # ESLint and Prettier must be in `package.json`
+      - name: Install Node.js dependencies
+        run: yarn
+
+      - name: Lint frontend
+        uses: yarn lint
+        with:
+          eslint: true
+          prettier: true

--- a/.github/workflows/pull_request-lint-frontend.yml
+++ b/.github/workflows/pull_request-lint-frontend.yml
@@ -2,11 +2,10 @@ name: Lint frontend
 on: [pull_request]
 
 jobs:
-  run-linters:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
       - name: Check out Git repository
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
## What and Why

Noticed that this check wasn't running. Looking at the only running flake8 check: 

<img width="939" alt="Screen Shot 2022-04-01 at 1 58 44 PM" src="https://user-images.githubusercontent.com/1530684/161340437-bc1f8eba-fadd-4f7e-8a5c-e66080e42c91.png">

to see if we have some formatting issue or something else going on.