### PR TITLE
Fix for inbox alert only showing once

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,3 +3,5 @@
 /gcloud-storage-credentials.json
 
 static/
+
+media/

--- a/frontend/pages/inbox.js
+++ b/frontend/pages/inbox.js
@@ -91,13 +91,25 @@ export default function Inbox({ chatData, next }) {
   const [newChatMembers, setNewChatMembers] = React.useState([]);
   const [errorMessage, setErrorMessage] = React.useState("");
   const [groupName, setGroupName] = React.useState("");
+  const [errorMessageController, setErrorMessageController] = React.useState(false);
   const [chatsState, setChatsState] = React.useState({
     chats: parseChats(chatData, texts),
     next: next,
   });
 
-  const updateErrorMessage = (e) => {
-    setErrorMessage(e);
+  const updateErrorMessage = () => {
+    if (errorMessageController) {
+      setErrorMessage(
+        texts.please_add_one_or_more_users_to_chat_to_by_searching_them_in_the_search_bar_above
+      );
+      setErrorMessageController(false);
+    } else {
+      setErrorMessage(
+        texts.please_add_one_or_more_users_to_chat_to_by_searching_them_in_the_search_bar_above +
+          " "
+      );
+      setErrorMessageController(true);
+    }
   };
 
   const handleGroupNameChange = (e) => {
@@ -149,10 +161,7 @@ export default function Inbox({ chatData, next }) {
           console.log(error.response);
           // TODO: Show error message that user cant connect
         });
-    } else
-      setErrorMessage(
-        texts.please_add_one_or_more_users_to_chat_to_by_searching_them_in_the_search_bar_above
-      );
+    } else updateErrorMessage();
   };
 
   const loadMoreChats = async () => {
@@ -184,12 +193,7 @@ export default function Inbox({ chatData, next }) {
 
   return (
     <div>
-      <WideLayout
-        title={texts.inbox}
-        messageType="error"
-        message={errorMessage}
-        resetAlertMessage={updateErrorMessage}
-      >
+      <WideLayout title={texts.inbox} messageType="error" message={errorMessage}>
         <Container maxWidth="md" className={classes.root}>
           <Typography component="h1" variant="h4" className={classes.headline}>
             {texts.inbox}

--- a/frontend/src/components/ideas/IdeaRoot.js
+++ b/frontend/src/components/ideas/IdeaRoot.js
@@ -215,7 +215,7 @@ export default function IdeaRoot({
 
       handleSetComments && handleSetComments(comments);
       //if the user is logged in, set their rating and join status. Otherwise just stop loading
-      if(token) {
+      if (token) {
         const notification_to_set_read = notifications.filter((n) =>
           all_comment_ids.includes(n.idea_comment?.id)
         );
@@ -226,7 +226,7 @@ export default function IdeaRoot({
             has_joined: hasJoinedIdea?.has_joined,
             chat_uuid: hasJoinedIdea?.chat_uuid,
           });
-          setLoading(false);
+        setLoading(false);
         await setNotificationsReadAndRefresh(notification_to_set_read);
       } else {
         setLoading(false);
@@ -426,7 +426,7 @@ const getUserRatingFromServer = async (idea, token, locale) => {
 };
 
 const getIdeaCommentsFromServer = async (idea, token, locale) => {
-  console.log("Getting idea comments!")
+  console.log("Getting idea comments!");
   try {
     const response = await apiRequest({
       method: "get",

--- a/frontend/src/components/layouts/WideLayout.js
+++ b/frontend/src/components/layouts/WideLayout.js
@@ -57,7 +57,6 @@ export default function WideLayout({
   useFloodStdFont,
   rootClassName,
   hideFooter,
-  resetAlertMessage,
 }) {
   const classes = useStyles({ noSpaceBottom: noSpaceBottom, isStaticPage: isStaticPage });
   const [alertOpen, setAlertOpen] = React.useState(true);
@@ -118,7 +117,6 @@ export default function WideLayout({
               }}
               onClose={() => {
                 setAlertOpen(false);
-                resetAlertMessage("");
               }}
             >
               {getMessageFromUrl(message ? message : initialMessage)}


### PR DESCRIPTION
## Description

Problem: 
When clicking start chat in the inbox with an empty search field, the user would receive an alert, prompting them to search for something. Upon closing the alert and repeating the process, the alert would not reopen. 

A prior solution makes a change to a generic layout component which has side effects on either parts of the website when closing the alert e.g. changing account settings.

Solution:
Make the start chat button change the alert message within the inbox component so it can be repeatedly shown when clicking with an empty search field.

## Test plan

1. Sign in
2. Navigate to the user inbox
3. Press start chat with an empty search field
4. Close the alert
5. Press start chat again

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
