### PR TITLE
Fix: Short description for organization limited to 280 characters

### DIFF
--- a/frontend/pages/inbox.js
+++ b/frontend/pages/inbox.js
@@ -96,7 +96,7 @@ export default function Inbox({ chatData, next }) {
     next: next,
   });
 
-  const resetAlertMessage = () => setErrorMessage("")
+  const resetAlertMessage = () => setErrorMessage("");
 
   const handleGroupNameChange = (e) => {
     setGroupName(e.target.value);

--- a/frontend/src/components/account/EditAccountPage.js
+++ b/frontend/src/components/account/EditAccountPage.js
@@ -274,7 +274,7 @@ export default function EditAccountPage({
   const handleDialogClickOpen = (dialogKey) => {
     setOpen({ ...open, [dialogKey]: true });
   };
-
+  console.log(account);
   const handleBackgroundClose = (image) => {
     setOpen({ ...open, backgroundDialog: false });
     if (image && image instanceof HTMLCanvasElement) {
@@ -596,6 +596,30 @@ export default function EditAccountPage({
             onSelectNewHub={onSelectNewHub}
           />
         );
+      } else if (key === "short_description") {
+        // textfield for short description of an Org, it should be limited to 280 characters
+        return (
+          <div key={key} className={classes.infoElement}>
+            <Typography className={classes.subtitle}>
+              {i.name}
+              {i.helptext && (
+                <Tooltip title={i.helptext}>
+                  <IconButton>
+                    <HelpOutlineIcon className={classes.helpIcon} />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </Typography>
+            <TextField
+              inputProps={{ maxLength: 280 }}
+              required={i.required}
+              fullWidth
+              value={i.value}
+              multiline
+              onChange={handleChange}
+            />
+          </div>
+        );
       } else if (key != "parent_organization" && ["text", "bio"].includes(i.type)) {
         //This is the fallback for normal textfields
         return (
@@ -690,7 +714,7 @@ export default function EditAccountPage({
     event.preventDefault();
     handleSubmit(editedAccount);
   };
-
+  console.log(editedAccount);
   const getDetailledDescription = () => {
     const detailled_description_obj = Object.keys(editedAccount.info).filter((i) => {
       const el = getFullInfoElement(infoMetadata, i, editedAccount.info[i]);

--- a/frontend/src/components/account/SettingsPage.js
+++ b/frontend/src/components/account/SettingsPage.js
@@ -548,7 +548,7 @@ export default function SettingsPage({ settings, setSettings, token, setMessage 
       <Typography variant="subtitle2" className={classes.deleteMessage}>
         <InfoOutlinedIcon />
         {texts.if_you_wish_to_delete_this_account}
-        <div className={classes.spaceStrings}/>
+        <div className={classes.spaceStrings} />
         <Link href="mailto:contact@climateconnect.earth">
           <a className={classes.primaryColor}>{emailLink}</a>
         </Link>

--- a/frontend/src/components/indexPage/hubsSubHeader/HubLinks.js
+++ b/frontend/src/components/indexPage/hubsSubHeader/HubLinks.js
@@ -13,8 +13,8 @@ const useStyles = makeStyles(() => ({
   },
   wrapper: {
     display: "flex",
-    alignItems: "center"
-  }
+    alignItems: "center",
+  },
 }));
 
 export default function HubLinks({

--- a/frontend/src/components/indexPage/hubsSubHeader/HubsDropDown.js
+++ b/frontend/src/components/indexPage/hubsSubHeader/HubsDropDown.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme) => ({
     fontSize: 16,
     height: 54,
     paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(2)
+    paddingBottom: theme.spacing(2),
   },
 }));
 

--- a/frontend/src/components/layouts/WideLayout.js
+++ b/frontend/src/components/layouts/WideLayout.js
@@ -118,7 +118,7 @@ export default function WideLayout({
               }}
               onClose={() => {
                 resetAlertMessage && resetAlertMessage();
-                setAlertOpen(false);                
+                setAlertOpen(false);
               }}
             >
               {getMessageFromUrl(message ? message : initialMessage)}


### PR DESCRIPTION
## Description

Solves #1039 

Added an extra else if branch to EditAccountPage, to check for short_description type. Here the maximum number of characters is now limited to 280. 

Sidenote: 
Perhaps this could also be changed and a user's bio/website or organization website fields could also be limited to 280. Should a maximum number of lines be added to these fields? How does this affect organizations or users that already exist with greater than 280 characters in these fields?
Translations section would also need to be updated to only allow 280, but what if an automated translation needs an extra word or 2?

## Test plan

- Go to 'edit organization' or 'create organization'
- In the summary text field attempt to enter a string greater than 280 characters

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
