### PR TITLE
feat(account):make summary input mandatory

### DIFF
--- a/frontend/public/data/organization_info_metadata.js
+++ b/frontend/public/data/organization_info_metadata.js
@@ -17,6 +17,7 @@ export default function getOrganizationInfoMetadata(locale, organization) {
       type: "bio",
       weight: 1,
       helptext: texts.how_to_summarize_organization,
+      required: true,
     },
     location: {
       icon: PlaceIcon,

--- a/frontend/src/components/account/EditAccountPage.js
+++ b/frontend/src/components/account/EditAccountPage.js
@@ -606,7 +606,7 @@ export default function EditAccountPage({
                 </Tooltip>
               )}
             </Typography>
-            <TextField fullWidth value={i.value} multiline onChange={handleChange} />
+            <TextField required={i.required} fullWidth value={i.value} multiline onChange={handleChange} />
           </div>
         );
       }


### PR DESCRIPTION
replace accidentally closed: #927 

1. added organisation info meta data required: true
2. EditAccountPage component Textfield for Bio and Text required depends on meta data



testing plan from @positiveimpact 
1. go to the /createorganization page
2. Try to create an organization without a summary
4. You should get a native error saying that you need to fill out this field