### PR TITLE
Fix: Added/modified some more chats in chats_texts.json

### DIFF
--- a/frontend/public/texts/chat_texts.json
+++ b/frontend/public/texts/chat_texts.json
@@ -165,6 +165,6 @@
   },
   "type_the_name_of_a_user_or_group_to_open_a_chat_with": {
     "en": "Type the name of a user or group you want to open",
-    "de": "Gib den Namen des Benutzers oder der Gruppe, die du kontaktieren möchtest"
+    "de": "Gib den Namen des Benutzers oder der Gruppe ein, die du kontaktieren möchtest"
   }
 }

--- a/frontend/public/texts/chat_texts.json
+++ b/frontend/public/texts/chat_texts.json
@@ -48,8 +48,12 @@
     "de": "Weitere Chat-Teilnehmer*innen hinzufügen"
   },
   "type_the_name_of_the_users_you_want_to_message": {
-    "en": "Type the name of the user(s) you want to message.",
+    "en": "Type the name of the user(s) you want to message",
     "de": "Gib den Namen der Benutzer*innen ein, die du konktaktieren möchtest"
+  },
+  "group_chat_creation_possible": {
+    "en": "Search for multiple users to create a group",
+    "de": "Gib den Namen meherer Benutzer*innen, um eine Gruppe zu erstellen"
   },
   "group_chat_name": {
     "en": "Group chat name",
@@ -85,7 +89,7 @@
   },
   "leave_group_chat": {
     "en": "Leave group chat",
-    "de": "Verwalten"
+    "de": "Chat verlassen"
   },
   "manage_chat_members": {
     "en": "Manage chat members",
@@ -146,5 +150,21 @@
   "everybody_who_clicked_join_is_in_this_group": {
     "en": "Everybody who clicked the \"join\" button on the idea's page is in this chat group",
     "de": "Alle, die auf den \"Mitmachen\" Knopf auf der Ideenseite geklickt haben, sind in diesem Gruppenchat"
+  },
+  "find_a_chat": {
+    "en": "Find a chat",
+    "de": "Chat Suchen"
+  },
+  "open_chat_from_search": {
+    "en": "Open Chat",
+    "de": "Chat Öffnen"
+  },
+  "enter_chat_name_to_open": {
+    "en": "Enter the chat name you want to open...",
+    "de": "Name vom Chat, den du öffnen möchtest..."
+  },
+  "type_the_name_of_a_user_or_group_to_open_a_chat_with": {
+    "en": "Type the name of a user or group you want to open",
+    "de": "Gib den Namen des Benutzers oder der Gruppe, die du kontaktieren möchtest"
   }
 }

--- a/frontend/public/texts/chat_texts.json
+++ b/frontend/public/texts/chat_texts.json
@@ -53,7 +53,7 @@
   },
   "group_chat_creation_possible": {
     "en": "Search for multiple users to create a group",
-    "de": "Gib den Namen meherer Benutzer*innen, um eine Gruppe zu erstellen"
+    "de": "Wähle mehrere Benutzer*innen aus, um eine Gruppe zu erstellen"
   },
   "group_chat_name": {
     "en": "Group chat name",

--- a/frontend/public/texts/chat_texts.json
+++ b/frontend/public/texts/chat_texts.json
@@ -161,7 +161,7 @@
   },
   "enter_chat_name_to_open": {
     "en": "Enter the chat name you want to open...",
-    "de": "Name vom Chat, den du öffnen möchtest..."
+    "de": "Name des Chat, den du öffnen möchtest..."
   },
   "type_the_name_of_a_user_or_group_to_open_a_chat_with": {
     "en": "Type the name of a user or group you want to open",


### PR DESCRIPTION
## Description

In the German version of the website, when viewing a group chat, the leave chat button hover text read "Verwalten" and now is changed to "Verlassen". 

Additionally some extra chats were added for future buttons.
- "group_chat_creation_possible"
- "find_a_chat"
- "open_chat_from_search"
- "enter_chat_name_to_open"
- "type_the_name_of_a_user_or_group_to_open_a_chat_with"

## Test plan

- Sign in
- Create a group chat
- Open the group chat
- Hover your cursor over the leave icon

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
