### PR TITLE
fixing overlapping slider

### DIFF
--- a/frontend/src/components/climateMatchResults/ClimateMatchSuggestionInfo.tsx
+++ b/frontend/src/components/climateMatchResults/ClimateMatchSuggestionInfo.tsx
@@ -67,6 +67,10 @@ const useStyles = makeStyles<Theme, { displayContactButton?: boolean }>((theme) 
   },
   locationText: {
     fontSize: 15,
+    maxWidth: "250px",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
   locationIcon: {
     fontSize: 19,
@@ -77,6 +81,7 @@ const useStyles = makeStyles<Theme, { displayContactButton?: boolean }>((theme) 
   },
   projectCategories: {
     cursor: "default",
+    
   },
   smallLocationIcon: {
     fontSize: 15,

--- a/frontend/src/components/project/ProjectCategoriesDisplay.tsx
+++ b/frontend/src/components/project/ProjectCategoriesDisplay.tsx
@@ -18,6 +18,10 @@ const useStyles = makeStyles<Theme, { hovering?: boolean }>((theme) => ({
   categoryText: {
     marginLeft: theme.spacing(0.5),
     fontSize: 15,
+    maxWidth: "250px",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
   icon: {
     fontSize: 17,


### PR DESCRIPTION
## Description
Fixing issue [1253](https://github.com/climateconnect/climateconnect/issues/1253)
This pull request improves the overlapping components on the ClimateMatch results page by adding styles for location and category.
## Changes
breaking the long text of location and category.
Because the slider has fixing height, for some content it happens that the slider overlap to the next component.
so to fixing completely it need more investigations and maybe more PRs.

before:
<img width="1144" alt="Screenshot 2024-06-17 at 1 17 20 PM" src="https://github.com/climateconnect/climateconnect/assets/11225608/c83aa885-e0ad-4568-8389-8f04c417d862">


after:
<img width="1157" alt="Screenshot 2024-06-17 at 1 18 23 PM" src="https://github.com/climateconnect/climateconnect/assets/11225608/deda8a6d-5f36-46d9-a533-55035cba1772">
