### PR TITLE
Fix: Align the project parent preview and text on project page

### DIFF
--- a/frontend/pages/inbox.js
+++ b/frontend/pages/inbox.js
@@ -113,7 +113,6 @@ export default function Inbox({ chatData, initialNextPage }) {
   };
 
   const loadMoreFilteredChats = async () => {
-   
     const url = `/api/chat/?page=${searchedChatsState.nextPage}&search=${searchTerm}`;
     const response = await apiRequest({
       token: token,
@@ -129,8 +128,6 @@ export default function Inbox({ chatData, initialNextPage }) {
       nextPage: response.data.next ? searchedChatsState.nextPage + 1 : null,
       chats: [...searchedChatsState.chats, ...parsedChats],
     });
-
-    
   };
 
   const handleSetIsLoading = (newValue) => {

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -35,12 +35,13 @@ const useStyles = makeStyles((theme) => ({
     display: "block",
     fontSize: 14,
   },
-  creator: {
+  creator: (props) => ({
+    paddingTop: props.isPersonalProject && theme.spacing(0.25),
     paddingLeft: theme.spacing(1),
     color: theme.palette.grey[800],
     cursor: "pointer",
     wordBreak: "break-word",
-  },
+  }),
   collaboratingOrganization: {
     paddingLeft: theme.spacing(1),
     paddingRight: theme.spacing(1),
@@ -168,7 +169,7 @@ const useStyles = makeStyles((theme) => ({
   collaborationContainer: {
     display: "flex",
     flexDirection: "row",
-  }
+  },
 }));
 
 /**
@@ -208,7 +209,7 @@ export default function ProjectContent({
   handleSendProjectJoinRequest,
   requestedToJoinProject,
 }) {
-  const classes = useStyles();
+  const classes = useStyles({isPersonalProject: project.isPersonalProject});
   const { user, locale } = useContext(UserContext);
   const texts = getTexts({ page: "project", locale: locale, project: project });
 
@@ -327,36 +328,36 @@ export default function ProjectContent({
           </Typography>
           <div>
             <div className={classes.projectParentContainer}>
-            <Typography component="span">
-              {texts.started + " "}
-              <TimeAgo
-                date={new Date(project.start_date)}
-                formatter={locale === "de" ? germanYearAndDayFormatter : yearAndDayFormatter}
-              />{" "}
-              {texts.by}
-            </Typography>
-            {project.isPersonalProject ? (
-              <MiniProfilePreview
-                className={classes.creator}
-                profile={project.creator}
-                size="small"
-              />
-            ) : (
-              <MiniOrganizationPreview
-                size="small"
-                className={classes.creator}
-                organization={project.creator}
-              />
-            )}
-            {project.end_date && (
-              <Typography className={classes.finishedDate}>
-                {texts.finished + " "}
+              <Typography component="span">
+                {texts.started + " "}
                 <TimeAgo
-                  date={new Date(project.end_date)}
+                  date={new Date(project.start_date)}
                   formatter={locale === "de" ? germanYearAndDayFormatter : yearAndDayFormatter}
                 />{" "}
+                {texts.by}
               </Typography>
-            )}
+              {project.isPersonalProject ? (
+                <MiniProfilePreview
+                  className={classes.creator}
+                  profile={project.creator}
+                  size="small"
+                />
+              ) : (
+                <MiniOrganizationPreview
+                  size="small"
+                  className={classes.creator}
+                  organization={project.creator}
+                />
+              )}
+              {project.end_date && (
+                <Typography className={classes.finishedDate}>
+                  {texts.finished + " "}
+                  <TimeAgo
+                    date={new Date(project.end_date)}
+                    formatter={locale === "de" ? germanYearAndDayFormatter : yearAndDayFormatter}
+                  />{" "}
+                </Typography>
+              )}
             </div>
             {project.collaborating_organizations && project.collaborating_organizations.length > 0 && (
               <div className={classes.collaborationContainer}>

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -161,6 +161,14 @@ const useStyles = makeStyles((theme) => ({
   projectDescription: {
     wordBreak: "break-word",
   },
+  projectParentContainer: {
+    display: "flex",
+    flexDirection: "row",
+  },
+  collaborationContainer: {
+    display: "flex",
+    flexDirection: "row",
+  }
 }));
 
 /**
@@ -318,6 +326,7 @@ export default function ProjectContent({
             {texts.created}: <DateDisplay date={new Date(project.creation_date)} />
           </Typography>
           <div>
+            <div className={classes.projectParentContainer}>
             <Typography component="span">
               {texts.started + " "}
               <TimeAgo
@@ -348,8 +357,9 @@ export default function ProjectContent({
                 />{" "}
               </Typography>
             )}
+            </div>
             {project.collaborating_organizations && project.collaborating_organizations.length > 0 && (
-              <div>
+              <div className={classes.collaborationContainer}>
                 <span> {texts.in_collaboration_with}</span>
                 {project.collaborating_organizations.map((o) => (
                   <MiniOrganizationPreview

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -344,9 +344,9 @@ export default function ProjectContent({
                 />
               ) : (
                 <MiniOrganizationPreview
-                  size="small"
                   className={classes.creator}
                   organization={project.creator}
+                  size="small"
                 />
               )}
               {project.end_date && (


### PR DESCRIPTION
## Description

Aligns text and project parent previews and collaborators, by adding them into divs with classes that applies CSS to them.

Before
![Screenshot from 2022-11-04 08-58-30](https://user-images.githubusercontent.com/49129464/199922325-bcadcb59-56b4-4fa0-b072-6740349e26c2.png)

After
![Screenshot from 2022-11-04 08-59-21](https://user-images.githubusercontent.com/49129464/199922352-a70b6972-cf9e-4732-ad98-64bfc306fe43.png)


## Test plan

1. Go to a project page 
2. See mini project previews are properly aligned with neighbouring text

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
