### PR TITLE
Feat: Show Idea Card Info

### DIFF
--- a/backend/ideas/serializers/idea.py
+++ b/backend/ideas/serializers/idea.py
@@ -2,7 +2,7 @@ from climateconnect_api.serializers.user import UserProfileStubSerializer
 from django.utils.translation import get_language
 from hubs.serializers.hub import HubStubSerializer
 from ideas.models import Idea, IdeaSupporter
-from ideas.utility.idea import get_idea_name, get_idea_short_description
+from ideas.utility.idea import get_number_of_idea_participants, get_number_of_idea_comments, get_idea_name, get_idea_short_description
 from organization.serializers.organization import OrganizationStubSerializer
 from rest_framework import serializers
 
@@ -40,6 +40,8 @@ class IdeaMinimalSerializer(serializers.ModelSerializer):
     organization = serializers.SerializerMethodField()
     url_slug = serializers.SerializerMethodField()
     hub_shared_in = serializers.SerializerMethodField()
+    number_of_comments = serializers.SerializerMethodField()
+    number_of_participants = serializers.SerializerMethodField()
 
     class Meta:
         model = Idea
@@ -57,6 +59,8 @@ class IdeaMinimalSerializer(serializers.ModelSerializer):
             "created_at",
             "organization",
             "hub_shared_in",
+            "number_of_comments",
+            "number_of_participants"
         ]
 
     def get_name(self, obj):
@@ -104,6 +108,12 @@ class IdeaMinimalSerializer(serializers.ModelSerializer):
 
     def get_url_slug(self, obj):
         return obj.url_slug
+    
+    def get_number_of_comments(self, obj):
+        return get_number_of_idea_comments(obj)
+
+    def get_number_of_participants(self, obj):
+        return get_number_of_idea_participants(obj)
 
 
 class IdeaSerializer(serializers.ModelSerializer):

--- a/backend/ideas/serializers/idea.py
+++ b/backend/ideas/serializers/idea.py
@@ -2,7 +2,12 @@ from climateconnect_api.serializers.user import UserProfileStubSerializer
 from django.utils.translation import get_language
 from hubs.serializers.hub import HubStubSerializer
 from ideas.models import Idea, IdeaSupporter
-from ideas.utility.idea import get_number_of_idea_participants, get_number_of_idea_comments, get_idea_name, get_idea_short_description
+from ideas.utility.idea import (
+    get_number_of_idea_participants,
+    get_number_of_idea_comments,
+    get_idea_name,
+    get_idea_short_description,
+)
 from organization.serializers.organization import OrganizationStubSerializer
 from rest_framework import serializers
 
@@ -60,7 +65,7 @@ class IdeaMinimalSerializer(serializers.ModelSerializer):
             "organization",
             "hub_shared_in",
             "number_of_comments",
-            "number_of_participants"
+            "number_of_participants",
         ]
 
     def get_name(self, obj):
@@ -108,7 +113,7 @@ class IdeaMinimalSerializer(serializers.ModelSerializer):
 
     def get_url_slug(self, obj):
         return obj.url_slug
-    
+
     def get_number_of_comments(self, obj):
         return get_number_of_idea_comments(obj)
 

--- a/backend/ideas/utility/idea.py
+++ b/backend/ideas/utility/idea.py
@@ -153,21 +153,18 @@ def get_idea_short_description(idea: Idea, language_code: str) -> str:
     return idea.short_description
 
 
-def get_number_of_idea_comments(idea: Idea):    
-    return IdeaComment.objects.filter(idea=idea,
-    is_abusive=False,
-            deleted_at__isnull=True,
-            parent_comment=None,).count()
+def get_number_of_idea_comments(idea: Idea):
+    return IdeaComment.objects.filter(
+        idea=idea,
+        is_abusive=False,
+        deleted_at__isnull=True,
+        parent_comment=None,
+    ).count()
 
 
-def get_number_of_idea_participants(idea: Idea): 
-    chats = (MessageParticipants.objects.filter(
-        name=idea.name
-    ))
+def get_number_of_idea_participants(idea: Idea):
+    chats = MessageParticipants.objects.filter(name=idea.name)
     for chat in chats:
-        user_count = Participant.objects.filter(
-        chat=chat,
-        is_active=True
-        ).count()
-        
+        user_count = Participant.objects.filter(chat=chat, is_active=True).count()
+
     return user_count

--- a/backend/ideas/utility/idea.py
+++ b/backend/ideas/utility/idea.py
@@ -2,7 +2,9 @@ import logging
 import urllib.parse
 from typing import Dict, Optional
 
+from chat_messages.models.message import MessageParticipants, Participant
 
+from ideas.models.comment import IdeaComment
 from climateconnect_api.models.language import Language
 from climateconnect_main.utility.general import get_image_from_data_url
 from django.contrib.auth.models import User
@@ -149,3 +151,23 @@ def get_idea_short_description(idea: Idea, language_code: str) -> str:
         )
 
     return idea.short_description
+
+
+def get_number_of_idea_comments(idea: Idea):    
+    return IdeaComment.objects.filter(idea=idea,
+    is_abusive=False,
+            deleted_at__isnull=True,
+            parent_comment=None,).count()
+
+
+def get_number_of_idea_participants(idea: Idea): 
+    chats = (MessageParticipants.objects.filter(
+        name=idea.name
+    ))
+    for chat in chats:
+        user_count = Participant.objects.filter(
+        chat=chat,
+        is_active=True
+        ).count()
+        
+    return user_count

