### PR TITLE
fixing the problem for display Icons in organization page

### DIFF
--- a/frontend/src/components/project/ProjectMetaData.tsx
+++ b/frontend/src/components/project/ProjectMetaData.tsx
@@ -249,7 +249,8 @@ const AdditionalPreviewInfo = ({ project }) => {
   const projectType =
     projectTypes && projectTypes.length > 0
       ? projectTypes.find((t) => t.type_id === project.project_type)
-      : { name: project.project_type.name };
+      : { name: project.project_type, type_id: project.project_type };
+      
   return (
     <Box className={classes.additionalInfoContainer}>
       {project.number_of_comments > 0 && (


### PR DESCRIPTION
## Description
Fixing issue [1297](https://github.com/climateconnect/climateconnect/issues/1297)

## Changes
A new property was added to the related component to display the icon.
This property, named `project_type`, is required to determine the appropriate icon to display.

## Before
<img width="681" alt="Screenshot 2024-07-08 at 10 52 17 AM" src="https://github.com/climateconnect/climateconnect/assets/11225608/793b511d-fbad-465b-a85a-6b92c1ab5ccd">

## After
<img width="681" alt="Screenshot 2024-07-08 at 10 51 19 AM" src="https://github.com/climateconnect/climateconnect/assets/11225608/c3c2fb6f-5835-4dc0-a7b6-ae5a13e9563d">


