### PR TITLE
Fix: Runtime Error When Closing Categories Dialog in Edit Project

### DIFF
--- a/frontend/src/components/editProject/EditProjectOverview.js
+++ b/frontend/src/components/editProject/EditProjectOverview.js
@@ -341,7 +341,11 @@ const InputTags = ({ project, handleChangeProject, tagsOptions, texts }) => {
     setOpen(true);
   };
 
-  const handleCategoriesDialogClose = (tags) => {
+  const handleCloseDialog = () => {
+    setOpen(false);
+  };
+
+  const handleSaveSelection = (tags) => {
     if (tags) handleChangeProject(tags, "tags");
     setOpen(false);
   };
@@ -378,7 +382,8 @@ const InputTags = ({ project, handleChangeProject, tagsOptions, texts }) => {
       )}
       <MultiLevelSelectDialog
         open={open}
-        onClose={handleCategoriesDialogClose}
+        onSave={handleSaveSelection}
+        onClose={handleCloseDialog}
         type="categories"
         options={tagsOptions}
         items={project.tags}

--- a/frontend/src/components/hub/HubHeadlineContainer.js
+++ b/frontend/src/components/hub/HubHeadlineContainer.js
@@ -107,7 +107,6 @@ export default function HubHeadlineContainer({ subHeadline, headline, isLocation
           <>
             {!isNarrowScreen && <hr />}
             {isNarrowScreen && !user ? (
-
               <div className={classes.signUpContainer}>
                 <Button
                   href={getLocalePrefix(locale) + "/signup"}
@@ -117,7 +116,6 @@ export default function HubHeadlineContainer({ subHeadline, headline, isLocation
                   {texts.sign_up_now}
                 </Button>
               </div>
-
             ) : (
               // not sure to add this button or have nothing here since there is this climatematch button on the headerbar
               // for small screen sizes


### PR DESCRIPTION
## Description

Closes #1132 

Underlying issue was that `tags` was being passed a `SyntheticBaseEvent` and it was using that to call `handleChangeProject` within the function `handleCategoriesDialogClose`.

Solution: Separate the button clicks for save & close with 2 different functions. `handleCategoriesDialogClose` & `handleSaveSelection`. Using the onSave prop of the `MultiSelectDialog` to call `handleSaveSelection`.
    

## Test plan

1. Go to edit project
2. Go to edit categores
3. Click close
4. Dialog should close without errors

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
