### PR TITLE
Fix: Long strings causing layout issues

### DIFF
--- a/frontend/pages/organizations/[organizationUrl].js
+++ b/frontend/pages/organizations/[organizationUrl].js
@@ -56,7 +56,7 @@ const useStyles = makeStyles((theme) => ({
     fontSize: 23,
     fontWeight: "bold",
     marginBottom: theme.spacing(1),
-    wordBreak: "break-all",
+    wordBreak: "break-word",
   },
   sectionHeadlineWithButtonContainer: {
     display: "flex",

--- a/frontend/pages/organizations/[organizationUrl].js
+++ b/frontend/pages/organizations/[organizationUrl].js
@@ -56,6 +56,7 @@ const useStyles = makeStyles((theme) => ({
     fontSize: 23,
     fontWeight: "bold",
     marginBottom: theme.spacing(1),
+    wordBreak: "break-all",
   },
   sectionHeadlineWithButtonContainer: {
     display: "flex",

--- a/frontend/public/styles/projectOverviewStyles.js
+++ b/frontend/public/styles/projectOverviewStyles.js
@@ -12,6 +12,7 @@ const projectOverviewStyles = (theme) => {
     projectInfoEl: {
       textAlign: "left",
       marginTop: theme.spacing(1),
+      wordBreak: "break-word"
     },
     icon: {
       verticalAlign: "bottom",
@@ -30,6 +31,7 @@ const projectOverviewStyles = (theme) => {
     smallScreenHeader: {
       textAlign: "center",
       paddingBottom: theme.spacing(2),
+      wordBreak: "break-word"
     },
     infoBottomBar: {
       paddingTop: theme.spacing(2),

--- a/frontend/src/components/account/AccountPage.js
+++ b/frontend/src/components/account/AccountPage.js
@@ -73,6 +73,7 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(1),
     paddingLeft: 0,
     paddingRight: 0,
+    wordBreak: "break-all",
   },
   subtitle: {
     color: `${theme.palette.secondary.main}`,

--- a/frontend/src/components/account/AccountPage.js
+++ b/frontend/src/components/account/AccountPage.js
@@ -73,16 +73,19 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(1),
     paddingLeft: 0,
     paddingRight: 0,
-    wordBreak: "break-all",
+    wordBreak: "break-word",
   },
   subtitle: {
     color: `${theme.palette.secondary.main}`,
     fontWeight: "bold",
+    wordBreak: "break-word",
+   
   },
   content: {
     paddingBottom: theme.spacing(2),
     color: `${theme.palette.secondary.main}`,
     fontSize: 16,
+    wordBreak: "break-word"
   },
   noPadding: {
     padding: 0,

--- a/frontend/src/components/general/SubTitleWithContent.js
+++ b/frontend/src/components/general/SubTitleWithContent.js
@@ -19,6 +19,7 @@ const useStyles = makeStyles((theme) => ({
     paddingBottom: theme.spacing(2),
     color: `${theme.palette.secondary.main}`,
     fontSize: 16,
+    wordBreak: "break-word",
   },
   marginRight: {
     marginRight: theme.spacing(0.5),

--- a/frontend/src/components/general/TranslateTexts.js
+++ b/frontend/src/components/general/TranslateTexts.js
@@ -79,7 +79,6 @@ const useStyles = makeStyles((theme) => ({
     marginRight: theme.spacing(1),
     marginLeft: theme.spacing(1),
     [theme.breakpoints.down("sm")]: {
-     
       minWidth: 100,
     },
     width: 265,
@@ -106,7 +105,6 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: "space-around",
   },
   backButton: {
-
     border: `1px solid #000000`,
   },
 }));
@@ -386,7 +384,7 @@ function TranslationBlock({
         handleContentChange={(event) => {
           handleTranslationChange(event.target.value, dataKey, indexInArray);
         }}
-        maxCharacters={maxCharacters*1.20}
+        maxCharacters={maxCharacters * 1.2}
         characterText={texts.characters}
         showCharacterCounter={showCharacterCounter}
       />
@@ -405,7 +403,6 @@ function TranslationBlockElement({
   characterText,
 }) {
   const classes = useStyles();
-
 
   return (
     <div className={classes.translationBlockElement}>

--- a/frontend/src/components/organization/MiniOrganizationPreview.js
+++ b/frontend/src/components/organization/MiniOrganizationPreview.js
@@ -6,6 +6,8 @@ import { getLocalePrefix } from "../../../public/lib/apiOperations";
 import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
 import { getImageUrl } from "./../../../public/lib/imageOperations";
+import Truncate from "react-truncate";
+
 
 const useStyles = makeStyles((theme) => ({
   orgImage: {
@@ -73,7 +75,9 @@ function Content({ organization, size, onDelete }) {
         alt={texts.organizations_logo}
       />
       {size === "small" ? (
-        <>{organization.name}</>
+        <Truncate lines={2}>
+        <Typography>{organization.name}</Typography>
+        </Truncate>
       ) : size === "medium" ? (
         <Typography className={classes.mediumOrgName}>{organization.name}</Typography>
       ) : (

--- a/frontend/src/components/organization/MiniOrganizationPreview.js
+++ b/frontend/src/components/organization/MiniOrganizationPreview.js
@@ -17,6 +17,7 @@ const useStyles = makeStyles((theme) => ({
   },
   orgName: {
     display: "inline-block",
+    wordBreak: "break-word"
   },
   wrapper: {
     display: "inline-flex",
@@ -24,6 +25,7 @@ const useStyles = makeStyles((theme) => ({
   },
   mediumOrgName: {
     fontSize: 16,
+    wordBreak: "break-word"
   },
   mediumOrgImage: {
     height: 30,

--- a/frontend/src/components/organization/OrganizationPreviewBody.js
+++ b/frontend/src/components/organization/OrganizationPreviewBody.js
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme) => {
       overflow: "hidden",
       WebkitBoxOrient: "vertical",
       display: "-webkit-box",
-      lineHeight: 1.25
+      lineHeight: 1.25,
     },
     summaryBox: {
       overflow: "hidden",

--- a/frontend/src/components/organization/OrganizationPreviewHeader.js
+++ b/frontend/src/components/organization/OrganizationPreviewHeader.js
@@ -10,10 +10,11 @@ const useStyles = makeStyles((theme) => {
       fontWeight: "bold",
       margin: "5px",
       overflow: "hidden",
-      lineHeight: 1.3
+      wordBreak: "break-word",
+      lineHeight: 1.3,
     },
     headerWrapper: (props) => ({
-      justifyContent: "center",  
+      justifyContent: "center",
     }),
     media: {
       height: 80,

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -39,12 +39,14 @@ const useStyles = makeStyles((theme) => ({
     paddingLeft: theme.spacing(1),
     color: theme.palette.grey[800],
     cursor: "pointer",
+    wordBreak: "break-word",
   },
   collaboratingOrganization: {
     paddingLeft: theme.spacing(1),
     paddingRight: theme.spacing(1),
     color: theme.palette.grey[800],
     cursor: "pointer",
+    breakWord: "break-word"
   },
   creatorImage: {
     height: 24,
@@ -156,6 +158,9 @@ const useStyles = makeStyles((theme) => ({
   joinButton: {
     float: "right",
   },
+  projectDescription: {
+    wordBreak: "break-word",
+  }
 }));
 
 /**
@@ -385,7 +390,7 @@ export default function ProjectContent({
         >
           {texts.project_description}
         </Typography>
-        <Typography component="div">
+        <Typography className={classes.projectDescription} component="div">
           {project.description ? (
             showFullDescription || project.description.length <= maxDisplayedDescriptionLength ? (
               <MessageContent content={project.description} renderYoutubeVideos={1} />

--- a/frontend/src/components/project/ProjectMetaData.js
+++ b/frontend/src/components/project/ProjectMetaData.js
@@ -15,6 +15,9 @@ const useStyles = makeStyles((theme) => ({
     marginRight: theme.spacing(1),
     marginBottom: -5,
   },
+  creator: {
+    wordBreak: "break-word",
+  },
   cardIcon: {
     verticalAlign: "bottom",
     marginBottom: -2,

--- a/frontend/src/components/project/ProjectOverview.js
+++ b/frontend/src/components/project/ProjectOverview.js
@@ -36,6 +36,7 @@ const useStyles = makeStyles((theme) => ({
   smallScreenHeader: {
     fontSize: "calc(1.6rem + 6 * ((100vw - 320px) / 680))",
     paddingBottom: theme.spacing(2),
+    wordBreak: "break-word",
   },
   rootLinksContainer: {
     display: "flex",
@@ -49,6 +50,7 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: "flex-start",
     cursor: "pointer",
     marginRight: theme.spacing(1),
+
   },
   linkIcon: {
     marginRight: theme.spacing(1),
@@ -58,6 +60,7 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: theme.spacing(4),
     paddingBottom: theme.spacing(4),
     textAlign: "center",
+    wordBreak: "break-word"
   },
   headerButton: {
     right: 0,
@@ -87,6 +90,9 @@ const useStyles = makeStyles((theme) => ({
     height: 40,
     minWidth: 120,
   },
+  shortDescription:{
+    wordBreak: "break-word"
+  }
 }));
 
 const componentDecorator = (href, text, key) => (
@@ -315,7 +321,7 @@ function SmallScreenOverview({
           {project.name}
         </Typography>
 
-        <Typography>{project?.short_description}</Typography>
+        <Typography className={classes.shortDescription}>{project?.short_description}</Typography>
 
         <div className={classes.projectInfoEl}>
           <Typography>
@@ -413,7 +419,7 @@ function LargeScreenOverview({
           <Typography component="h2" variant="h5" className={classes.subHeader}>
             {texts.summary}
           </Typography>
-          <Typography component="div">
+          <Typography component="div" className={classes.shortDescription}>
             <MessageContent content={project?.short_description} />
           </Typography>
           <div className={classes.projectInfoEl}>

--- a/frontend/src/components/project/ProjectPreview.js
+++ b/frontend/src/components/project/ProjectPreview.js
@@ -45,6 +45,7 @@ const useStyles = makeStyles((theme) => {
       ["&span"]: {
         whiteSpace: "nowrap",
       },
+      wordBreak: "break-word",
     },
     button: {
       marginTop: theme.spacing(1),


### PR DESCRIPTION
## Description
Added word break css to content within account page/org previews/projects page. This includes names, descriptions and websites.
Also added to org previews and org minipreviews.

## Test plan
See organization pages / organization previews in /browse. 
By editing org names/project names, websites, or project/org summaries to some very long continuous string i.e. "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE", the word should break and not push content around.

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
