### PR TITLE
fixed bug to show date tag for events on organization page

### DIFF
--- a/frontend/src/components/project/ProjectPreview.tsx
+++ b/frontend/src/components/project/ProjectPreview.tsx
@@ -113,7 +113,7 @@ export default function ProjectPreview({ project, projectRef, hubUrl, className 
   const projectType =
     projectTypes && projectTypes.length > 0
       ? projectTypes.find((t) => t.type_id === project.project_type)
-      : { name: project.project_type };
+      : { name: project.project_type, type_id: project.project_type };
   const texts = getTexts({ page: "project", locale: locale });
   const classes = useStyles({ hovering: hovering });
   const handleMouseEnter = () => {


### PR DESCRIPTION
## Description
fixing issue [1286](https://github.com/climateconnect/climateconnect/issues/1286)

## Changes
The _ProjectPreview_ component requires an event type property for the date/time feature in the top corner of the cards. However, this property seems to be missing.

In the browse page:
<img width="1216" alt="Screenshot 2024-05-30 at 1 25 46 AM" src="https://github.com/climateconnect/climateconnect/assets/11225608/46d3b2d2-20d3-431b-9a66-2c5cfa86382f">

In the organization page(after the changes):
<img width="1243" alt="Screenshot 2024-05-30 at 1 27 49 AM" src="https://github.com/climateconnect/climateconnect/assets/11225608/e45d981f-400a-4028-954c-2c487ccf5add">
