### PR TITLE
add climatehub page (1st iteration)

### DIFF
--- a/frontend/pages/climatehubs.js
+++ b/frontend/pages/climatehubs.js
@@ -1,0 +1,23 @@
+//This is a page where just part of the content comes from the codebase.
+//The other part comes from webflow pages that our design team built
+//The skeleton for this page was built using this tutorial: https://dev.to/kennedyrose/integrating-webflow-and-next-js-39kk
+
+import React from "react";
+import WebflowPage from "../src/components/webflow/WebflowPage";
+import { retrievePage } from "../src/utils/webflow";
+
+//Explainer page for what a ClimateHub is and how we plan to spread them throughout Germany
+export default function ClimateHubs({ bodyContent, headContent }) {
+  return <WebflowPage bodyContent={bodyContent} headContent={headContent} pageKey="climatehubs" hideFooter />;
+}
+
+export async function getServerSideProps(ctx) {
+  const WEBFLOW_URLS = {
+    de: "https://climateconnect.webflow.io",
+    en: "https://climateconnect.webflow.io",
+  };
+  const props = await retrievePage(WEBFLOW_URLS[ctx.locale]);
+  return {
+    props: props,
+  };
+}

--- a/frontend/src/components/indexPage/hubsSubHeader/HubLinks.js
+++ b/frontend/src/components/indexPage/hubsSubHeader/HubLinks.js
@@ -103,6 +103,7 @@ export default function HubLinks({
           open={open["climateHubs"]}
           onOpen={(e) => handleOpen(e, "climateHubs")}
           onClose={() => handleClose("climateHubs")}
+          addLocationHubExplainerLink
         />
       )}
     </div>

--- a/frontend/src/components/indexPage/hubsSubHeader/HubsDropDown.js
+++ b/frontend/src/components/indexPage/hubsSubHeader/HubsDropDown.js
@@ -1,6 +1,9 @@
 import { Button, makeStyles } from "@material-ui/core";
+import { Textsms } from "@material-ui/icons";
 import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
-import React, { useRef } from "react";
+import React, { useContext, useRef } from "react";
+import getTexts from "../../../../public/texts/texts";
+import UserContext from "../../context/UserContext";
 import DropDownList from "../../header/DropDownList";
 
 const useStyles = makeStyles((theme) => ({
@@ -14,6 +17,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+//Generic component to show a list of hubs in the HubsSubHeader
 export default function HubsDropDown({
   open,
   hubs,
@@ -22,10 +26,13 @@ export default function HubsDropDown({
   onToggleOpen,
   onOpen,
   onClose,
+  addLocationHubExplainerLink,
 }) {
   const classes = useStyles();
   const buttonRef = useRef(null);
   const popperRef = useRef(null);
+  const { locale } = useContext(UserContext)
+  const texts = getTexts({page: "hub", locale: locale})
 
   const toggleButtonProps = {};
   if (!isNarrowScreen) {
@@ -38,6 +45,19 @@ export default function HubsDropDown({
       onClose();
     }
   };
+
+  const dropDownHubItems = hubs.map((h) => ({
+    href: `/hubs/${h.url_slug}/`,
+    text: h.name,
+  }))
+
+  const dropDownItems = [
+    ...dropDownHubItems,
+    addLocationHubExplainerLink && {
+      href: `/climatehubs`,
+      text: texts.more_info
+    }
+  ]
 
   return (
     <span onBlur={handleBlur} id={`dropdown-${label.toLowerCase()}`}>
@@ -54,10 +74,7 @@ export default function HubsDropDown({
       <DropDownList
         buttonRef={buttonRef}
         handleOpen={onOpen}
-        items={hubs.map((h) => ({
-          href: `/hubs/${h.url_slug}/`,
-          text: h.name,
-        }))}
+        items={dropDownItems}
         handleClose={onClose}
         open={open}
         popperRef={popperRef}

--- a/frontend/src/components/layouts/WideLayout.js
+++ b/frontend/src/components/layouts/WideLayout.js
@@ -35,6 +35,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+//Wrapper layout component for pages where the content takes the whole width of the screen
 export default function WideLayout({
   children,
   title,
@@ -55,6 +56,7 @@ export default function WideLayout({
   image,
   useFloodStdFont,
   rootClassName,
+  hideFooter
 }) {
   const classes = useStyles({ noSpaceBottom: noSpaceBottom, isStaticPage: isStaticPage });
   const [alertOpen, setAlertOpen] = React.useState(true);
@@ -129,12 +131,14 @@ export default function WideLayout({
           {children}
         </Container>
       )}
-      <Footer
-        noSpacingTop={noSpaceBottom}
-        noAbsolutePosition={noSpaceBottom}
-        showOnScrollUp={showOnScrollUp}
-        large={isStaticPage || largeFooter}
-      />
+      {!hideFooter &&
+        <Footer
+          noSpacingTop={noSpaceBottom}
+          noAbsolutePosition={noSpaceBottom}
+          showOnScrollUp={showOnScrollUp}
+          large={isStaticPage || largeFooter}
+        />
+      }
     </LayoutWrapper>
   );
 }

--- a/frontend/src/components/webflow/WebflowPage.js
+++ b/frontend/src/components/webflow/WebflowPage.js
@@ -5,7 +5,7 @@ import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
 import WideLayout from "../layouts/WideLayout";
 
-export default function WebflowPage({ bodyContent, headContent, pageKey, className }) {
+export default function WebflowPage({ bodyContent, headContent, pageKey, className, hideFooter }) {
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "navigation", locale: locale });
   return (
@@ -17,6 +17,7 @@ export default function WebflowPage({ bodyContent, headContent, pageKey, classNa
         isStaticPage
         hideHeadline
         noSpaceBottom
+        hideFooter={hideFooter}
       >
         <div dangerouslySetInnerHTML={{ __html: bodyContent }} />
       </WideLayout>


### PR DESCRIPTION
## Description

The https://www.climatehub.earth/ can now also be accessed through climateconnect.earth so that we can use our Google Ad Grants to advertise it. To make it easier to find I'll also add it to the static pages and rework the navigation there as it's starting to get too confusing with so many static pages