### PR TITLE
Upgraded uvicorn library

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -92,8 +92,8 @@ txaio==20.4.1
 typing_extensions==4.3.0
 tzdata==2022.1
 urllib3==1.26.12
-uvicorn==0.17.6
-uvloop==0.16.0
+uvicorn==0.19.0
+uvloop==0.17.0
 validators==0.20.0
 vine==5.0.0
 watchgod==0.6


### PR DESCRIPTION
## Description

PR to fix backend error we are getting in the backend. This may not fix the underlying problem but giving it a shot. 
```
Fatal error on transport TCPTransport
protocol: <uvicorn.protocols.http.httptools_impl.HttpToolsProtocol object at 0x7f792ba1c130>
transport: <TCPTransport closed=False reading=False 0x55762e048690>
```

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
