### PR TITLE
fixing the problem of width for organization card

### DIFF
--- a/frontend/src/components/organization/OrganizationPreviewBody.tsx
+++ b/frontend/src/components/organization/OrganizationPreviewBody.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme) => {
       justifyContent: "center",
     },
     locationNameBox: {
-      maxWidth: "220px",
+      maxWidth: "200px",
       overflow: "hidden",
     },
     shortenedSummary: {


### PR DESCRIPTION
## Description
fixing issue [1280]( https://github.com/climateconnect/climateconnect/issues/1280).

## Changes
changing the style of the location section in the organization card.
The reason is:
 base on the the size of location box, the locationNameBox max-width property could not be more than 202px;
 
 before:
 
<img width="296" alt="Screenshot 2024-05-30 at 12 43 15 AM" src="https://github.com/climateconnect/climateconnect/assets/11225608/fe7d725a-79f4-4ab2-9e1f-6ba68b7c6bad">

after:
<img width="296" alt="Screenshot 2024-05-30 at 12 42 35 AM" src="https://github.com/climateconnect/climateconnect/assets/11225608/b414adad-3173-4708-bb00-0361e58044b3">
