### PR TITLE
add locale to ClimateMatch lastResults-URI andranslate loading text for climateMatch

### DIFF
--- a/frontend/public/texts/climatematch_texts.ts
+++ b/frontend/public/texts/climatematch_texts.ts
@@ -11,7 +11,7 @@ export default function getClimatematchTexts({ location, question }) {
     },
     loading_the_climatematch: {
       en: "Loading the ClimateMatch...",
-      de: "Loading the ClimateMatch...",
+      de: "Lade das ClimateMatch...",
     },
     calculating_your_results: {
       en: "Calculating your results...",

--- a/frontend/src/components/climateMatch/WelcomeToClimateMatch.tsx
+++ b/frontend/src/components/climateMatch/WelcomeToClimateMatch.tsx
@@ -143,7 +143,7 @@ export default function WelcomeToClimateMatch({
       <Container className={`${classes.buttonBar} ${!unfixButtonBar && classes.fixedOnMobile}`}>
         <div className={classes.buttonBarLeft}>
           {hasDoneClimateMatch && (
-            <Button href="/climatematchresults" className={classes.lastResultButton}>
+            <Button href={`/${locale}/climatematchresults`} className={classes.lastResultButton}>
               <RestoreIcon className={classes.lastResultIcon} />
               {texts.your_last_result}
             </Button>


### PR DESCRIPTION
## What and Why

- translated the german text of the loading screen for the ClimateMatch
- add locale URI for the ClimateMatch "last Results" button to keep the user language while navigate