### PR TITLE
Fix: Project finish text alignment error

### DIFF
--- a/frontend/src/components/hub/HubHeadlineContainer.js
+++ b/frontend/src/components/hub/HubHeadlineContainer.js
@@ -107,7 +107,6 @@ export default function HubHeadlineContainer({ subHeadline, headline, isLocation
           <>
             {!isNarrowScreen && <hr />}
             {isNarrowScreen && !user ? (
-
               <div className={classes.signUpContainer}>
                 <Button
                   href={getLocalePrefix(locale) + "/signup"}
@@ -117,7 +116,6 @@ export default function HubHeadlineContainer({ subHeadline, headline, isLocation
                   {texts.sign_up_now}
                 </Button>
               </div>
-
             ) : (
               // not sure to add this button or have nothing here since there is this climatematch button on the headerbar
               // for small screen sizes

--- a/frontend/src/components/project/ProjectContent.js
+++ b/frontend/src/components/project/ProjectContent.js
@@ -153,9 +153,6 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: theme.palette.error.main,
     },
   },
-  finishedDate: {
-    marginTop: theme.spacing(0.5),
-  },
   joinButton: {
     float: "right",
   },
@@ -349,16 +346,17 @@ export default function ProjectContent({
                   size="small"
                 />
               )}
-              {project.end_date && (
-                <Typography className={classes.finishedDate}>
-                  {texts.finished + " "}
-                  <TimeAgo
-                    date={new Date(project.end_date)}
-                    formatter={locale === "de" ? germanYearAndDayFormatter : yearAndDayFormatter}
-                  />{" "}
-                </Typography>
-              )}
             </div>
+            {project.end_date && (
+              <Typography>
+                {texts.finished + " "}
+                <TimeAgo
+                  date={new Date(project.end_date)}
+                  formatter={locale === "de" ? germanYearAndDayFormatter : yearAndDayFormatter}
+                />{" "}
+              </Typography>
+            )}
+
             {project.collaborating_organizations && project.collaborating_organizations.length > 0 && (
               <div className={classes.collaborationContainer}>
                 <span> {texts.in_collaboration_with}</span>


### PR DESCRIPTION
## Description
Closes #1130
Moved project finish text into its own line so it doesn't look out of place.

Before:
![Screenshot from 2022-11-11 14-44-18](https://user-images.githubusercontent.com/49129464/201357439-6b857b6b-e23f-44b9-aa9b-da2992b8f6e3.png)
After:
![Screenshot from 2022-11-11 15-09-32](https://user-images.githubusercontent.com/49129464/201357505-0859b0cd-4aff-4355-93d7-05e61b1e1e37.png)

## Test plan

1. Go to project page of project which status is finished.
2. See correction

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
