### PR TITLE
Bug 1298 youtube mobile

### DIFF
--- a/frontend/src/components/communication/MessageContent.tsx
+++ b/frontend/src/components/communication/MessageContent.tsx
@@ -15,6 +15,9 @@ const useStyles = makeStyles({
       color: "inherit",
     },
   },
+  youtubeWrapper: {
+    maxWidth: "640px",
+  }
 });
 
 type Props = {
@@ -31,10 +34,10 @@ export default function MessageContent({ content, renderYoutubeVideos = false }:
       {text}
     </a>
   );
+  const screenWidth = window.innerWidth;
 
   const opts = {
-    height: "390",
-    width: "640",
+    width: "100%",
     host: "https://www.youtube-nocookie.com",
     playerVars: {
       // https://developers.google.com/youtube/player_parameters
@@ -53,7 +56,11 @@ export default function MessageContent({ content, renderYoutubeVideos = false }:
             let video_id = YouTubeGetID(w);
             const ampersandPosition = video_id.indexOf("&");
             if (ampersandPosition !== -1) video_id = video_id.substring(0, ampersandPosition);
-            return <YouTube videoId={video_id} opts={opts as any} />;
+            return (
+              <div className={classes.youtubeWrapper}>
+                <YouTube videoId={video_id} opts={opts as any} />
+              </div>
+            )
           } else {
             return <Linkify componentDecorator={componentDecorator}>{w + " "}</Linkify>;
           }

--- a/frontend/src/components/communication/MessageContent.tsx
+++ b/frontend/src/components/communication/MessageContent.tsx
@@ -34,7 +34,6 @@ export default function MessageContent({ content, renderYoutubeVideos = false }:
       {text}
     </a>
   );
-  const screenWidth = window.innerWidth;
 
   const opts = {
     width: "100%",


### PR DESCRIPTION
## Description
Fixing [issue](1298) https://github.com/climateconnect/climateconnect/issues/1298

## Changes
Added `width: 100%` to Youtube component: Ensures the component takes up the full available width on mobile.
Added parent with style: Provides additional `maxWidth` for responsive behavior in desktop.

## Before
<img width="669" alt="Screenshot 2024-06-28 at 4 15 03 PM" src="https://github.com/climateconnect/climateconnect/assets/11225608/2a52eb94-498f-4e1b-b444-1c5253529da4">

## After
<img width="669" alt="Screenshot 2024-06-28 at 4 14 04 PM" src="https://github.com/climateconnect/climateconnect/assets/11225608/ac7283c6-8c20-4576-a3bf-ba7d8d6da80c">

