### PR TITLE
Only send out notifications if project is not in draft mode.

### DIFF
--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -448,9 +448,10 @@ class CreateProjectView(APIView):
                 organization__name=organization.name
             )
 
-            create_organization_project_published_notification(
-                followers_of_org, organization, project
-            )
+            if not project.is_draft:
+                create_organization_project_published_notification(
+                    followers_of_org, organization, project
+                )
 
         return Response(
             {


### PR DESCRIPTION
## What and Why

PR fixes #1200 bug. Now only the published projects will send notifications to organization members.