### PR TITLE
Bug 1299 overlapping event's date on Footer element

### DIFF
--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -19,6 +19,7 @@ const useStyles = makeStyles((theme) => ({
     height: theme.spacing(8),
     borderTop: `1px solid ${theme.palette.grey[100]}`,
     width: "100%",
+    zIndex: "900"
   },
   absolutePosition: {
     position: "absolute",

--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
     height: theme.spacing(8),
     borderTop: `1px solid ${theme.palette.grey[100]}`,
     width: "100%",
-    zIndex: "900"
+    zIndex: "15"
   },
   absolutePosition: {
     position: "absolute",


### PR DESCRIPTION
## Description
Fixing issue [1299](https://github.com/climateconnect/climateconnect/issues/1299)

## Changes
Applying the `z-index` property to the footer element to prevent overlapping.
