### PR TITLE
Feat: Add search field for chat IDs in django admin

### DIFF
--- a/backend/chat_messages/admin.py
+++ b/backend/chat_messages/admin.py
@@ -6,7 +6,14 @@ from chat_messages.models.message import (
     MessageReceiver,
 )
 
-pass_through_models = (MessageParticipants, Participant, Message, MessageReceiver)
+pass_through_models = (MessageParticipants, Participant, MessageReceiver)
 
 for model in pass_through_models:
     admin.site.register(model, admin.ModelAdmin)
+
+class MessageAdmin(admin.ModelAdmin):
+    search_fields = (
+        "message_participant__id",
+    )
+
+admin.site.register(Message, MessageAdmin)


### PR DESCRIPTION
## Description

Add the ability to search for the chat ids of chat messages within django admin.

## Test plan

1. Open django admin
2. Click on messages
3. Enter an integer in the search field

## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