--- a/backend/ideas/utility/idea.py
+++ b/backend/ideas/utility/idea.py
@@ -163,8 +163,5 @@ def get_number_of_idea_comments(idea: Idea):
 
 
 def get_number_of_idea_participants(idea: Idea):
-    chats = MessageParticipants.objects.filter(name=idea.name)
-    for chat in chats:
-        user_count = Participant.objects.filter(chat=chat, is_active=True).count()
-
-    return user_count
+    chat_user_count = Participant.objects.filter(chat__name=idea.name, is_active=True).count()
+    return chat_user_count

--- a/frontend/public/texts/general_texts.json
+++ b/frontend/public/texts/general_texts.json
@@ -774,5 +774,9 @@
   "days": {
     "en": "days",
     "de": "Tage"
+  },
+  "participants": {
+    "en": "Participants",
+    "de": "Teilnehmer"
   }
 }

--- a/frontend/src/components/hub/HubHeadlineContainer.js
+++ b/frontend/src/components/hub/HubHeadlineContainer.js
@@ -107,7 +107,6 @@ export default function HubHeadlineContainer({ subHeadline, headline, isLocation
           <>
             {!isNarrowScreen && <hr />}
             {isNarrowScreen && !user ? (
-
               <div className={classes.signUpContainer}>
                 <Button
                   href={getLocalePrefix(locale) + "/signup"}
@@ -117,7 +116,6 @@ export default function HubHeadlineContainer({ subHeadline, headline, isLocation
                   {texts.sign_up_now}
                 </Button>
               </div>
-
             ) : (
               // not sure to add this button or have nothing here since there is this climatematch button on the headerbar
               // for small screen sizes

--- a/frontend/src/components/ideas/IdeaPreview.js
+++ b/frontend/src/components/ideas/IdeaPreview.js
@@ -234,7 +234,7 @@ function IdeaCardContent(idea) {
                 ? idea.idea.short_description.slice(0, 200) + "..."
                 : idea.idea.short_description}
             </Typography>
-            {(idea.idea.rating?.number_of_ratings > 0 || false) && (
+            {(idea.idea.number_of_comments > 0 || idea.idea.number_of_participants > 0) && (
               <AdditionalInfoIdeaCardPreview
                 containerName={classes.noImgAdditionalInfoContainer}
                 commentCount={idea.idea.number_of_comments}
@@ -249,7 +249,7 @@ function IdeaCardContent(idea) {
               alt={idea.idea.name}
               className={classes.placeholderImg}
             />
-            {(idea.idea.rating?.number_of_ratings > 0 || false) && (
+            {(idea.idea.rating?.number_of_ratings > 0 || idea.idea.number_of_participants > 0) && (
               <AdditionalInfoIdeaCardPreview
                 containerName={classes.imgAdditionalInfoContainer}
                 commentCount={idea.idea.number_of_comments}
@@ -270,20 +270,22 @@ function AdditionalInfoIdeaCardPreview({ containerName, commentCount, participat
   return (
     <>
       <div className={containerName}>
-        <Tooltip arrow title={texts.comments}>
-          <ModeCommentIcon className={classes.additionalInfoIcon} color="primary" />
-        </Tooltip>
-
-        <span className={classes.additionalInfoCounter}> {commentCount} </span>
-        {/* 
-        TODO: Perhaps a different icon / text is necessary as this uses the # of interactions and not participants?
-        maybe a heart icon or something different. Atm this is just following the design from the description in the issue.
-        Maybe get # of participants inside the group chat? 
-        */}
-        <Tooltip arrow title={texts.participants}>
-          <PersonAddIcon className={classes.additionalInfoIcon} color="primary" />
-        </Tooltip>
-        <span className={classes.additionalInfoCounter}> {participationCount} </span>
+        {commentCount > 0 && (
+          <>
+            <Tooltip arrow title={texts.comments}>
+              <ModeCommentIcon className={classes.additionalInfoIcon} color="primary" />
+            </Tooltip>
+            <span className={classes.additionalInfoCounter}> {commentCount} </span>
+          </>
+        )}
+        {participationCount > 0 && (
+          <>
+            <Tooltip arrow title={texts.participants}>
+              <PersonAddIcon className={classes.additionalInfoIcon} color="primary" />
+            </Tooltip>
+            <span className={classes.additionalInfoCounter}> {participationCount} </span>
+          </>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Description

Closes #962
This PR displays the number of chat participants in the group chat of the idea and the number of comments left on it.
See below for images of the changes (I don't have the category icons in my backend).

Backend changes:
- Updated serializer to include number of participants in the group chat of the idea, number is obtained via utility functions.

Frontend changes:
- IdeaPreviews has a number reflecting the number of comments/participants, alongside an icon. The number and icon will not be displayed if it is  < 1. 
- IdeaPreviews with an image will have the information displayed ontop of the image.
- IdeaPreviews without an image will have the information displayed underneath the summary text.

Before:

![77b4f7b3dcdb6677dd7fe454f2873f2d](https://user-images.githubusercontent.com/49129464/201349818-6cf14814-0a19-47f8-a235-3036248ccc60.png)


After: 

![Screenshot from 2022-11-11 14-14-29](https://user-images.githubusercontent.com/49129464/201349614-93e1caf6-0cc3-441a-bf4e-9436fc007d21.png)



## Test plan

1. Go to a Climate Hub
2. Click the ideas tab
3. See the previews now have the additional feature

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
