### PR TITLE
Only allow viewing and accepting project join requests with correct permissions

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,6 +1,3 @@
-install:
-	pip3 install -r requirements.txt
-
 default: start
 
 start:
@@ -8,6 +5,9 @@ start:
 	$(info -- Starting server --)
 	$(info )
 	python3 manage.py runserver
+
+install:
+	pip3 install -r requirements.txt
 
 test:
 	python3 manage.py test

--- a/backend/chat_messages/utility/chat_setup.py
+++ b/backend/chat_messages/utility/chat_setup.py
@@ -74,7 +74,7 @@ def check_can_start_chat(user_profile: UserProfile) -> bool:
         print("forbidden because user profile is restricted")
         return "User profile restricted"
     # Users with special permissions aren't restricted
-    if(user_profile.user.has_perm("chat_messages.create_unlimited_messageparticipants")):
+    if user_profile.user.has_perm("chat_messages.create_unlimited_messageparticipants"):
         return True
     # You can only start up to 4 chats within a 180 minute timeframe
     cooldown_minutes_for_starting_chats = 180
@@ -88,7 +88,9 @@ def check_can_start_chat(user_profile: UserProfile) -> bool:
         created_by=user_profile.user, created_at__gte=cutoff_date
     ).order_by("-created_at")
     if affected_chats.count() >= max_new_chats_per_timeframe:
