### PR TITLE
[security] Fix Django `DEBUG` setting

### DIFF
--- a/backend/climateconnect_main/settings.py
+++ b/backend/climateconnect_main/settings.py
@@ -38,7 +38,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = env("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = env("DEBUG", False)
+DEBUG = env("DEBUG", "false") == "true"  # needs to gravitate towards False!
 
 ALLOWED_HOSTS = get_allowed_hosts(env("ALLOWED_HOSTS"))
 


### PR DESCRIPTION
The current code makes `DEBUG=False` activate debug because `bool("False")` is `True` in Python. In general, `DEBUG` should be disabled in production and made to gravitate towards `False` (rather than current `True`) for security.
