### PR TITLE
Fix: Group chat and icon size decreased to match private chat size

### DIFF
--- a/frontend/src/components/communication/chat/ChatPreviews.js
+++ b/frontend/src/components/communication/chat/ChatPreviews.js
@@ -8,6 +8,7 @@ import {
   useMediaQuery,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
+import { hasBasePath } from "next/dist/server/router";
 import PropTypes from "prop-types";
 import React, { useContext } from "react";
 import InfiniteScroll from "react-infinite-scroller";
@@ -125,7 +126,7 @@ const ChatPreview = ({ chat, isNarrowScreen, isFirstChat, locale }) => {
           className={classes.listItem}
         >
           {chat.name ? (
-            <ChatTitle chat={chat} className={classes.miniProfilePreview} mobile={isNarrowScreen} />
+            <ChatTitle chat={chat} className={classes.miniProfilePreview} mobile={isNarrowScreen} size="medium"/>
           ) : (
             <MiniProfilePreview
               className={classes.miniProfilePreview}

--- a/frontend/src/components/communication/chat/ChatPreviews.js
+++ b/frontend/src/components/communication/chat/ChatPreviews.js
@@ -8,7 +8,6 @@ import {
   useMediaQuery,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import { hasBasePath } from "next/dist/server/router";
 import PropTypes from "prop-types";
 import React, { useContext } from "react";
 import InfiniteScroll from "react-infinite-scroller";
@@ -126,7 +125,12 @@ const ChatPreview = ({ chat, isNarrowScreen, isFirstChat, locale }) => {
           className={classes.listItem}
         >
           {chat.name ? (
-            <ChatTitle chat={chat} className={classes.miniProfilePreview} mobile={isNarrowScreen} size="medium"/>
+            <ChatTitle
+              chat={chat}
+              className={classes.miniProfilePreview}
+              mobile={isNarrowScreen}
+              size="medium"
+            />
           ) : (
             <MiniProfilePreview
               className={classes.miniProfilePreview}

--- a/frontend/src/components/communication/chat/ChatTitle.js
+++ b/frontend/src/components/communication/chat/ChatTitle.js
@@ -3,7 +3,6 @@ import { Avatar, Typography } from "@material-ui/core";
 import GroupIcon from "@material-ui/icons/Group";
 import { makeStyles } from "@material-ui/core/styles";
 
-
 const useStyles = makeStyles((theme) => {
   return {
     avatarWrapper: {
@@ -15,7 +14,6 @@ const useStyles = makeStyles((theme) => {
       verticalAlign: "middle",
       marginLeft: theme.spacing(1),
       whiteSpace: "nowrap",
-     
     },
     mediumProfileName: {
       fontSize: 16,
@@ -28,18 +26,21 @@ const useStyles = makeStyles((theme) => {
   };
 });
 
-export default function ChatTitle({ chat, className, size}) {
+export default function ChatTitle({ chat, className, size }) {
   const classes = useStyles();
- 
+
   return (
-    
     <div className={className}>
       <div className={classes.avatarWrapper}>
         <Avatar className={`${size == "medium" && classes.mediumAvatar}`}>
           <GroupIcon />
         </Avatar>
       </div>
-      <Typography color="inherit" className={`${classes.profileName} ${size === "medium" && classes.mediumProfileName}`} variant="h6">
+      <Typography
+        color="inherit"
+        className={`${classes.profileName} ${size === "medium" && classes.mediumProfileName}`}
+        variant="h6"
+      >
         {chat.name}
       </Typography>
     </div>

--- a/frontend/src/components/communication/chat/ChatTitle.js
+++ b/frontend/src/components/communication/chat/ChatTitle.js
@@ -3,6 +3,7 @@ import { Avatar, Typography } from "@material-ui/core";
 import GroupIcon from "@material-ui/icons/Group";
 import { makeStyles } from "@material-ui/core/styles";
 
+
 const useStyles = makeStyles((theme) => {
   return {
     avatarWrapper: {
@@ -14,20 +15,31 @@ const useStyles = makeStyles((theme) => {
       verticalAlign: "middle",
       marginLeft: theme.spacing(1),
       whiteSpace: "nowrap",
+     
+    },
+    mediumProfileName: {
+      fontSize: 16,
+    },
+
+    mediumAvatar: {
+      height: 30,
+      width: 30,
     },
   };
 });
 
-export default function ChatTitle({ chat, className }) {
+export default function ChatTitle({ chat, className, size}) {
   const classes = useStyles();
+ 
   return (
+    
     <div className={className}>
       <div className={classes.avatarWrapper}>
-        <Avatar>
+        <Avatar className={`${size == "medium" && classes.mediumAvatar}`}>
           <GroupIcon />
         </Avatar>
       </div>
-      <Typography color="inherit" className={classes.profileName} variant="h6">
+      <Typography color="inherit" className={`${classes.profileName} ${size === "medium" && classes.mediumProfileName}`} variant="h6">
         {chat.name}
       </Typography>
     </div>


### PR DESCRIPTION
## Description

Closes issue #904 

The size of the group chat icon and name did not match the size of private chat icon and name in your inbox.

Changes made in ChatPreviews.js and ChatTitle.js
- prop "size" added to make the adjustments to the size of the icon and the font

'yarn format' and 'make format' still need to be performed.

## Test plan

You can check your inbox https://climateconnect.earth/inbox when it has at least 1 private chat and 1 group chat in it to see the size of the icons and names.

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
