### PR TITLE
Fix german error message prompting you to login to see your chats

### DIFF
--- a/frontend/public/texts/chat_texts.json
+++ b/frontend/public/texts/chat_texts.json
@@ -1,7 +1,7 @@
 {
   "login_required": {
     "en": "You need to be logged in to see your chats",
-    "de": "Du musst eingeloggt sein, um deine Chats sehen zu können"
+    "de": "Du musst eingeloggt sein, um deine Chats zu sehen"
   },
   "cannot_leave_private_chats": {
     "en": "You can only leave group chats, not private chats",


### PR DESCRIPTION
## What and Why

When clicking the "see messages" link in the email notifying you about a message you got people who use german as a language were shown a 500 error page. This was due to a fauly query in the url caused by the german character "ö" in the word "können"(can). For this reason I changed the german error message to not include an "ö" anymore.