### PR TITLE
Fix: Correct notification type on mention in comments

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,3 +3,4 @@
 /gcloud-storage-credentials.json
 
 static/
+media/

--- a/backend/organization/utility/notification.py
+++ b/backend/organization/utility/notification.py
@@ -74,12 +74,12 @@ def get_mentions(text, url_slugs_only):
 def create_comment_mention_notification(entity_type, entity, comment, sender):
     if entity_type == "project":
         notification = Notification.objects.create(
-            notification_type=9, project_comment=comment
+            notification_type=11, project_comment=comment
         )
 
     if entity_type == "idea":
         notification = Notification.objects.create(
-            notification_type=9, idea_comment=comment
+            notification_type=11, idea_comment=comment
         )
     matches = get_mentions(text=comment.content, url_slugs_only=False)
     sender_url_slug = UserProfile.objects.get(user=sender).url_slug

--- a/frontend/src/components/communication/notifications/Notification.js
+++ b/frontend/src/components/communication/notifications/Notification.js
@@ -50,22 +50,22 @@ export const StyledMenuItem = withStyles((theme) => ({
 //When editing this: make sure all entries are still at the correct index afterwards
 //It has to match with Notification.NOTIFICATION_TYPES in the backend
 const NOTIFICATION_TYPES = [
-  "broadcast",
-  "private_message",
-  "project_comment",
-  "reply_to_project_comment",
-  "project_follower",
-  "project_update_post",
-  "post_comment",
-  "reply_to_post_comment",
-  "group_message",
-  "join_project_request",
-  "project_join_request_approved",
-  "mention",
-  "project_like",
-  "idea_comment",
-  "reply_to_idea_comment",
-  "person_joined_idea",
+  "broadcast", // 0
+  "private_message", // 1
+  "project_comment", // 2
+  "reply_to_project_comment", // 3
+  "project_follower", // 4
+  "project_update_post", // 5
+  "post_comment", // 6
+  "reply_to_post_comment", // 7
+  "group_message", // 8
+  "join_project_request", // 9
+  "project_join_request_approved", // 10
+  "mention", // 11
+  "project_like", // 12
+  "idea_comment", // 13
+  "reply_to_idea_comment", // 14
+  "person_joined_idea", // 15
 ];
 
 //component for rendering the notifications that are shown when clicking on the bell on the right side of the header


### PR DESCRIPTION
## Description
Solves #1032

Changed the notification type from 9 (project join request) to 11 (mention) in a utility function that is called when posting a comment for either a project or idea.

Added a number to each notification type via comment in frontend array for easier comparison to backend array.

## Test plan

- Sign in and go to the comment section for an idea or project
- Write a comment in which you @ the name of a user, ideally for another account you can sign in to
- Sign into the account you just mentioned with @ in the comment
- You should see a notification icon that you can click and it should say that you were mentioned.

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
