### PR TITLE
add border and update box shadow color for hub preview cards

### DIFF
--- a/frontend/src/components/hub/HubPreview.js
+++ b/frontend/src/components/hub/HubPreview.js
@@ -7,8 +7,8 @@ import UserContext from "../context/UserContext";
 
 const useStyles = makeStyles((theme) => ({
   root: (props) => ({
-    boxShadow: props.disableBoxShadow ? 0 : `3px 3px 3px #f8f8f8`,
-    border: 0,
+    boxShadow: props.disableBoxShadow ? 0 : `3px 3px 3px #e0e0e0`,
+    borderColor: "#e0e0e0",
   }),
   placeholderImg: {
     visibility: "hidden",


### PR DESCRIPTION
fixes #489

Before:

<img width="794" alt="Screen Shot 2022-07-09 at 10 06 59 PM" src="https://user-images.githubusercontent.com/294695/178132155-cd307ee8-0fb1-47bc-88c2-53228436cb40.png">

After:

<img width="691" alt="Screen Shot 2022-07-09 at 10 05 56 PM" src="https://user-images.githubusercontent.com/294695/178132159-8301f954-69eb-448a-9f84-eef3de06048c.png">
