### PR TITLE
Fix: Add Exact Filtering To The Chat Id in Django Admin

### DIFF
--- a/backend/chat_messages/admin.py
+++ b/backend/chat_messages/admin.py
@@ -13,7 +13,7 @@ for model in pass_through_models:
 
 class MessageAdmin(admin.ModelAdmin):
     search_fields = (
-        "message_participant__id",
+        "message_participant__id__exact",
     )
 
 admin.site.register(Message, MessageAdmin)


### PR DESCRIPTION
## Description

This PR adds a modification that enables exact filtering of chat ids rather than all the chats containing the searched substring.


## Before landing

1. PR has meaningful title
1. `yarn lint` passes (frontend)
1. `yarn format` passes (frontend)
1. `make format` passes (backend)
