### PR TITLE
Don't show translation step automatically anymore when your language is German

### DIFF
--- a/frontend/pages/createorganization.js
+++ b/frontend/pages/createorganization.js
@@ -222,7 +222,7 @@ export default function CreateOrganization({ tagOptions, rolesOptions, allHubs }
         return;
       }
     }
-    if (locale !== "en") {
+    /*if (locale !== "en") {
       console.log(account);
       setOrganizationInfo({
         ...account,
@@ -230,7 +230,7 @@ export default function CreateOrganization({ tagOptions, rolesOptions, allHubs }
       });
       setCurStep(steps[2]);
       return;
-    }
+    }*/
     setLoadingSubmit(true);
     await makeCreateOrganizationRequest(organizationToSubmit);
   };

--- a/frontend/src/components/shareProject/ShareProjectRoot.js
+++ b/frontend/src/components/shareProject/ShareProjectRoot.js
@@ -53,14 +53,14 @@ const getSteps = (texts, sourceLocale) => {
       headline: texts.add_your_team,
     },
   ];
-  if (sourceLocale === "de") {
+  /*if (sourceLocale === "de") {
     steps.push({
       key: "translate",
       text: texts.languages,
       headline: texts.translate,
       sourceLocale: ["de"],
-    });
-  }
+    })
+  }*/
   return steps;
 };
 


### PR DESCRIPTION
## Description

Before this change if your language was german you'd always get to a page where you have the option to manually translate your project or organization after creating a project or organization. This could be quite confusing and is something very few people do. Therefore we decided to stop showing this step to german users. They can still change their translations by clicking on "check translations" in the edit organization or edit project view

## Test plan

Switch to german language and navigate to /createorganization or /share. Finish creating your project or organization and see that there is no translation step shown.
