### PR TITLE
Make local ambassador button work on mobile; implement mobile bottom bar

### DIFF
--- a/frontend/pages/hubs/[hubUrl].js
+++ b/frontend/pages/hubs/[hubUrl].js
@@ -35,9 +35,6 @@ const useStyles = makeStyles((theme) => ({
       paddingTop: theme.spacing(1),
     },
   },
-  contentUnderHeader: {
-    marginTop: 112,
-  },
   contentRef: {
     position: "absolute",
     top: -90,
@@ -134,7 +131,7 @@ export default function Hub({
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "hub", locale: locale, hubName: name });
   const token = new Cookies().get("auth_token");
-  const [hubAmbassador, setHubAmbassador] = useState(null)
+  const [hubAmbassador, setHubAmbassador] = useState(null);
 
   // Initialize filters. We use one set of filters for all tabs (projects, organizations, members)
   const [filters, setFilters] = useState(
@@ -163,9 +160,9 @@ export default function Hub({
   };
 
   useEffect(async () => {
-    const retrievedHubAmbassador = await getHubAmbassadorData(hubUrl, locale)
-    setHubAmbassador(retrievedHubAmbassador)
-  }, [])
+    const retrievedHubAmbassador = await getHubAmbassadorData(hubUrl, locale);
+    setHubAmbassador(retrievedHubAmbassador);
+  }, []);
 
   //Refs and state for tutorial
   const hubQuickInfoRef = useRef(null);
@@ -234,13 +231,7 @@ export default function Hub({
       {hubDescription && hubDescription.headContent && (
         <Head>{parseHtml(hubDescription.headContent)}</Head>
       )}
-      <WideLayout
-        title={headline}
-        fixedHeader
-        headerBackground="#FFF"
-        image={getImageUrl(image)}
-        isHubPage
-      >
+      <WideLayout title={headline} headerBackground="#FFF" image={getImageUrl(image)} isHubPage>
         <div className={classes.contentUnderHeader}>
           <NavigationSubHeader hubName={name} allHubs={allHubs} isLocationHub={isLocationHub} />
           {<DonationCampaignInformation />}
@@ -283,6 +274,7 @@ export default function Hub({
               applyNewFilters={handleApplyNewFilters}
               customSearchBarLabels={customSearchBarLabels}
               errorMessage={errorMessage}
+              hubAmbassador={hubAmbassador}
               filters={filters}
               handleUpdateFilterValues={handleUpdateFilterValues}
               filterChoices={filterChoices}
@@ -369,4 +361,4 @@ const getHubAmbassadorData = async (url_slug, locale) => {
     console.log(err);
     return null;
   }
-}
+};

--- a/frontend/src/components/account/EditAccountPage.js
+++ b/frontend/src/components/account/EditAccountPage.js
@@ -244,7 +244,6 @@ export default function EditAccountPage({
   loadingSubmit,
   onClickCheckTranslations,
   allHubs,
-  type,
 }) {
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "account", locale: locale });

--- a/frontend/src/components/browse/BrowseContent.js
+++ b/frontend/src/components/browse/BrowseContent.js
@@ -24,6 +24,7 @@ import FeedbackContext from "../context/FeedbackContext";
 import LoadingContext from "../context/LoadingContext";
 import UserContext from "../context/UserContext";
 import LoadingSpinner from "../general/LoadingSpinner";
+import MobileBottomMenu from "./MobileBottomMenu";
 
 const FilterSection = React.lazy(() => import("../indexPage/FilterSection"));
 const IdeasBoard = React.lazy(() => import("../ideas/IdeasBoard"));
@@ -80,6 +81,7 @@ export default function BrowseContent({
   initialLocationFilter,
   resetTabsWhereFiltersWereApplied,
   hubUrl,
+  hubAmbassador,
 }) {
   const initialState = {
     items: {
@@ -508,30 +510,43 @@ export default function BrowseContent({
             hideFilterButton={tabValue === TYPES_BY_TAB_VALUE.indexOf("ideas")}
           />
         </Suspense>
-        <Tabs
-          variant={isNarrowScreen ? "fullWidth" : "standard"}
-          value={tabValue}
-          onChange={handleTabChange}
-          indicatorColor="primary"
-          textColor="primary"
-          centered={true}
-        >
-          {TYPES_BY_TAB_VALUE.map((t, index) => {
-            const tabProps = {
-              label: type_names[t],
-              className: classes.tab,
-            };
-            if (index === TYPES_BY_TAB_VALUE.indexOf("ideas")) {
-              tabProps.label = (
-                <div className={classes.ideasTabLabel}>
-                  <EmojiObjectsIcon className={classes.ideasIcon} /> {type_names[t]}
-                </div>
-              );
-            }
-            if (index === 1) tabProps.ref = organizationsTabRef;
-            return <Tab {...tabProps} key={index} />;
-          })}
-        </Tabs>
+        {/* Desktop screens: show tabs under the search bar */}
+        {/* Mobile screens: show tabs fixed to the bottom of the screen */}
+        {!isNarrowScreen ? (
+          <Tabs
+            variant={isNarrowScreen ? "fullWidth" : "standard"}
+            value={tabValue}
+            onChange={handleTabChange}
+            indicatorColor="primary"
+            textColor="primary"
+            centered={true}
+          >
+            {TYPES_BY_TAB_VALUE.map((t, index) => {
+              const tabProps = {
+                label: type_names[t],
+                className: classes.tab,
+              };
+              if (index === TYPES_BY_TAB_VALUE.indexOf("ideas")) {
+                tabProps.label = (
+                  <div className={classes.ideasTabLabel}>
+                    <EmojiObjectsIcon className={classes.ideasIcon} /> {type_names[t]}
+                  </div>
+                );
+              }
+              if (index === 1) tabProps.ref = organizationsTabRef;
+              return <Tab {...tabProps} key={index} />;
+            })}
+          </Tabs>
+        ) : (
+          <MobileBottomMenu
+            tabValue={tabValue}
+            handleTabChange={handleTabChange}
+            TYPES_BY_TAB_VALUE={TYPES_BY_TAB_VALUE}
+            type_names={type_names}
+            organizationsTabRef={organizationsTabRef}
+            hubAmbassador={hubAmbassador}
+          />
+        )}
 
         <Divider className={classes.mainContentDivider} />
 

--- a/frontend/src/components/browse/MobileBottomMenu.js
+++ b/frontend/src/components/browse/MobileBottomMenu.js
@@ -1,0 +1,60 @@
+import React from "react";
+import EmojiObjectsIcon from "@material-ui/icons/EmojiObjects";
+import { makeStyles, Tab, Tabs } from "@material-ui/core";
+import ContactAmbassadorButton from "../hub/ContactAmbassadorButton";
+import AssignmentIcon from "@material-ui/icons/Assignment";
+import AccountCircleIcon from "@material-ui/icons/AccountCircle";
+import GroupIcon from "@material-ui/icons/Group";
+
+const useStyles = makeStyles(() => ({
+  root: {
+    position: "fixed",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10,
+    background: "#f0f2f5",
+  },
+}));
+
+export default function MobileBottomMenu({
+  tabValue,
+  handleTabChange,
+  TYPES_BY_TAB_VALUE,
+  organizationsTabRef,
+  hubAmbassador,
+}) {
+  const type_icons = {
+    projects: AssignmentIcon,
+    organizations: GroupIcon,
+    members: AccountCircleIcon,
+    ideas: EmojiObjectsIcon,
+  };
+  const classes = useStyles();
+  return (
+    <div className={classes.root}>
+      <ContactAmbassadorButton mobile hubAmbassador={hubAmbassador} />
+      <>
+        <Tabs
+          variant="fullWidth"
+          value={tabValue}
+          onChange={handleTabChange}
+          indicatorColor="primary"
+          textColor="primary"
+          centered={true}
+        >
+          {TYPES_BY_TAB_VALUE.map((t, index) => {
+            const tabProps = {
+              className: classes.tab,
+            };
+            const typeIcon = {
+              icon: type_icons[t],
+            };
+            if (index === 1) tabProps.ref = organizationsTabRef;
+            return <Tab label={<typeIcon.icon />} {...tabProps} key={index} />;
+          })}
+        </Tabs>
+      </>
+    </div>
+  );
+}

--- a/frontend/src/components/communication/contactcreator/ContactCreatorButtonInfo.js
+++ b/frontend/src/components/communication/contactcreator/ContactCreatorButtonInfo.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles({
     justifyContent: "center",
     backgroundColor: "#F8F8F8",
     cursor: "pointer",
-    flexDirection: "column"
+    flexDirection: "column",
   },
   slideInRoot: {
     textAlign: "left",
@@ -23,20 +23,20 @@ const useStyles = makeStyles({
     height: 50,
     width: 50,
   },
-  customMessage:{
+  customMessage: {
     fontSize: 14,
-    fontStyle: "italic"
-  }
+    fontStyle: "italic",
+  },
 });
 
 export default function ContactCreatorButtonInfo({
   creatorName,
   creatorImageURL,
   creatorsRoleInProject,
-  customMessage
+  customMessage,
 }) {
   const classes = useStyles();
-
+  console.log("customMessage: "+customMessage)
   return (
     <Card className={classes.slideInCard} variant="outlined">
       <CardHeader
@@ -47,7 +47,13 @@ export default function ContactCreatorButtonInfo({
         }}
         avatar={<Avatar src={creatorImageURL} className={classes.avatar} />}
         title={creatorName}
-        subheader={creatorsRoleInProject ? creatorsRoleInProject : (<Typography className={classes.customMessage}>"{customMessage}"</Typography>)}
+        subheader={
+          creatorsRoleInProject ? (
+            creatorsRoleInProject
+          ) : (
+            <Typography className={classes.customMessage}>"{customMessage}"</Typography>
+          )
+        }
       />
     </Card>
   );

--- a/frontend/src/components/hub/ContactAmbassadorButton.js
+++ b/frontend/src/components/hub/ContactAmbassadorButton.js
@@ -1,4 +1,4 @@
-import { Button, Hidden, Typography } from "@material-ui/core";
+import { Avatar, Button } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import React, { useContext } from "react";
 import { redirect } from "../../../public/lib/apiOperations";
@@ -9,6 +9,8 @@ import getTexts from "../../../public/texts/texts";
 import Cookies from "universal-cookie";
 import ContactCreatorButtonInfo from "../communication/contactcreator/ContactCreatorButtonInfo";
 import { getImageUrl } from "../../../public/lib/imageOperations";
+import SendIcon from "@material-ui/icons/Send";
+import theme from "../../themes/theme";
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -18,11 +20,22 @@ const useStyles = makeStyles(() => ({
     right: "1%",
     display: "flex",
     flexDirection: "column",
-    maxWidth: 300
+    maxWidth: 300,
+  },
+  mobileButton: {
+    width: "100%",
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+  },
+  mobileAvatar: {
+    margin: 1,
   },
 }));
 
-export default function ContactAmbassadorButton({ hubAmbassador }) {
+export default function ContactAmbassadorButton({ hubAmbassador, mobile }) {
   const classes = useStyles();
   const { locale, user } = useContext(UserContext);
   const cookies = new Cookies();
@@ -42,14 +55,35 @@ export default function ContactAmbassadorButton({ hubAmbassador }) {
     const chat = await startPrivateChat(hubAmbassador?.user, token, locale);
     Router.push("/chat/" + chat.chat_uuid + "/");
   };
+  if (mobile) {
+    return (
+      <>
+        {hubAmbassador && (
+          <Button
+            className={classes.mobileButton}
+            variant="contained"
+            color="primary"
+            onClick={handleClickContact}
+            size="small"
+          >
+            <Avatar
+              className={classes.mobileAvatar}
+              src={getImageUrl(hubAmbassador?.user?.thumbnail_image)}
+            />
+            {texts.contact_ambassador}
+            <SendIcon />
+          </Button>
+        )}
+      </>
+    );
+  }
   return (
-    <Hidden xsDown>
+    <>
       {hubAmbassador && (
         <div className={classes.root} onClick={handleClickContact}>
           <ContactCreatorButtonInfo
             creatorName={`${hubAmbassador?.user?.first_name} ${hubAmbassador?.user?.last_name}`}
             creatorImageURL={getImageUrl(hubAmbassador?.user?.thumbnail_image)}
-            creatorsRoleInProject={hubAmbassador.title_de}
             customMessage={hubAmbassador.custom_message}
           />
           <Button variant="contained" color="primary">
@@ -57,6 +91,6 @@ export default function ContactAmbassadorButton({ hubAmbassador }) {
           </Button>
         </div>
       )}
-    </Hidden>
+    </>
   );
 }

--- a/frontend/src/components/hub/HubContent.js
+++ b/frontend/src/components/hub/HubContent.js
@@ -161,6 +161,7 @@ export default function HubContent({
                   handleClickExpand={handleClickExpand}
                   isLocationHub={isLocationHub}
                   hubAmbassador={hubAmbassador}
+                  isNarrowScreen={isNarrowScreen}
                 />
               </div>
               {user && (
@@ -187,6 +188,7 @@ export default function HubContent({
               handleClickExpand={handleClickExpand}
               isLocationHub={isLocationHub}
               hubAmbassador={hubAmbassador}
+              isNarrowScreen={isNarrowScreen}
             />
           </div>
         )}
@@ -221,6 +223,7 @@ const BottomContent = ({
   handleClickExpand,
   hubAmbassador,
   isLocationHub,
+  isNarrowScreen,
 }) => {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
@@ -257,7 +260,7 @@ const BottomContent = ({
           )}
         </Button>
       </div>
-      <ContactAmbassadorButton hubAmbassador={hubAmbassador} />
+      {!isNarrowScreen && <ContactAmbassadorButton hubAmbassador={hubAmbassador} />}
     </>
   );
 };

--- a/frontend/src/components/layouts/layout.js
+++ b/frontend/src/components/layouts/layout.js
@@ -16,9 +16,9 @@ const useStyles = makeStyles((theme) => ({
     textAlign: "center",
     margin: `${theme.spacing(4)}px 0`,
   },
-  alert: (props) => ({
+  alert: () => ({
     width: "100%",
-    zIndex: 100
+    zIndex: 100,
   }),
 }));
 
@@ -50,7 +50,7 @@ export default function Layout({
       {isLoading ? (
         <LoadingContainer headerHeight={113} footerHeight={80} />
       ) : (
-        <Container maxWidth="lg" component="main">
+        <>
           {(message || initialMessage) && !(hideAlertMessage === message) && (
             <Alert
               className={classes.alert}
@@ -64,15 +64,17 @@ export default function Layout({
               {getMessageFromUrl(message ? message : initialMessage)}
             </Alert>
           )}
-          <Container maxWidth="sm">
-            {!hideHeadline && (
-              <Typography component="h1" variant="h5" className={classes.mainHeading}>
-                {title}
-              </Typography>
-            )}
+          <Container maxWidth="lg" component="main">
+            <Container maxWidth="sm">
+              {!hideHeadline && (
+                <Typography component="h1" variant="h5" className={classes.mainHeading}>
+                  {title}
+                </Typography>
+              )}
+            </Container>
+            {children}
           </Container>
-          {children}
-        </Container>
+        </>
       )}
       <Footer />
     </LayoutWrapper>


### PR DESCRIPTION
## Description

Implemented most of the mobile button bar from `[this design](https://xd.adobe.com/view/6bade6c1-8cb5-41f2-8bd6-118dccd77d74-3efe/screen/71cea1e7-30f9-43f0-9b63-4d0de960d1a7/specs/)`. I did not yet implement the generic "share" button to keep the PR small and because there wasn't a design for the menus yet. 

## Test plan

Look at the platform on a mobile screen and see the tabs fixed at the bottom of the screen.
On hubs you will also see the contact ambassador button there if you have added an ambassador

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
