### PR TITLE
Fix: Runtime Error When Closing Skills Dialog in Edit Project

### DIFF
--- a/frontend/src/components/editProject/EditProjectContent.js
+++ b/frontend/src/components/editProject/EditProjectContent.js
@@ -189,7 +189,7 @@ export default function EditProjectContent({
         <div className={classes.block}>
           {project.is_personal_project ? (
             <>
-              Created by
+              {texts.created_by}
               <MiniProfilePreview
                 className={classes.creator}
                 profile={project.project_parents.parent_user}

--- a/frontend/src/components/editProject/EditProjectContent.js
+++ b/frontend/src/components/editProject/EditProjectContent.js
@@ -95,6 +95,10 @@ export default function EditProjectContent({
     setOpen({ ...open, skills: true });
   };
 
+  const handleSkillsDialogClose = () => {
+    setOpen({ ...open, skills: false });
+  };
+
   const handleSkillDelete = (skill) => {
     handleSetProject({
       ...project,
@@ -103,7 +107,7 @@ export default function EditProjectContent({
     setSelectedItems(project.skills.filter((s) => s.id !== skill.id));
   };
 
-  const handleSkillsDialogClose = (skills) => {
+  const handleSkillsDialogSave = (skills) => {
     if (skills) handleSetProject({ ...project, skills: skills });
     setOpen({ ...open, skills: false });
   };
@@ -350,6 +354,7 @@ export default function EditProjectContent({
       <MultiLevelSelectDialog
         open={open.skills}
         onClose={handleSkillsDialogClose}
+        onSave={handleSkillsDialogSave}
         type="skills"
         options={skillsOptions}
         items={project.skills}


### PR DESCRIPTION
## Description

Closes #1048

Underlying issue was that `skills` was being passed a `SyntheticBaseEvent `and it was using that to call ` handleSetProject` within the function `handleSkillsDialogClose `.

Solution: Separate the button clicks for save & close with 2 different functions. `handleSkillsDialogClose `& `handleSkillsDialogSave`. Using the onSave prop of the `MultiSelectDialog `to call `handleSkillsDialogSave`.

This PR also handles the change of a hard coded string and instead uses `texts`.

## Test plan
-- Skills
1. Go to edit project
2. Scroll down to skills
3. Click edit skills
4. Click close button
5. Dialog should close without errors

-- Text change
1. Make the project a personal project
2. See text "Created by"/"Erstellt von" under the slider, next to the name of the creator

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
