### PR TITLE
Fix null value error on idea comment notification

### DIFF
--- a/frontend/src/components/communication/notifications/CommentNotifications.js
+++ b/frontend/src/components/communication/notifications/CommentNotifications.js
@@ -38,7 +38,7 @@ export const IdeaCommentNotification = ({ notification }) => {
     <CommentNotification
       link={`/hubs/${notification.idea.hub_url_slug}?idea=${notification.idea.url_slug}&show_comments=true#ideas`}
       object_commented_on={notification.idea}
-      comment_text={notification.idea_comment.content}
+      comment_text={notification?.idea_comment?.content}
       is_reply={false}
     />
   );


### PR DESCRIPTION
## Description
Fixes null value error on idea comment notifications. 

![Screen Shot 2022-08-07 at 6 48 33 PM](https://user-images.githubusercontent.com/15343711/183322675-c3a29b44-d49a-411a-9119-6070fd7207dc.png)

## Test plan
Hard to reproduce it locally, You can try by setting idea comment to null in the database. 

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
