### PR TITLE
Changed celery periodic task schedule to be weekly on Thursday

### DIFF
--- a/backend/climateconnect_main/celery.py
+++ b/backend/climateconnect_main/celery.py
@@ -17,7 +17,8 @@ app.autodiscover_tasks()
 app.conf.beat_schedule = {
     "schedule_automated_email_reminder_for_notifications": {
         "task": "climateconnect_api.tasks.schedule_automated_reminder_for_user_notifications",
-        "schedule": crontab(minute=0, hour=0),
+        # 0-6 = Sunday to Saturday
+        "schedule": crontab(day_of_week=4, minute=0, hour=0),
     },
     "testing_task": {
         "task": "climateconnect_api.tasks.testing_task",


### PR DESCRIPTION
## Description

We do not want to send daily emails about unread messages. I have changed daily reminder to weekly. 

## Test plan

<!-- _Include relevant test configuration details for the reviewer(s), and steps to test and verify new feature._ -->

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
