### PR TITLE
Feat: Display child orgs/projects on organization page

### DIFF
--- a/backend/organization/urls.py
+++ b/backend/organization/urls.py
@@ -60,6 +60,11 @@ urlpatterns = [
         organization_views.ListFeaturedOrganizations.as_view(),
         name="featured-organizations-api-view",
     ),
+    path(
+        "child_organizations/<str:url_slug>/",
+        organization_views.ListChildOrganizations.as_view(),
+        name="child-organizations-api-view",
+    ),
     # Project URLs
     path("projects/", project_views.ListProjectsView.as_view(), name="list-projects"),
     path(

--- a/backend/organization/views/organization_views.py
+++ b/backend/organization/views/organization_views.py
@@ -693,11 +693,12 @@ class ListOrganizationTags(ListAPIView):
 class ListFeaturedOrganizations(ListAPIView):
     permission_classes = [AllowAny]
     serializer_class = OrganizationCardSerializer
-
+    
     def get_serializer_context(self):
         return {"language_code": self.request.LANGUAGE_CODE}
 
     def get_queryset(self):
+        print("called")
         return Organization.objects.filter(rating__lte=99)[0:4]
 
 
@@ -721,3 +722,18 @@ class SetOrganisationSharedView(APIView):
             )
         save_content_shared(request, organization)
         return Response(status=status.HTTP_201_CREATED)
+
+
+class ListChildOrganizations(ListAPIView):
+    permission_classes = [AllowAny]
+    serializer_class = OrganizationSerializer
+    def get_queryset(self):
+        organizations = Organization.objects.filter( parent_organization__url_slug = self.kwargs['url_slug']) 
+        
+        return organizations
+        
+        
+        
+
+   
+    

--- a/frontend/src/components/project/ProjectOverview.js
+++ b/frontend/src/components/project/ProjectOverview.js
@@ -276,7 +276,7 @@ function SmallScreenOverview({
   texts,
   toggleShowFollowers,
   token,
-  numberOfFollowers
+  numberOfFollowers,
 }) {
   const classes = useStyles();
 

--- a/frontend/src/components/project/ProjectPageRoot.js
+++ b/frontend/src/components/project/ProjectPageRoot.js
@@ -65,7 +65,6 @@ const useStyles = makeStyles((theme) => ({
     paddingRight: theme.spacing(4),
   },
 
-
   showAllProjectsButton: {
     marginTop: theme.spacing(1),
     fontSize: 14,


### PR DESCRIPTION
## Description
Closes #1064 

Added backend API call to obtain an organizations sub-orgs. 
In the frontend, we obtain the sub-org projects and display them alongside the sub-orgs, should they exist. 

## Test plan

<!-- _Include relevant test configuration details for the reviewer(s), and steps to test and verify new feature._ -->

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
