### PR TITLE
Fix CI with regard to artifact actions

### DIFF
--- a/.github/workflows/master_climateconnect-frontend(slot2).yml
+++ b/.github/workflows/master_climateconnect-frontend(slot2).yml
@@ -42,7 +42,7 @@ jobs:
         run: zip release.zip ./* -r
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: node-app
           path: release.zip

--- a/.github/workflows/master_climateconnect-frontend(slot2).yml
+++ b/.github/workflows/master_climateconnect-frontend(slot2).yml
@@ -56,7 +56,7 @@ jobs:
     
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: node-app
 

--- a/.github/workflows/master_deploy-backend.yml
+++ b/.github/workflows/master_deploy-backend.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: python-app
           path: .

--- a/.github/workflows/master_deploy-backend.yml
+++ b/.github/workflows/master_deploy-backend.yml
@@ -33,7 +33,7 @@ jobs:
       # Optional: Add step to run tests here (PyTest, Django test suites, etc.)
 
       - name: Upload artifact for deployment jobs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: python-app
           path: |


### PR DESCRIPTION
Fixes the CI issue seen at https://github.com/climateconnect/climateconnect/actions/runs/10970230674/job/30463848543 …

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

… and its sibling.