### PR TITLE
Fix: Display long chat titles correctly

### DIFF
--- a/frontend/src/components/communication/chat/ChatTitle.js
+++ b/frontend/src/components/communication/chat/ChatTitle.js
@@ -13,7 +13,6 @@ const useStyles = makeStyles((theme) => {
       display: "inline-block",
       verticalAlign: "middle",
       marginLeft: theme.spacing(1),
-      whiteSpace: "nowrap",
     },
     mediumProfileName: {
       fontSize: 16,

--- a/frontend/src/components/profile/MiniProfilePreview.js
+++ b/frontend/src/components/profile/MiniProfilePreview.js
@@ -17,7 +17,6 @@ const useStyles = makeStyles((theme) => {
       display: "inline-block",
       verticalAlign: "middle",
       marginLeft: theme.spacing(1),
-      whiteSpace: "nowrap",
     },
     smallProfileName: {
       fontSize: 14,


### PR DESCRIPTION
## Description

Solves #464 

- Long chat names are not displayed correctly in the chat preview
- Long names in the chat are now using a line break and no longer protrude

## Test plan

1. Log in
1. Visit your inbox
1. Long names in the chat preview are displayed correctly

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
