### PR TITLE
Don't allow to progress in share project if you did not choose a valid location

### DIFF
--- a/frontend/public/texts/general_texts.json
+++ b/frontend/public/texts/general_texts.json
@@ -132,8 +132,8 @@
     "de": "Hubs"
   },
   "please_choose_one_of_the_location_options": {
-    "en": "Please choose one of the location options",
-    "de": "Bitte wähle eine der Optionen für den Ort"
+    "en": "Please choose one of the location options. Choose the city you are in if the location is online.",
+    "de": "Bitte wähle eine der Optionen für den Ort. Wähle Deinen Standort, wenn der Ort \"Online\" ist."
   },
   "organization_type": {
     "en": "Organization type",

--- a/frontend/src/components/shareProject/EnterDetails.tsx
+++ b/frontend/src/components/shareProject/EnterDetails.tsx
@@ -14,6 +14,7 @@ import AddSummarySection from "./AddSummarySection";
 import CollaborateSection from "./CollaborateSection";
 import ProjectNameSection from "./ProjectNameSection";
 import { checkProjectDatesValid } from "../../../public/lib/dateOperations";
+import { indicateWrongLocation, isLocationValid } from "../../../public/lib/locationOperations";
 
 const useStyles = makeStyles((theme) => {
   return {
@@ -80,6 +81,7 @@ export default function EnterDetails({
   goToNextStep,
   goToPreviousStep,
   skillsOptions,
+  setMessage
 }) {
   const [open, setOpen] = useState({
     avatarDialog: false,
@@ -90,6 +92,8 @@ export default function EnterDetails({
     start_date: "",
     end_date: "",
   });
+  const locationInputRef = useRef(null);
+  const [locationOptionsOpen, setLocationOptionsOpen] = React.useState(false);
   const classes = useStyles(projectData);
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "project", locale: locale, project: projectData });
@@ -110,6 +114,11 @@ export default function EnterDetails({
 
   const onClickNextStep = (event) => {
     event.preventDefault();
+    //Short circuit if the location is not valid and we're not in legacy mode
+    if (!isLocationValid(projectData.loc)) {
+      indicateWrongLocation(locationInputRef, setLocationOptionsOpen, setMessage, texts);
+      return;
+    }
     if (isProjectDataValid(projectData)) {
       handleSetProjectData({ ...projectData });
       goToNextStep();
@@ -156,6 +165,10 @@ export default function EnterDetails({
       });
       return false;
     }
+    if(isLocationValid(project.loc)) {
+      indicateWrongLocation(locationInputRef, setLocationOptionsOpen, setMessage, texts);
+      return false;
+    }
     return true;
   };
 
@@ -174,6 +187,9 @@ export default function EnterDetails({
           <ProjectTimeAndPlaceSection
             projectData={projectData}
             handleSetProjectData={handleSetProjectData}
+            locationInputRef={locationInputRef}
+            locationOptionsOpen={locationOptionsOpen}
+            setLocationOptionsOpen={setLocationOptionsOpen}
             errors={errors}
           />
           <div className={classes.block}>

--- a/frontend/src/components/shareProject/ShareProjectRoot.tsx
+++ b/frontend/src/components/shareProject/ShareProjectRoot.tsx
@@ -276,6 +276,7 @@ export default function ShareProjectRoot({
               goToNextStep={goToNextStep}
               goToPreviousStep={goToPreviousStep}
               skillsOptions={skillsOptions}
+              setMessage={setMessage}
             />
           )}
           {curStep.key === "addTeam" && (

--- a/frontend/src/components/shareProject/TimeAndPlaceSection.tsx
+++ b/frontend/src/components/shareProject/TimeAndPlaceSection.tsx
@@ -13,18 +13,27 @@ const useStyles = makeStyles<Theme>((theme) => {
         justifyContent: "space-between",
       },
     },
+    locationSearchBar: {
+      flexGrow: 1
+    }
   };
 });
 
 type Args = {
   projectData: Project;
   handleSetProjectData: Function;
+  locationInputRef: any;
+  locationOptionsOpen: boolean;
+  setLocationOptionsOpen: Function;
   errors: any;
 };
 
 export default function ProjectTimeAndPlaceSection({
   projectData,
   handleSetProjectData,
+  locationInputRef,
+  locationOptionsOpen,
+  setLocationOptionsOpen,
   errors,
 }: Args) {
   const classes = useStyles();
@@ -39,6 +48,9 @@ export default function ProjectTimeAndPlaceSection({
       <ProjectLocationSearchBar
         projectData={projectData}
         handleSetProjectData={handleSetProjectData}
+        locationInputRef={locationInputRef}
+        locationOptionsOpen={locationOptionsOpen}
+        handleSetLocationOptionsOpen={setLocationOptionsOpen}
         className={classes.locationSearchBar}
       />
     </div>


### PR DESCRIPTION
## What and Why
When we adapted share project to the event calendar there was an unintended side-effect. You can now progress to the last step without choosing a location option. This would then lead to a server error when trying to submit the project and there would be no indication what the problem is. All your input was lost and you had to start over again.

## The Fix
Now you are again forced to choose a location option from the dropdown. If you do not do that you will get an error message and won't be able to progress to the next step when sharing a project.