### PR TITLE
Add dot to event displays

### DIFF
--- a/frontend/public/lib/dateOperations.ts
+++ b/frontend/public/lib/dateOperations.ts
@@ -4,7 +4,7 @@ import dayjs from "dayjs";
 import { getProjectTypeDateOptions } from "../data/projectTypeOptions";
 
 export function getDayAndMonth(date) {
-  return format(date, "dd.MM");
+  return format(date, "dd.MM.");
 }
 
 export function getTime(date) {
@@ -12,7 +12,7 @@ export function getTime(date) {
 }
 
 export function getDateAndTime(date) {
-  return format(date, "dd.MM HH:mm");
+  return format(date, "dd.MM. HH:mm");
 }
 
 export function getDateTime(rawDate) {


### PR DESCRIPTION
## What and Why

The dot was missing on date displays ("29.07" instead of "29.07."). This update fixes that