### PR TITLE
Fix: positioning of avatar image when user has no profile picture

### DIFF
--- a/frontend/pages/inbox.js
+++ b/frontend/pages/inbox.js
@@ -96,7 +96,7 @@ export default function Inbox({ chatData, next }) {
     next: next,
   });
 
-  const resetAlertMessage = () => setErrorMessage("")
+  const resetAlertMessage = () => setErrorMessage("");
 
   const handleGroupNameChange = (e) => {
     setGroupName(e.target.value);

--- a/frontend/src/components/account/SettingsPage.js
+++ b/frontend/src/components/account/SettingsPage.js
@@ -548,7 +548,7 @@ export default function SettingsPage({ settings, setSettings, token, setMessage 
       <Typography variant="subtitle2" className={classes.deleteMessage}>
         <InfoOutlinedIcon />
         {texts.if_you_wish_to_delete_this_account}
-        <div className={classes.spaceStrings}/>
+        <div className={classes.spaceStrings} />
         <Link href="mailto:contact@climateconnect.earth">
           <a className={classes.primaryColor}>{emailLink}</a>
         </Link>

--- a/frontend/src/components/header/Header.js
+++ b/frontend/src/components/header/Header.js
@@ -639,17 +639,19 @@ function NarrowScreenLinks({
                 if (link.avatar)
                   return (
                     <div className={classes.mobileAvatarContainer}>
-                      {loggedInUser?.badges?.length > 0 ? (
-                        <ProfileBadge
-                          badge={loggedInUser?.badges[0]}
-                          size="medium"
-                          className={classes.badge}
-                        >
+                      <Link href={"/profiles/" + loggedInUser.url_slug}>
+                        {loggedInUser?.badges?.length > 0 ? (
+                          <ProfileBadge
+                            badge={loggedInUser?.badges[0]}
+                            size="medium"
+                            className={classes.badge}
+                          >
+                            <Avatar {...avatarProps} />
+                          </ProfileBadge>
+                        ) : (
                           <Avatar {...avatarProps} />
-                        </ProfileBadge>
-                      ) : (
-                        <Avatar {...avatarProps} />
-                      )}
+                        )}
+                      </Link>
                     </div>
                   );
                 else if (link.isLogoutButton)

--- a/frontend/src/components/header/Header.js
+++ b/frontend/src/components/header/Header.js
@@ -124,7 +124,7 @@ const useStyles = makeStyles((theme) => {
     loggedInAvatarMobile: {
       height: 60,
       width: 60,
-      display: "block",
+
       margin: "0 auto",
     },
     loggedInLink: {
@@ -171,6 +171,8 @@ const useStyles = makeStyles((theme) => {
     mobileAvatarContainer: {
       display: "flex",
       justifyContent: "center",
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(2),
     },
   };
 });

--- a/frontend/src/components/indexPage/hubsSubHeader/HubLinks.js
+++ b/frontend/src/components/indexPage/hubsSubHeader/HubLinks.js
@@ -13,8 +13,8 @@ const useStyles = makeStyles(() => ({
   },
   wrapper: {
     display: "flex",
-    alignItems: "center"
-  }
+    alignItems: "center",
+  },
 }));
 
 export default function HubLinks({

--- a/frontend/src/components/indexPage/hubsSubHeader/HubsDropDown.js
+++ b/frontend/src/components/indexPage/hubsSubHeader/HubsDropDown.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme) => ({
     fontSize: 16,
     height: 54,
     paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(2)
+    paddingBottom: theme.spacing(2),
   },
 }));
 


### PR DESCRIPTION
## Description
Solves #1034 

Increased margins between clickable options and the user's profile picture. If the user has no self defined profile picture, the default one that shows is now centered.

Added link to the profile picture that redirects to my profile.

## Test plan

1. Reduce screen with to <600px
2. Click the menu icon in the top right
3. See change

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
