### PR TITLE
Make GitHub Dependabot keep the GitHub Actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@
 # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#target-branch
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    target-branch: "master"
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
.. through pull requests every Sunday

So that pull requests like #1330 will be automatic in the future.

PS: Please merge #1330 before this one.