### PR TITLE
Fix: Inbox alert only opened once

### DIFF
--- a/frontend/pages/inbox.js
+++ b/frontend/pages/inbox.js
@@ -96,6 +96,10 @@ export default function Inbox({ chatData, next }) {
     next: next,
   });
 
+  const resetErrorMessage = (e) => {
+    setErrorMessage(e);
+  };
+
   const handleGroupNameChange = (e) => {
     setGroupName(e.target.value);
   };
@@ -119,6 +123,7 @@ export default function Inbox({ chatData, next }) {
     if (newChatMembers.length >= 1) {
       const payload = {};
       if (isGroupchat) {
+        //The if statement (line 127) is never entered due to TextField having a the required property set (line 216)
         if (!groupName) {
           setErrorMessage(
             texts.please_set_a_group_name_if_youre_starting_a_chat_with_more_than_one_member
@@ -179,7 +184,12 @@ export default function Inbox({ chatData, next }) {
 
   return (
     <div>
-      <WideLayout title={texts.inbox} messageType="error" message={errorMessage}>
+      <WideLayout
+        title={texts.inbox}
+        messageType="error"
+        message={errorMessage}
+        resetAlertMessage={resetErrorMessage}
+      >
         <Container maxWidth="md" className={classes.root}>
           <Typography component="h1" variant="h4" className={classes.headline}>
             {texts.inbox}

--- a/frontend/pages/inbox.js
+++ b/frontend/pages/inbox.js
@@ -96,7 +96,7 @@ export default function Inbox({ chatData, next }) {
     next: next,
   });
 
-  const resetErrorMessage = (e) => {
+  const updateErrorMessage = (e) => {
     setErrorMessage(e);
   };
 

--- a/frontend/pages/inbox.js
+++ b/frontend/pages/inbox.js
@@ -188,7 +188,7 @@ export default function Inbox({ chatData, next }) {
         title={texts.inbox}
         messageType="error"
         message={errorMessage}
-        resetAlertMessage={resetErrorMessage}
+        resetAlertMessage={updateErrorMessage}
       >
         <Container maxWidth="md" className={classes.root}>
           <Typography component="h1" variant="h4" className={classes.headline}>

--- a/frontend/public/texts/chat_texts.json
+++ b/frontend/public/texts/chat_texts.json
@@ -36,8 +36,8 @@
     "de": "Bitte lege einen Gruppennamen fest, wenn du einen Chat mit mehr als einem Mitglied startest"
   },
   "please_add_one_or_more_users_to_chat_to_by_searching_them_in_the_search_bar_above": {
-    "en": "Please add one or more users to chat to by searching them in the search bar above",
-    "de": "Bitte füge einen oder mehrere Benutzer*innen zum Chatten hinzu, indem du sie in der Suchleiste oben suchst"
+    "en": "Please add one or more users to chat to by searching for them in the search bar below",
+    "de": "Bitte füge einen oder mehrere Benutzer*innen zum Chatten hinzu, indem du sie in der Suchleiste unten suchst"
   },
   "search_user_to_message": {
     "en": "Search user to message",

--- a/frontend/src/components/layouts/WideLayout.js
+++ b/frontend/src/components/layouts/WideLayout.js
@@ -57,6 +57,7 @@ export default function WideLayout({
   useFloodStdFont,
   rootClassName,
   hideFooter,
+  resetAlertMessage,
 }) {
   const classes = useStyles({ noSpaceBottom: noSpaceBottom, isStaticPage: isStaticPage });
   const [alertOpen, setAlertOpen] = React.useState(true);
@@ -117,6 +118,7 @@ export default function WideLayout({
               }}
               onClose={() => {
                 setAlertOpen(false);
+                resetAlertMessage("");
               }}
             >
               {getMessageFromUrl(message ? message : initialMessage)}


### PR DESCRIPTION
## Description

When clicking the button "Start Chat" while the searchbar is empty, an alert would appear, indicating the user needs to search for another user to message. Closing the alert and repeating the same step does not open the alert again.

The wording for the alert was also changed in both English and German.

Potential conflict could occur with ["frontend/pages/editprofile.js"] as it also contains a component which uses the WideLayout component which was slightly modified.

## Test plan

- Sign in 
- Navigate to inbox
- Press the "New Chat" button
- Press the "Start Chat" button
- Close the alert
- Press the "Start Chat" button again


## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
