### PR TITLE
Added gunicorn initialization before start celery server

### DIFF
--- a/start_celery.sh
+++ b/start_celery.sh
@@ -10,4 +10,4 @@ cd backend
 pip install -r requirements.txt
 
 # starting celery worker
-celery -A climateconnect_main worker -l INFO
+gunicorn --bind=0.0.0.0 climateconnect_main.asgi:application & celery -A climateconnect_main worker -l INFO


### PR DESCRIPTION
## Description

Attempting to fix celery server


## Test plan
I will be testing this in production environment. 

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
