### PR TITLE
Fix: Added link to email in settings page for account deletion request

### DIFF
--- a/frontend/public/texts/settings.json
+++ b/frontend/public/texts/settings.json
@@ -180,8 +180,8 @@
     "de": "Profilseite bearbeiten"
   },
   "if_you_wish_to_delete_this_account": {
-    "en": "If you wish to delete this account, send an email to contact@climateconnect.earth",
-    "de": "Wenn du das Konto löschen willst, sende eine E-Mail an contact@climateconnect.earth"
+    "en": "If you wish to delete this account, send an email to",
+    "de": "Wenn du das Konto löschen willst, sende eine E-Mail an"
   },
   "old_password": {
     "en": "Old Password",

--- a/frontend/src/components/account/SettingsPage.js
+++ b/frontend/src/components/account/SettingsPage.js
@@ -549,7 +549,7 @@ export default function SettingsPage({ settings, setSettings, token, setMessage 
         <InfoOutlinedIcon />
         {texts.if_you_wish_to_delete_this_account}
         <div className={classes.spaceStrings}/>
-        <Link href="contact@climateconnect.earth">
+        <Link href="mailto:contact@climateconnect.earth">
           <a className={classes.primaryColor}>{emailLink}</a>
         </Link>
       </Typography>

--- a/frontend/src/components/account/SettingsPage.js
+++ b/frontend/src/components/account/SettingsPage.js
@@ -49,13 +49,16 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(5),
     marginBottom: theme.spacing(5),
   },
+  spaceStrings: {
+    width: 4,
+  },
 }));
 
 export default function SettingsPage({ settings, setSettings, token, setMessage }) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "settings", locale: locale });
-
+  const emailLink = "contact@climateconnect.earth";
   const possibleEmailPreferences = [
     {
       key: "send_newsletter",
@@ -545,6 +548,10 @@ export default function SettingsPage({ settings, setSettings, token, setMessage 
       <Typography variant="subtitle2" className={classes.deleteMessage}>
         <InfoOutlinedIcon />
         {texts.if_you_wish_to_delete_this_account}
+        <div className={classes.spaceStrings}/>
+        <Link href="contact@climateconnect.earth">
+          <a className={classes.primaryColor}>{emailLink}</a>
+        </Link>
       </Typography>
     </>
   );

--- a/frontend/src/components/ideas/IdeaRoot.js
+++ b/frontend/src/components/ideas/IdeaRoot.js
@@ -215,7 +215,7 @@ export default function IdeaRoot({
 
       handleSetComments && handleSetComments(comments);
       //if the user is logged in, set their rating and join status. Otherwise just stop loading
-      if(token) {
+      if (token) {
         const notification_to_set_read = notifications.filter((n) =>
           all_comment_ids.includes(n.idea_comment?.id)
         );
@@ -226,7 +226,7 @@ export default function IdeaRoot({
             has_joined: hasJoinedIdea?.has_joined,
             chat_uuid: hasJoinedIdea?.chat_uuid,
           });
-          setLoading(false);
+        setLoading(false);
         await setNotificationsReadAndRefresh(notification_to_set_read);
       } else {
         setLoading(false);
@@ -426,7 +426,7 @@ const getUserRatingFromServer = async (idea, token, locale) => {
 };
 
 const getIdeaCommentsFromServer = async (idea, token, locale) => {
-  console.log("Getting idea comments!")
+  console.log("Getting idea comments!");
   try {
     const response = await apiRequest({
       method: "get",


### PR DESCRIPTION
## Description
Added a link to email in settings page for account deletion requests.

## Test plan
1. Open settings page
2. Scroll down to the bottom
3. Click the link to open an email

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
