### PR TITLE
Fixing EventDateIndicator Tooltip that overlaps the MobileBottomMenu

### DIFF
--- a/frontend/src/components/browse/MobileBottomMenu.tsx
+++ b/frontend/src/components/browse/MobileBottomMenu.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles(() => ({
     bottom: 0,
     left: 0,
     right: 0,
-    zIndex: 10,
+    zIndex: 20,
     background: "#f0f2f5",
   },
 }));

--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -28,6 +28,7 @@ const useStyles = makeStyles((theme) => ({
     position: "fixed",
     bottom: 0,
     backgroundColor: "#FFFFFF",
+    height: "49px",
   },
   spacingTop: {
     marginTop: theme.spacing(2),

--- a/frontend/src/components/project/EventDateIndicator.tsx
+++ b/frontend/src/components/project/EventDateIndicator.tsx
@@ -9,7 +9,7 @@ const useStyles = makeStyles((theme) => ({
     top: 0,
     right: 20,
     background: props.isInPast ? theme.palette.secondary.extraLight : theme.palette.yellow.main,
-    zIndex: 100,
+    zIndex: 10,
     borderRadius: "0px 0px 8px 8px",
     padding: theme.spacing(1),
     boxShadow: `2px 3px 7px -2px ${theme.palette.secondary.main}`,


### PR DESCRIPTION
## What and Why

#### These updates will fix this bug #1279 
- Updated the z-index for the `EventDateIndicator`,  lowering to `10`
- Updated also the z-index for the `MobileBottomMenu`, bumping it up to `20`

#### Additional fix : Found an issue when scrolling down the content: where the Footer's height is still higher than the mobile bottom menu and can still be seen 
- Added also height for the `Footer` in relative position, with `49px`
  
  #### See Screenshot Below of the Issue: 
  
    <img width="352" alt="image" src="https://github.com/climateconnect/climateconnect/assets/65673814/6301f468-9109-4a0d-884b-10cd0fbaefb6">

  
  

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->