### PR TITLE
Follow-Up Quick-Fixes after event calendar update

### DIFF
--- a/frontend/src/components/project/Buttons/ProjectContentSideButtons.tsx
+++ b/frontend/src/components/project/Buttons/ProjectContentSideButtons.tsx
@@ -203,7 +203,7 @@ export default function ProjectContentSideButtons({
       {/* If the user is an admin on the project, or is already part
         of the project (has read only permissions), then we don't want to show the membership request button. */}
       {!hasAdminPermissions &&
-        !project.project_type.type_id === "event" &&
+        project.project_type.type_id !== "event" &&
         !(user_permission && [ROLE_TYPES.read_only_type].includes(user_permission)) && (
           <JoinButton
             handleSendProjectJoinRequest={handleSendProjectJoinRequest}

--- a/frontend/src/components/project/Buttons/ProjectInteractionButtons.tsx
+++ b/frontend/src/components/project/Buttons/ProjectInteractionButtons.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles(() => ({
     top: "auto",
     bottom: props.visibleFooterHeight,
     boxShadow: "-3px -3px 6px #00000029",
-    zIndex: "1",
+    zIndex: 101,
   }),
   containerButtonsActionBar: {
     display: "flex",

--- a/frontend/src/components/project/ProjectContent.tsx
+++ b/frontend/src/components/project/ProjectContent.tsx
@@ -132,6 +132,7 @@ const useStyles = makeStyles((theme) => ({
   collaborationContainer: {
     display: "flex",
     flexDirection: "row",
+    flexWrap: "wrap"
   },
 }));
 


### PR DESCRIPTION
## What and Why
This PR addresses some small follow-up fixes which emerged from #1267 
- Project page: on mobile screen there is a bar with buttons to interact fixed to the bottom of the screen. The new event date indicators on suggested event project cards were being displayed over this making it unusable in certain scroll positions. The interaction bar is now always being displayed on top of this date indicator
- The project join button was not shown anymore. Now it is shown again for ideas and projects
- If a project had many collaborating organizations they were shown of the project interaction buttons. Now they are just being pushed into a new line