### PR TITLE
Bump psycopg2 dep in requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -62,7 +62,7 @@ Pillow==9.3.0
 platformdirs==2.5.4
 prompt-toolkit==3.0.14
 protobuf==3.18.3
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.5
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycodestyle==2.8.0


### PR DESCRIPTION
## What and Why

Previous version wasn't compatible with 3.10; see https://github.com/psycopg/psycopg2/issues/1529.