### PR TITLE
Fix: Reformatting organization previews

### DIFF
--- a/frontend/src/components/organization/OrganizationPreviewBody.js
+++ b/frontend/src/components/organization/OrganizationPreviewBody.js
@@ -39,6 +39,7 @@ const useStyles = makeStyles((theme) => {
       overflow: "hidden",
       WebkitBoxOrient: "vertical",
       display: "-webkit-box",
+      lineHeight: 1.25
     },
     summaryBox: {
       overflow: "hidden",

--- a/frontend/src/components/organization/OrganizationPreviewHeader.js
+++ b/frontend/src/components/organization/OrganizationPreviewHeader.js
@@ -10,10 +10,10 @@ const useStyles = makeStyles((theme) => {
       fontWeight: "bold",
       margin: "5px",
       overflow: "hidden",
+      lineHeight: 1.3
     },
     headerWrapper: (props) => ({
-      justifyContent: "center",
-      marginTop: props.numOfTypes > 1 ? 0 : 21,
+      justifyContent: "center",  
     }),
     media: {
       height: 80,
@@ -37,9 +37,7 @@ const useStyles = makeStyles((theme) => {
 });
 
 export default function OrganizationPreviewHeader({ organization }) {
-  const classes = useStyles({
-    numOfTypes: organization.types.length,
-  });
+  const classes = useStyles();
 
   return (
     <div>


### PR DESCRIPTION
## Description

Closes #1105 

Removed gap between tags and org name to make more space for org summary. Decreased space between lines in org summary and org names.

## Test plan

1. Go to org previews in /browse to see changes or on the landing page section where orgs are shown.

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
