### PR TITLE
Expire email reminder after 4 weeks

### DIFF
--- a/backend/climateconnect_api/models/notification.py
+++ b/backend/climateconnect_api/models/notification.py
@@ -174,9 +174,15 @@ class Notification(models.Model):
     )
 
 
-class Meta:
-    verbose_name_plural = "Notifications"
-    ordering = ["-created_at"]
+    class Meta:
+        verbose_name_plural = "Notifications"
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return "%s-Notification %d" % (
+            self.NOTIFICATION_TYPES[self.notification_type][1],
+            self.id,
+        )
 
 
 class UserNotification(models.Model):
@@ -211,10 +217,11 @@ class UserNotification(models.Model):
         verbose_name_plural = "User notifications"
 
     def __str__(self):
-        return "Notified %s %s about Notification %d at %s" % (
+        return "Notified %s %s about Notification %d of type %s at %s" % (
             self.user.first_name,
             self.user.last_name,
             self.notification.id,
+            self.notification.NOTIFICATION_TYPES[self.notification.notification_type][1],
             self.notification.created_at,
         )
 

--- a/backend/climateconnect_api/tasks.py
+++ b/backend/climateconnect_api/tasks.py
@@ -57,13 +57,14 @@ def send_email_notifications(self, user_ids: List):
         except User.DoesNotExist:
             logger.info(f"User profile does not exists for user {u_id}")
             continue
-
+        
+        four_weeks_ago = timezone.now()-timedelta(weeks=4)
         unread_user_notifications = UserNotification.objects.filter(
             user=user,
             read_at__isnull=True,
             notification__notification_type=Notification.PRIVATE_MESSAGE,
+            notification__created_at__gte=four_weeks_ago
         )
-
         if (
             unread_user_notifications.exists()
             and user.user_profile


### PR DESCRIPTION
## What and Why

People are currently getting weekly email reminders for messages they sometimes got more than 2 years ago. If they don't answer that for a few weeks it simply becomes annoying spam. 

## The Change
Therefore I made a change that weekly email reminders are only send for messages which are less than 4 weeks old. 
Additionally I made a small change to how notifications are displayed in Django Admin.