### PR TITLE
Fixed dependant libraries for celery

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,7 @@ Automat==20.2.0
 azure-common==1.1.25
 azure-storage-blob==2.1.0
 azure-storage-common==2.1.0
-billiard==4.0.0
+billiard==3.6.4.0
 black==21.12b0
 cachetools==4.1.0
 celery==5.2.2
@@ -38,7 +38,7 @@ dynaconf==3.1.8
 entrypoints==0.3
 factory-boy==2.12.0
 Faker==4.0.2
-flake8==3.7.9
+flake8==4.0.1
 h11==0.11.0
 hiredis==1.1.0
 httptools==0.4.0
@@ -61,7 +61,7 @@ protobuf==3.15.0
 psycopg2-binary==2.8.6
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-pycodestyle==2.5.0
+pycodestyle==2.8.0
 pycparser==2.20
 pyflakes==2.4.0
 PyHamcrest==2.0.2


### PR DESCRIPTION
## Description

A dependabot PR to upgrade billiard broke celery configuration on our server. https://github.com/climateconnect/climateconnect/pull/981

This PR is to fix the underlying issue.

## Test plan

- Run `pip install -r requirements.txt`
- Make all libraries are installed correctly. 
- You can run server locally if you like. 
```
Make sure redis is running locally: `redis-server`
On a different terminal window inside virtual env run: celery -A climateconnect_main worker -l INFO
```

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
