### PR TITLE
fix organization edit button blocking organization description

### DIFF
--- a/frontend/src/components/account/AccountPage.js
+++ b/frontend/src/components/account/AccountPage.js
@@ -61,11 +61,11 @@ const useStyles = makeStyles((theme) => ({
   accountInfo: (props) => ({
     padding: 0,
     marginTop: theme.spacing(1),
-    [theme.breakpoints.up("sm")]: {
-      paddingRight: theme.spacing(15),
-    },
-    marginRight: props.isOwnAccount ? theme.spacing(10) : 0,
+    marginRight: props.isOwnAccount ? theme.spacing(0.5) : 0,
   }),
+  editButtonWrapper: {
+    flex: "1 0 auto",
+  },
   name: {
     fontWeight: "bold",
     padding: theme.spacing(1),
@@ -90,6 +90,7 @@ const useStyles = makeStyles((theme) => ({
   infoContainer: {
     [theme.breakpoints.up("sm")]: {
       display: "flex",
+      alignItems: "center",
     },
     position: "relative",
   },
@@ -118,11 +119,6 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: "50%",
     padding: "5px",
     left: "0",
-  },
-  desktopButton: {
-    marginTop: theme.spacing(2),
-    right: theme.spacing(2),
-    position: "absolute",
   },
   infoIcon: {
     marginBottom: -4,
@@ -341,17 +337,6 @@ export default function AccountPage({
         </div>
       </div>
       <Container className={classes.infoContainer}>
-        {isOwnAccount && !isSmallScreen && (
-          <Button
-            variant="contained"
-            color="primary"
-            className={classes.desktopButton}
-            href={editHref}
-          >
-            <EditSharpIcon className={classes.innerIcon} />
-            {editText ? editText : texts.edit_profile}
-          </Button>
-        )}
         <Container className={classes.avatarWithInfo}>
           <div className={classes.avatarContainer}>
             {account.badges?.length > 0 ? (
@@ -387,6 +372,14 @@ export default function AccountPage({
           )}
         </Container>
         <Container className={classes.accountInfo}>{displayAccountInfo(account.info)}</Container>
+        {isOwnAccount && !isSmallScreen && (
+          <div className={classes.editButtonWrapper}>
+            <Button variant="contained" color="primary" href={editHref}>
+              <EditSharpIcon className={classes.innerIcon} />
+              {editText ? editText : texts.edit_profile}
+            </Button>
+          </div>
+        )}
       </Container>
       <Divider className={classes.marginTop} />
       {detailledDescription?.value && (


### PR DESCRIPTION
## Description

removes absolute positioning of button so that text will not overlap it

fixes #931

to test the fix:

1. create an organization with a long description
2. log in as a user who is an owner of that organization
3. navigate to the organization page

before (description is covered by edit button):

<img width="1171" alt="Screen Shot 2022-06-21 at 8 58 28 PM" src="https://user-images.githubusercontent.com/294695/174940624-10518e25-b8a0-4a0f-97b4-d4237b327c1b.png">

after:

<img width="1182" alt="Screen Shot 2022-06-19 at 10 02 42 PM" src="https://user-images.githubusercontent.com/294695/174940668-418e7f8c-9656-4e8e-9c6e-b84e9e735eeb.png">