-        minutes_since_last_chat = (datetime.now() - affected_chats[0].created_at.replace(tzinfo=None)).total_seconds() / 60
+        minutes_since_last_chat = (
+            datetime.now() - affected_chats[0].created_at.replace(tzinfo=None)
+        ).total_seconds() / 60
         print("too many chats started: " + str(affected_chats.count()))
         return _(
             "Currently you can only contact %(max_chats_per_timeframe)d new people within %(hours)d hours. You can start a new chat in %(minutes)d minutes."

--- a/backend/chat_messages/views/message_views.py
+++ b/backend/chat_messages/views/message_views.py
@@ -91,9 +91,9 @@ class StartPrivateChat(APIView):
         print("checking whether user can send message")
         can_start_chat = check_can_start_chat(request.user.user_profile)
         if not can_start_chat == True:
-            return Response({
-                "message": can_start_chat
-            }, status=status.HTTP_403_FORBIDDEN)
+            return Response(
+                {"message": can_start_chat}, status=status.HTTP_403_FORBIDDEN
+            )
 
         chatting_partner_user = user_profile.user
         participants = [request.user, chatting_partner_user]
@@ -113,7 +113,9 @@ class StartPrivateChat(APIView):
         if private_chat_with_both_users.exists():
             private_chat = private_chat_with_both_users[0]
         else:
-            private_chat = MessageParticipants.objects.create(chat_uuid=str(uuid4()), created_by=request.user)
+            private_chat = MessageParticipants.objects.create(
+                chat_uuid=str(uuid4()), created_by=request.user
+            )
             basic_role = Role.objects.get(role_type=0)
             for participant in participants:
                 Participant.objects.create(
@@ -138,9 +140,9 @@ class StartGroupChatView(APIView):
             )
         can_start_chat = check_can_start_chat(request.user.user_profile)
         if not can_start_chat == True:
-            return Response({
-                "message": can_start_chat
-            }, status=status.HTTP_403_FORBIDDEN)
+            return Response(
+                {"message": can_start_chat}, status=status.HTTP_403_FORBIDDEN
+            )
 
         if "participants" not in request.data or "group_chat_name" not in request.data:
             return Response(
@@ -157,7 +159,9 @@ class StartGroupChatView(APIView):
             )
 
         chat = MessageParticipants.objects.create(
-            chat_uuid=str(uuid4()), name=request.data["group_chat_name"], created_by=request.user
+            chat_uuid=str(uuid4()),
+            name=request.data["group_chat_name"],
+            created_by=request.user,
         )
         creator_role = Role.objects.get(role_type=2)
         member_role = Role.objects.get(role_type=0)
@@ -432,17 +436,21 @@ class SendChatMessage(APIView):
         if chat:
             # Check if this is a first message and restrict sending a message
             # if its a cold-message.
-            message_count = Message.objects.filter(
-                message_participant=chat
-            ).count()
-            num_of_words_on_a_message = len(request.data.get('message_content').split())
+            message_count = Message.objects.filter(message_participant=chat).count()
+            num_of_words_on_a_message = len(request.data.get("message_content").split())
 
-            if message_count == 0 and num_of_words_on_a_message < NUM_OF_WORDS_REQUIRED_FOR_FIRST_MESSAGE:
-                return Response({
-                    'detail': f'Dear {user.user_profile.name}, This is your first'
-                    f' interaction with a member on the platform. Please introduce yourself and the reason for'
-                    f' your outreach in {NUM_OF_WORDS_REQUIRED_FOR_FIRST_MESSAGE} or more words.'
-                }, status=status.HTTP_411_LENGTH_REQUIRED)
+            if (
+                message_count == 0
+                and num_of_words_on_a_message < NUM_OF_WORDS_REQUIRED_FOR_FIRST_MESSAGE
+            ):
+                return Response(
+                    {
+                        "detail": f"Dear {user.user_profile.name}, This is your first"
+                        f" interaction with a member on the platform. Please introduce yourself and the reason for"
+                        f" your outreach in {NUM_OF_WORDS_REQUIRED_FOR_FIRST_MESSAGE} or more words."
+                    },
+                    status=status.HTTP_411_LENGTH_REQUIRED,
+                )
             receiver_user_ids = Participant.objects.filter(
                 chat=chat, is_active=True
             ).values_list("user", flat=True)

--- a/backend/climateconnect_api/models/user.py
+++ b/backend/climateconnect_api/models/user.py
@@ -322,7 +322,7 @@ class UserProfile(models.Model):
     restricted_profile = models.BooleanField(
         help_text="Restrict user profile to perform certain actions on the platform.",
         verbose_name="Is profile restricted?",
-        default=False
+        default=False,
     )
 
     class Meta:

--- a/backend/climateconnect_api/utility/translation.py
+++ b/backend/climateconnect_api/utility/translation.py
@@ -11,6 +11,7 @@ from rest_framework.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 
+
 def get_locale(language_code):
     LANGUAGE_CODE_MAP = {
         "en-us": "en",
@@ -62,9 +63,7 @@ def translate(text, target_lang):
     if target_lang == "de":
         payload["formality"] = "less"
 
-    url = (
-        "https://api.deepl.com/v2/translate?auth_key=" + settings.DEEPL_API_KEY
-    )
+    url = "https://api.deepl.com/v2/translate?auth_key=" + settings.DEEPL_API_KEY
     translation = requests.post(url, payload)
     return json.loads(translation.content)["translations"][0]
 

--- a/backend/climateconnect_main/settings.py
+++ b/backend/climateconnect_main/settings.py
@@ -341,5 +341,5 @@ sentry_sdk.init(
 )
 
 CLIMATE_CONNECT_CONTACT_EMAIL = env(
-    'CLIMATE_CONNECT_CONTACT_EMAIL', 'contact@climateconnect.earth'
+    "CLIMATE_CONNECT_CONTACT_EMAIL", "contact@climateconnect.earth"
 )

--- a/backend/organization/permissions.py
+++ b/backend/organization/permissions.py
@@ -8,6 +8,7 @@ from organization.models import (
     ProjectParents,
 )
 from climateconnect_api.models import Role
+from django.db.models import Q
 
 
 class OrganizationProjectCreationPermission(BasePermission):
@@ -61,7 +62,7 @@ class ProjectReadWritePermission(BasePermission):
         return False
 
 
-class ReadSensibleProjectDataPermission(BasePermission):
+class ReadWriteSensibleProjectDataPermission(BasePermission):
     def has_permission(self, request, view):
         try:
             project = Project.objects.get(url_slug=str(view.kwargs.get("url_slug")))
@@ -69,7 +70,12 @@ class ReadSensibleProjectDataPermission(BasePermission):
             return False
 
         if ProjectMember.objects.filter(
-            user=request.user, role__role_type=Role.ALL_TYPE, project=project
+            Q(user=request.user)
+            & Q(
+                Q(role__role_type=Role.ALL_TYPE)
+                | Q(role__role_type=Role.READ_WRITE_TYPE)
+            )
+            & Q(project=project)
         ).exists():
             return True
         return False

--- a/backend/organization/permissions.py
+++ b/backend/organization/permissions.py
@@ -68,7 +68,6 @@ class ReadWriteSensibleProjectDataPermission(BasePermission):
             project = Project.objects.get(url_slug=str(view.kwargs.get("url_slug")))
         except Project.DoesNotExist:
             return False
-
         if ProjectMember.objects.filter(
             Q(user=request.user)
             & Q(
@@ -316,7 +315,7 @@ class ApproveDenyProjectMemberRequest(BasePermission):
             return False
 
         project = Project.objects.filter(
-            url_slug=str(view.kwargs.get("project_slug"))
+            url_slug=str(view.kwargs.get("url_slug"))
         ).first()
 
         # When calling from the POST in ManageJoinProjectView, Verify

--- a/backend/organization/urls.py
+++ b/backend/organization/urls.py
@@ -169,6 +169,13 @@ urlpatterns = [
         project_views.ListProjectRequestersView.as_view(),
         name="list-requesters-view",
     ),
+    # This endpoint returns whether the user
+    # calling it has an open join request
+    path(
+        "projects/<str:url_slug>/have_i_requested_to_join/",
+        project_views.HasUserRequested.as_view(),
+        name="have-i-requested-to-join-project",
+    ),
     path(
         "projects/<str:url_slug>/likes/",
         project_views.ListProjectLikesView.as_view(),

--- a/backend/organization/urls.py
+++ b/backend/organization/urls.py
@@ -138,14 +138,9 @@ urlpatterns = [
         name="set-like-view",
     ),
     path(
-        "projects/<str:url_slug>/am_i_following/",
-        project_views.IsUserFollowing.as_view(),
+        "projects/<str:url_slug>/my_interactions/",
+        project_views.GetUserInteractionsWithProjectView.as_view(),
         name="am-i-following-view",
-    ),
-    path(
-        "projects/<str:url_slug>/am_i_liking/",
-        project_views.IsUserLiking.as_view(),
-        name="am-i-liking-view",
     ),
     path(
         "projects/<str:url_slug>/comment/",
@@ -168,13 +163,6 @@ urlpatterns = [
         "projects/<str:url_slug>/requesters/",
         project_views.ListProjectRequestersView.as_view(),
         name="list-requesters-view",
-    ),
-    # This endpoint returns whether the user
-    # calling it has an open join request
-    path(
-        "projects/<str:url_slug>/have_i_requested_to_join/",
-        project_views.HasRequestedToJoinProjectView.as_view(),
-        name="have-i-requested-to-join-project",
     ),
     path(
         "projects/<str:url_slug>/likes/",

--- a/backend/organization/urls.py
+++ b/backend/organization/urls.py
@@ -207,12 +207,12 @@ urlpatterns = [
         name="leave-project",
     ),
     path(
-        "projects/<str:project_slug>/request_membership/<str:user_slug>/",
+        "projects/<str:url_slug>/request_membership/<str:user_slug>/",
         project_views.RequestJoinProject.as_view(),
         name="request-join-entity",
     ),
     path(
-        "projects/<str:project_slug>/request_membership/<str:request_action>/<str:request_id>/",
+        "projects/<str:url_slug>/request_membership/<str:request_action>/<str:request_id>/",
         project_views.ManageJoinProjectView.as_view(),
         name="request-membership-action-entity",
     ),

--- a/backend/organization/urls.py
+++ b/backend/organization/urls.py
@@ -173,7 +173,7 @@ urlpatterns = [
     # calling it has an open join request
     path(
         "projects/<str:url_slug>/have_i_requested_to_join/",
-        project_views.HasUserRequested.as_view(),
+        project_views.HasRequestedToJoinProjectView.as_view(),
         name="have-i-requested-to-join-project",
     ),
     path(

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -1065,12 +1065,8 @@ class ListProjectRequestersView(ListAPIView):
 
 
 class HasRequestedToJoinProjectView(APIView):
+    permission_classes = [IsAuthenticated]
     def get(self, request, url_slug):
-        if not request.user.is_authenticated:
-            return Response(
-                data={"message": f"You need to be logged in to use this endpoint"},
-                status=status.HTTP_401_UNAUTHORIZED,
-            )
         try:
             project = Project.objects.get(url_slug=self.kwargs["url_slug"])
         except Project.DoesNotExist:

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -1064,7 +1064,7 @@ class ListProjectRequestersView(ListAPIView):
         return open_membership_requests
 
 
-class HasUserRequested(APIView):
+class HasRequestedToJoinProjectView(APIView):
     def get(self, request, url_slug):
         if not request.user.is_authenticated:
             return Response(

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -1172,7 +1172,7 @@ class RequestJoinProject(RetrieveUpdateAPIView):
 
     permission_classes = (IsAuthenticated,)
 
-    def post(self, request, user_slug, project_slug):
+    def post(self, request, user_slug, url_slug):
         required_params = ["user_availability", "message"]
         missing_param = any([param not in request.data for param in required_params])
         if missing_param:
@@ -1193,7 +1193,7 @@ class RequestJoinProject(RetrieveUpdateAPIView):
             )
 
         try:
-            project = Project.objects.get(url_slug=project_slug)
+            project = Project.objects.get(url_slug=url_slug)
         except Project.DoesNotExist:
             return Response(
                 {"message": "Requested project does not exist"},
@@ -1262,11 +1262,11 @@ class ManageJoinProjectView(RetrieveUpdateDestroyAPIView):
 
     serializer_class = ProjectMemberSerializer
 
-    lookup_field = "project_slug"
+    lookup_field = "url_slug"
 
-    def post(self, request, project_slug, request_action, request_id):
+    def post(self, request, url_slug, request_action, request_id):
         try:
-            project = Project.objects.filter(url_slug=project_slug).first()
+            project = Project.objects.filter(url_slug=url_slug).first()
         except:
             return Response(
                 {"message": "Project Does Not Exist"}, status=status.HTTP_404_NOT_FOUND

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -1063,9 +1063,10 @@ class ListProjectRequestersView(ListAPIView):
 
         return open_membership_requests
 
+
 class HasUserRequested(APIView):
     def get(self, request, url_slug):
-        if(not request.user.is_authenticated):
+        if not request.user.is_authenticated:
             return Response(
                 data={"message": f"You need to be logged in to use this endpoint"},
                 status=status.HTTP_401_UNAUTHORIZED,
@@ -1081,13 +1082,14 @@ class HasUserRequested(APIView):
             target_project=project,
             rejected_at=None,
             approved_at=None,
-            user=self.request.user
+            user=self.request.user,
         ).exists()
 
         return Response(
-                data={"has_requested": has_open_membership_request},
-                status=status.HTTP_200_OK,
-            )
+            data={"has_requested": has_open_membership_request},
+            status=status.HTTP_200_OK,
+        )
+
 
 class ListProjectLikesView(ListAPIView):
     permission_classes = [IsAuthenticated]

--- a/frontend/pages/donate.tsx
+++ b/frontend/pages/donate.tsx
@@ -102,10 +102,10 @@ const useStyles = makeStyles((theme) => {
 });
 
 export async function getServerSideProps(ctx) {
-  if(process.env.DONATION_CAMPAIGN_RUNNING !== "true")
+  if (process.env.DONATION_CAMPAIGN_RUNNING !== "true")
     return {
-      props: {}
-    }
+      props: {},
+    };
   const { goal_name, goal_amount, current_amount } = (await getDonations(ctx.locale))!;
   return {
     props: {

--- a/frontend/public/lib/projectOperations.ts
+++ b/frontend/public/lib/projectOperations.ts
@@ -1,0 +1,26 @@
+import { CcLocale, User } from "../../src/types";
+import { apiRequest } from "./apiOperations";
+
+/**
+ * Calls endpoint to return a current list
+ * of users that have requested to
+ * join a specific project (i.e. requested membership).
+ *
+ * Note that the response includes a list of requests
+ * (with corresponding request ID), and the users themselves.
+ */
+ export async function getMembershipRequests(url_slug: string, locale: CcLocale, token: string) {
+  try{
+    const resp = await apiRequest({
+      method: "get",
+      url: `/api/projects/${url_slug}/requesters/`,
+      locale: locale,
+      token: token
+    });
+  
+    // TODO: we should probably have an associated timestamp with each request too.
+    return resp.data.results;
+  } catch(e) {
+    throw e
+  }
+}

--- a/frontend/public/lib/projectOperations.ts
+++ b/frontend/public/lib/projectOperations.ts
@@ -9,18 +9,18 @@ import { apiRequest } from "./apiOperations";
  * Note that the response includes a list of requests
  * (with corresponding request ID), and the users themselves.
  */
- export async function getMembershipRequests(url_slug: string, locale: CcLocale, token: string) {
-  try{
+export async function getMembershipRequests(url_slug: string, locale: CcLocale, token: string) {
+  try {
     const resp = await apiRequest({
       method: "get",
       url: `/api/projects/${url_slug}/requesters/`,
       locale: locale,
-      token: token
+      token: token,
     });
-  
+
     // TODO: we should probably have an associated timestamp with each request too.
     return resp.data.results;
-  } catch(e) {
-    throw e
+  } catch (e) {
+    throw e;
   }
 }

--- a/frontend/public/texts/general_texts.json
+++ b/frontend/public/texts/general_texts.json
@@ -778,5 +778,9 @@
   "participants": {
     "en": "Participants",
     "de": "Teilnehmer"
+  },
+  "no_permission": {
+    "en": "You do not have permission to do this.",
+    "de": "Dir fehlen die Berechtigungen für diese Aktion."
   }
 }

--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -968,5 +968,9 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       en: "View all projects",
       de: "Alle Projekte anzeigen",
     },
+    only_project_admins_can_view_join_requests: {
+      en: "Only project admins can view join requests.",
+      de: "Nur Projektadministratoren können sehen, wer mitmachen möchte."
+    }
   };
 }

--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -970,7 +970,11 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
     },
     only_project_admins_can_view_join_requests: {
       en: "Only project admins can view join requests.",
-      de: "Nur Projektadministratoren können sehen, wer mitmachen möchte."
+      de: "Nur Projektadministratoren können sehen, wer mitmachen möchte.",
+    },
+    your_request_has_been_sent: {
+      en: "We notified the project owner that you would like to join this project.",
+      de: "Die Projektverantwortlichen wurden benachrichtigt, dass du gerne mitmachen möchtest."
     }
   };
 }

--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -974,7 +974,7 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
     },
     your_request_has_been_sent: {
       en: "We notified the project owner that you would like to join this project.",
-      de: "Die Projektverantwortlichen wurden benachrichtigt, dass du gerne mitmachen möchtest."
-    }
+      de: "Die Projektverantwortlichen wurden benachrichtigt, dass du gerne mitmachen möchtest.",
+    },
   };
 }

--- a/frontend/src/components/communication/InputWithMentions.tsx
+++ b/frontend/src/components/communication/InputWithMentions.tsx
@@ -47,7 +47,6 @@ const useStyles = makeStyles((theme) => ({
 export default function InputWithMentions({ baseUrl, value, onChange, placeholder, onKeyDown }) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
-  const mentionsInputRef = useRef(null);
 
   //TODO: This function might have to be throttled in the future
   function lookupUsers(searchValue, callback) {
@@ -72,7 +71,6 @@ export default function InputWithMentions({ baseUrl, value, onChange, placeholde
       <div className={classes.InputWithMentionsBox}>
         <MentionsInput
           value={value}
-          ref={mentionsInputRef}
           className={classes.messageInput}
           onChange={onChange}
           placeholder={placeholder}

--- a/frontend/src/components/dialogs/ProjectRequestersDialog.tsx
+++ b/frontend/src/components/dialogs/ProjectRequestersDialog.tsx
@@ -64,7 +64,7 @@ export default function ProjectRequestersDialog({
   requesters,
   url,
   user,
-  user_permission
+  user_permission,
 }) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
@@ -78,51 +78,46 @@ export default function ProjectRequestersDialog({
     <GenericDialog onClose={handleClose} open={open} title={texts.project_requesters_dialog_title}>
       <>
         {
-        // If we don't have any permissions, we can't load the join requests
-        !user_permission ? (
-          <Typography className={classes.noOpenRequestsText}>
-            {texts.only_project_admins_can_view_join_requests}
-          </Typography>
-        ) :
-        loading ? (
-          <LinearProgress />
-        ) : !user ? (
-          <>
-            <Typography>
-              {texts.please_log_in + " " + texts.to_see_this_projects_requesters + "!"}
+          // If we don't have any permissions, we can't load the join requests
+          !user_permission ? (
+            <Typography className={classes.noOpenRequestsText}>
+              {texts.only_project_admins_can_view_join_requests}
             </Typography>
-            <Container className={classes.loginButtonContainer}>
-              <Button
-                className={classes.loginButton}
-                variant="contained"
-                color="primary"
-                href={getLocalePrefix(locale) + "/signin?redirect=" + encodeURIComponent(url)}
-              >
-                {texts.log_in}
-              </Button>
-            </Container>
-          </>
-        ) : // If there are users requesting to join and we have permission to view them: render them!
-        requesters && requesters.length > 0 ? (
-          <ProjectRequesters
-            onClose={onClose}
-            project={project}
-            initialRequesters={requesters}
-          />
-        ) : (
-          <Typography className={classes.noOpenRequestsText}>
-            {texts.no_open_project_join_requests}
-          </Typography>
-        )}
+          ) : loading ? (
+            <LinearProgress />
+          ) : !user ? (
+            <>
+              <Typography>
+                {texts.please_log_in + " " + texts.to_see_this_projects_requesters + "!"}
+              </Typography>
+              <Container className={classes.loginButtonContainer}>
+                <Button
+                  className={classes.loginButton}
+                  variant="contained"
+                  color="primary"
+                  href={getLocalePrefix(locale) + "/signin?redirect=" + encodeURIComponent(url)}
+                >
+                  {texts.log_in}
+                </Button>
+              </Container>
+            </>
+          ) : // If there are users requesting to join and we have permission to view them: render them!
+          requesters && requesters.length > 0 ? (
+            <ProjectRequesters onClose={onClose} project={project} initialRequesters={requesters} />
+          ) : (
+            <Typography className={classes.noOpenRequestsText}>
+              {texts.no_open_project_join_requests}
+            </Typography>
+          )
+        }
       </>
     </GenericDialog>
   );
 }
 
 const ProjectRequesters = ({ initialRequesters, project, onClose }) => {
-
   const [requesters, setRequesters] = useState(initialRequesters);
-  const { locale } = useContext(UserContext)
+  const { locale } = useContext(UserContext);
   const cookies = new Cookies();
   const token = cookies.get("auth_token");
   /**
@@ -131,11 +126,11 @@ const ProjectRequesters = ({ initialRequesters, project, onClose }) => {
    * current list.
    */
   async function handleUpdateRequesters() {
-    try{
-      const newRequesters = await getMembershipRequests(project.url_slug, locale, token)
+    try {
+      const newRequesters = await getMembershipRequests(project.url_slug, locale, token);
       setRequesters(newRequesters);
-    } catch(e){
-      console.log(e)
+    } catch (e) {
+      console.log(e);
     }
   }
 
@@ -170,10 +165,12 @@ const ProjectRequesters = ({ initialRequesters, project, onClose }) => {
  */
 const Requester = ({ handleUpdateRequesters, locale, project, requester, requestId, token }) => {
   const classes = useStyles();
-  const { showFeedbackMessage } = useContext(FeedbackContext)
-  const texts = getTexts({"page": "general", "locale": locale})
-  async function handleRequest(approve: boolean) : Promise<void> {
-    const url = `/api/projects/${project.url_slug}/request_membership/${approve ? "approve" : "reject"}/${requestId}/`
+  const { showFeedbackMessage } = useContext(FeedbackContext);
+  const texts = getTexts({ page: "general", locale: locale });
+  async function handleRequest(approve: boolean): Promise<void> {
+    const url = `/api/projects/${project.url_slug}/request_membership/${
+      approve ? "approve" : "reject"
+    }/${requestId}/`;
     try {
       await apiRequest({
         method: "post",
@@ -182,24 +179,24 @@ const Requester = ({ handleUpdateRequesters, locale, project, requester, request
         headers: {
           Authorization: `Token ${token}`,
         },
-        payload: {}
+        payload: {},
       });
       showFeedbackMessage({
         message: texts.no_permission,
-        success: true
-      })
+        success: true,
+      });
       // Now notify parent list to update current list
       // of requesters to immediately
       // show the updated state in the UI.
       handleUpdateRequesters();
     } catch (e) {
-      if(e.response.status === 401) {
+      if (e.response.status === 401) {
         showFeedbackMessage({
           message: texts.no_permission,
-          error: true
-        })
+          error: true,
+        });
       }
-      console.log(e)
+      console.log(e);
     }
   }
 
@@ -234,7 +231,11 @@ const Requester = ({ handleUpdateRequesters, locale, project, requester, request
         </Tooltip>
 
         <Tooltip title="Deny">
-          <IconButton aria-label="deny project request" disableRipple onClick={() => handleRequest(false)}>
+          <IconButton
+            aria-label="deny project request"
+            disableRipple
+            onClick={() => handleRequest(false)}
+          >
             <BlockIcon />
           </IconButton>
         </Tooltip>

--- a/frontend/src/components/project/ProjectContent.tsx
+++ b/frontend/src/components/project/ProjectContent.tsx
@@ -22,6 +22,7 @@ import ProjectStatus from "./ProjectStatus";
 import ROLE_TYPES from "../../../public/data/role_types";
 import UserContext from "../context/UserContext";
 import JoinButton from "./Buttons/JoinButton";
+import { getMembershipRequests } from "../../../public/lib/projectOperations";
 
 const MAX_DISPLAYED_DESCRIPTION_LENGTH = 500;
 
@@ -169,28 +170,6 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-/**
- * Calls endpoint to return a current list
- * of users that have requested to
- * join a specific project (i.e. requested membership).
- *
- * Note that the response includes a list of requests
- * (with corresponding request ID), and the users themselves.
- */
-async function getMembershipRequests(url_slug) {
-  const resp = await apiRequest({
-    method: "get",
-    url: `/api/projects/${url_slug}/requesters/`,
-  });
-
-  if (!resp?.data?.results) {
-    // TODO: error appropriately here
-  }
-
-  // TODO: we should probably have an associated timestamp with each request too.
-  return resp.data.results;
-}
-
 export default function ProjectContent({
   collaborationSectionRef,
   discussionTabLabel,
@@ -205,6 +184,7 @@ export default function ProjectContent({
   toggleShowRequests,
   handleSendProjectJoinRequest,
   requestedToJoinProject,
+  token
 }) {
   const classes = useStyles({ isPersonalProject: project.isPersonalProject });
   const { user, locale } = useContext(UserContext);
@@ -221,20 +201,27 @@ export default function ProjectContent({
   const [requestersRetrieved, setRequestersRetrieved] = useState(false);
   // Fetch and populate requesters on initial load
   useEffect(async () => {
+    //short circuit if the user doesn't have the necessary permissions to see join requests
+    if(!(user_permission && hasAdminPermissions)) {
+      return
+    }
     // Returns an array of objects with an ID (request ID) and
     // associated user profile.
-    const membershipRequests = await getMembershipRequests(project.url_slug);
-
-    // Now transform to a shape of objects where a specific request ID is
-    // alongside a user profile.
-    const userRequests = membershipRequests.map((r) => {
-      const user = {};
-      user.requestId = r.id;
-      user.user = r.user_profile;
-      return user;
-    });
-    setRequesters(userRequests);
-    setRequestersRetrieved(true);
+    try{
+      const membershipRequests = await getMembershipRequests(project.url_slug, locale, token);
+      // Now transform to a shape of objects where a specific request ID is
+      // alongside a user profile.
+      const userRequests = membershipRequests.map((r) => {
+        const user = {};
+        user.requestId = r.id;
+        user.user = r.user_profile;
+        return user;
+      });
+      setRequesters(userRequests);
+      setRequestersRetrieved(true);
+    } catch (e) {
+      console.log(e.response.data)
+    }
   }, []);
 
   const CalculateMaxDisplayedDescriptionLength = (description) => {
@@ -317,6 +304,7 @@ export default function ProjectContent({
             onClose={toggleShowRequests}
             user={user}
             loading={!requestersRetrieved}
+            user_permission={user_permission}
           />
 
           {/* Note: created date is not the same as the start date, for projects */}

--- a/frontend/src/components/project/ProjectContent.tsx
+++ b/frontend/src/components/project/ProjectContent.tsx
@@ -184,7 +184,7 @@ export default function ProjectContent({
   toggleShowRequests,
   handleSendProjectJoinRequest,
   requestedToJoinProject,
-  token
+  token,
 }) {
   const classes = useStyles({ isPersonalProject: project.isPersonalProject });
   const { user, locale } = useContext(UserContext);
@@ -202,12 +202,12 @@ export default function ProjectContent({
   // Fetch and populate requesters on initial load
   useEffect(async () => {
     //short circuit if the user doesn't have the necessary permissions to see join requests
-    if(!(user_permission && hasAdminPermissions)) {
-      return
+    if (!(user_permission && hasAdminPermissions)) {
+      return;
     }
     // Returns an array of objects with an ID (request ID) and
     // associated user profile.
-    try{
+    try {
       const membershipRequests = await getMembershipRequests(project.url_slug, locale, token);
       // Now transform to a shape of objects where a specific request ID is
       // alongside a user profile.
@@ -220,7 +220,7 @@ export default function ProjectContent({
       setRequesters(userRequests);
       setRequestersRetrieved(true);
     } catch (e) {
-      console.log(e.response.data)
+      console.log(e.response.data);
     }
   }, []);
 

--- a/frontend/src/components/project/ProjectOverview.tsx
+++ b/frontend/src/components/project/ProjectOverview.tsx
@@ -140,29 +140,11 @@ export default function ProjectOverview({
   toggleShowFollowers,
   toggleShowLikes,
   token,
-  user,
-  handleSetRequestedToJoinProject,
-  requestedToJoinProject,
+  user
 }) {
   const classes = useStyles({});
 
   const texts = getTexts({ page: "project", locale: locale, project: project });
-
-  const getHasRequestedToJoin = async () => {
-    try {
-      const resp = await apiRequest({
-        method: "get",
-        url: `/api/projects/${project.url_slug}/have_i_requested_to_join/`,
-        locale: locale,
-        token: token,
-      });
-
-      // TODO: we should probably have an associated timestamp with each request too.
-      handleSetRequestedToJoinProject(resp.data.has_requested);
-    } catch (e) {
-      throw e;
-    }
-  };
 
   const [gotParams, setGotParams] = useState(false);
   useEffect(() => {
@@ -172,13 +154,6 @@ export default function ProjectOverview({
         toggleShowFollowers();
       }
       setGotParams(true);
-    }
-
-    // For non-members, check whether the user has requested to join,
-    // so that we can update the state of the button as "Requested"
-    // for the user.
-    if (user) {
-      getHasRequestedToJoin();
     }
   }, []);
 

--- a/frontend/src/components/project/ProjectOverview.tsx
+++ b/frontend/src/components/project/ProjectOverview.tsx
@@ -147,23 +147,22 @@ export default function ProjectOverview({
   const classes = useStyles({});
 
   const texts = getTexts({ page: "project", locale: locale, project: project });
-  
+
   const getHasRequestedToJoin = async () => {
-    try{
+    try {
       const resp = await apiRequest({
         method: "get",
         url: `/api/projects/${project.url_slug}/have_i_requested_to_join/`,
         locale: locale,
         token: token,
       });
-    
+
       // TODO: we should probably have an associated timestamp with each request too.
-      handleSetRequestedToJoinProject(resp.data.has_requested)
-    } catch(e) {
-      throw e
+      handleSetRequestedToJoinProject(resp.data.has_requested);
+    } catch (e) {
+      throw e;
     }
-  }
-  
+  };
 
   const [gotParams, setGotParams] = useState(false);
   useEffect(() => {
@@ -178,8 +177,8 @@ export default function ProjectOverview({
     // For non-members, check whether the user has requested to join,
     // so that we can update the state of the button as "Requested"
     // for the user.
-    if(user) {
-      getHasRequestedToJoin()
+    if (user) {
+      getHasRequestedToJoin();
     }
   }, []);
 

--- a/frontend/src/components/project/ProjectPageRoot.tsx
+++ b/frontend/src/components/project/ProjectPageRoot.tsx
@@ -201,14 +201,14 @@ export default function ProjectPageRoot({
       });
       showFeedbackMessage({
         message: texts.your_request_has_been_sent,
-        success: true
-      })
+        success: true,
+      });
       setRequestedToJoinProject(true);
     } catch (error) {
       showFeedbackMessage({
         message: error?.response?.data?.message,
-        error: true
-      })
+        error: true,
+      });
       if (error?.response?.data?.message === "Request already exists to join project") {
         setRequestedToJoinProject(true);
       }

--- a/frontend/src/components/project/ProjectPageRoot.tsx
+++ b/frontend/src/components/project/ProjectPageRoot.tsx
@@ -551,6 +551,7 @@ export default function ProjectPageRoot({
             toggleShowRequests={toggleShowRequests}
             handleSendProjectJoinRequest={handleSendProjectJoinRequest}
             requestedToJoinProject={requestedToJoinProject}
+            token={token}
           />
         </TabContent>
         <TabContent value={tabValue} index={1}>

--- a/frontend/src/components/project/ProjectPageRoot.tsx
+++ b/frontend/src/components/project/ProjectPageRoot.tsx
@@ -199,9 +199,16 @@ export default function ProjectPageRoot({
           Authorization: `Token ${token}`,
         },
       });
-
+      showFeedbackMessage({
+        message: texts.your_request_has_been_sent,
+        success: true
+      })
       setRequestedToJoinProject(true);
     } catch (error) {
+      showFeedbackMessage({
+        message: error?.response?.data?.message,
+        error: true
+      })
       if (error?.response?.data?.message === "Request already exists to join project") {
         setRequestedToJoinProject(true);
       }

--- a/frontend/src/components/project/ProjectPageRoot.tsx
+++ b/frontend/src/components/project/ProjectPageRoot.tsx
@@ -93,6 +93,8 @@ export default function ProjectPageRoot({
   similarProjects,
   showSimilarProjects,
   handleHideContent,
+  requestedToJoinProject,
+  handleJoinRequest,
 }) {
   const visibleFooterHeight = VisibleFooterHeight({});
   const tabContentRef = useRef(null);
@@ -163,12 +165,6 @@ export default function ProjectPageRoot({
     }
   });
 
-  const [requestedToJoinProject, setRequestedToJoinProject] = useState(false);
-
-  const handleSetRequestedToJoinProject = (newValue) => {
-    setRequestedToJoinProject(newValue);
-  };
-
   /**
    * Calls backend, sending a request to join this project based
    * on user token stored in cookies.
@@ -203,14 +199,14 @@ export default function ProjectPageRoot({
         message: texts.your_request_has_been_sent,
         success: true,
       });
-      setRequestedToJoinProject(true);
+      handleJoinRequest(true);
     } catch (error) {
       showFeedbackMessage({
         message: error?.response?.data?.message,
         error: true,
       });
       if (error?.response?.data?.message === "Request already exists to join project") {
-        setRequestedToJoinProject(true);
+        handleJoinRequest(true);
       }
     }
   };
@@ -482,8 +478,6 @@ export default function ProjectPageRoot({
         toggleShowLikes={toggleShowLikes}
         token={token}
         user={user}
-        requestedToJoinProject={requestedToJoinProject}
-        handleSetRequestedToJoinProject={handleSetRequestedToJoinProject}
       />
 
       <Container className={classes.tabsContainerWithoutPadding}>

--- a/frontend/src/components/shareProject/ShareProject.tsx
+++ b/frontend/src/components/shareProject/ShareProject.tsx
@@ -128,7 +128,7 @@ export default function Share({
   };
 
   const getOrgObject = (org) => {
-    return userOrganizations.find((o) => o.name === org);
+    return userOrganizations.find((o) => o.name.trim() === org);
   };
 
   const onSubmit = (event, values) => {


### PR DESCRIPTION
## What and Why
Fixes #1197
We had a bug where anybody could  accept or decline join requests from any project.

## Changes in this PR
- Fixed and used the permission class `ReadWriteSensibleProjectDataPermission` for viewing, accepting and declining project join requests
- Refactored `project_slug` --> `url_slug` in some places for standardization and because it was breaking some code
- Added a view and endpoint for checking whether you have requested to join a specific project. Before the frontend would just request all requesters and then check if the current user is in there. Had to make the new endpoint because viewing all requesters isn't possible for normal users anymore with the new permissions
- Added proper error and feedback messages when sending, accepting or declining a join request
- Put `getMembershipRequests` function into a lib file because it was used in many places
- ran `yarn format`, `yarn lint` and `black`

## Testing steps

1. Create a project with one account
2. Switch to a different account and navigate to the project you just created
4. Add `?show_join_requests=true` to the end of the project url. You should see a message telling you only administrators can view open join requests
5. Request to join the project 
6. Log in on the account who owns the project
7. Go to the project with `?show_join_requests=true` attached to the url
8. You should be able to accept and decline join requests as expected