### PR TITLE
Bugfix: make edit org button clickable on mobile again

### DIFF
--- a/frontend/src/components/account/AccountPage.tsx
+++ b/frontend/src/components/account/AccountPage.tsx
@@ -36,6 +36,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
     },
     marginTop: theme.spacing(-11),
     marginBottom: theme.spacing(2),
+    display: "inline-block"
   },
   avatarWithInfo: {
     textAlign: "center",


### PR DESCRIPTION
## What and Why
As seen in the screenshot the `AvatarContainer` component was completely covering the edit organization button on mobile. This means the button simply did nothing when trying to click it on mobile. This is now fixed and the organization avatar is centered again by making it `inline-block`

## Before
![Screenshot from 2024-06-03 10-17-26](https://github.com/climateconnect/climateconnect/assets/10531079/923f9030-024b-4266-9812-026737c2ba90)

## After
![Screenshot from 2024-06-03 10-21-34](https://github.com/climateconnect/climateconnect/assets/10531079/1623cf12-9cf8-4f97-adb3-26a96ec90e54)
