### PR TITLE
Fix: "All Projects" link now displays onscreen while looking at a hub

### DIFF
--- a/frontend/src/components/hub/NavigationSubHeader.js
+++ b/frontend/src/components/hub/NavigationSubHeader.js
@@ -94,6 +94,7 @@ export default function NavigationSubHeader({ hubName, allHubs, isLocationHub })
             locale={locale}
             isNarrowScreen={isNarrowScreen}
             showAllProjectsButton
+            linkClassName={classes.link}
           />
         </Typography>
       </Container>

--- a/frontend/src/components/ideas/IdeaRoot.js
+++ b/frontend/src/components/ideas/IdeaRoot.js
@@ -215,7 +215,7 @@ export default function IdeaRoot({
 
       handleSetComments && handleSetComments(comments);
       //if the user is logged in, set their rating and join status. Otherwise just stop loading
-      if(token) {
+      if (token) {
         const notification_to_set_read = notifications.filter((n) =>
           all_comment_ids.includes(n.idea_comment?.id)
         );
@@ -226,7 +226,7 @@ export default function IdeaRoot({
             has_joined: hasJoinedIdea?.has_joined,
             chat_uuid: hasJoinedIdea?.chat_uuid,
           });
-          setLoading(false);
+        setLoading(false);
         await setNotificationsReadAndRefresh(notification_to_set_read);
       } else {
         setLoading(false);
@@ -426,7 +426,7 @@ const getUserRatingFromServer = async (idea, token, locale) => {
 };
 
 const getIdeaCommentsFromServer = async (idea, token, locale) => {
-  console.log("Getting idea comments!")
+  console.log("Getting idea comments!");
   try {
     const response = await apiRequest({
       method: "get",

--- a/frontend/src/components/indexPage/hubsSubHeader/HubLinks.js
+++ b/frontend/src/components/indexPage/hubsSubHeader/HubLinks.js
@@ -11,6 +11,10 @@ const useStyles = makeStyles(() => ({
     justifyContent: "flex-end",
     width: "100%",
   },
+  wrapper: {
+    display: "flex",
+    alignItems: "center"
+  }
 }));
 
 export default function HubLinks({
@@ -62,7 +66,7 @@ export default function HubLinks({
     setOpen(newOpen);
   };
   return (
-    <div className={isNarrowScreen && classes.spaceAround}>
+    <div className={`${isNarrowScreen && classes.spaceAround} ${classes.wrapper}`}>
       {!isMediumScreen &&
         !onlyShowDropDown &&
         (showAllProjectsButton ? (

--- a/frontend/src/components/indexPage/hubsSubHeader/HubLinks.js
+++ b/frontend/src/components/indexPage/hubsSubHeader/HubLinks.js
@@ -66,10 +66,7 @@ export default function HubLinks({
       {!isMediumScreen &&
         !onlyShowDropDown &&
         (showAllProjectsButton ? (
-          <Link
-            className={`${classes.link} ${classes.allProjectsLink}`}
-            href={getLocalePrefix(locale) + "/browse"}
-          >
+          <Link className={linkClassName} href={getLocalePrefix(locale) + "/browse"}>
             {texts.all_projects}
           </Link>
         ) : (

--- a/frontend/src/components/indexPage/hubsSubHeader/HubsDropDown.js
+++ b/frontend/src/components/indexPage/hubsSubHeader/HubsDropDown.js
@@ -12,10 +12,7 @@ const useStyles = makeStyles((theme) => ({
     fontSize: 16,
     height: 54,
     paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(2),
-    [theme.breakpoints.up("md")]: {
-      paddingBottom: theme.spacing(2.5),
-    },
+    paddingBottom: theme.spacing(2)
   },
 }));
 

--- a/frontend/src/components/indexPage/hubsSubHeader/HubsDropDown.js
+++ b/frontend/src/components/indexPage/hubsSubHeader/HubsDropDown.js
@@ -13,6 +13,9 @@ const useStyles = makeStyles((theme) => ({
     height: 54,
     paddingTop: theme.spacing(2),
     paddingBottom: theme.spacing(2),
+    [theme.breakpoints.up("md")]: {
+      paddingBottom: theme.spacing(2.5),
+    },
   },
 }));
 


### PR DESCRIPTION
## Description

When viewing a location or sector hub the navigation sub-header would have an invisible button. If you highlight the text in the sub navigation sub-header you would see "All projects" that when clicked, would route the user to the browse page. This button is now visible.

Additionally, all the items in the navigation sub-header are properly inline. (The dropdown buttons used to be a few pixels lower)

## Test plan

- For sub-header items, simply open the browse page and look at the navigation sub-header

- To see the "All Projects" link:
1. Open the browse page and select "All hubs" and in the next page select any of the hubs. Or simply click any of the hubs already displayed on the navigation sub-header. Lastly, you can open a hub by opening the "ClimateHubs/SectorHubs" dropdown buttons and picking one.
2. Look at the navigation-subheader to see the "All Projects" link.

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
