### PR TITLE
fixing the footer to stick the bottom

### DIFF
--- a/frontend/src/components/climateMatchResults/ClimateMatchResultsRoot.tsx
+++ b/frontend/src/components/climateMatchResults/ClimateMatchResultsRoot.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme) => ({
   root: {
     position: "relative",
     width: "100%",
-    height: "100vh",
+    minHeight: "100vh",
   },
   loadingOverlay: {
     background: theme.palette.primary.main,


### PR DESCRIPTION
## Description
fixing issue [1253](https://github.com/climateconnect/climateconnect/issues/1253)

##Changes
changing the height property of the root container on climatematchresults page. 
The root container had fixed height and when the content inside the element is longer than 100vh, the root will overflow. So to fix it we need to change the height to min-height.

after changing code :
<img width="1299" alt="Screenshot 2024-05-30 at 7 54 35 PM" src="https://github.com/climateconnect/climateconnect/assets/11225608/a8c04fdd-d297-4e22-b107-cdc67319ccf2">
