### PR TITLE
fixed date && time overlapping in hubs page

### DIFF
--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -187,8 +187,8 @@ type Props = {
   hubData?: Object;
   className?: any;
   location?: any;
-  welcomeMessageLoggedIn?: string,
-  welcomeMessageLoggedOut?: string
+  welcomeMessageLoggedIn?: string;
+  welcomeMessageLoggedOut?: string;
 };
 
 export default function Dashboard({
@@ -197,7 +197,7 @@ export default function Dashboard({
   className,
   location,
   welcomeMessageLoggedIn,
-  welcomeMessageLoggedOut
+  welcomeMessageLoggedOut,
 }: Props) {
   const classes = useStyles();
   const { user, locale } = useContext(UserContext);
@@ -214,21 +214,25 @@ export default function Dashboard({
     }
   }, []);
 
-  const parseWelcomeMessage = m => {
-    const message = m.replaceAll("${user.first_name}", user.first_name)
-    return m.replaceAll("${user.first_name}", user.first_name)
-  }
+  const parseWelcomeMessage = (m) => {
+    const message = m.replaceAll("${user.first_name}", user.first_name);
+    return m.replaceAll("${user.first_name}", user.first_name);
+  };
 
   const getWelcomeMessage = () => {
     //Hallo {User}, +quickInfo
-    if(user) {
-      return parseWelcomeMessage(welcomeMessageLoggedIn ? welcomeMessageLoggedIn : texts.welcome_message_logged_in)
+    if (user) {
+      return parseWelcomeMessage(
+        welcomeMessageLoggedIn ? welcomeMessageLoggedIn : texts.welcome_message_logged_in
+      );
     } else {
-      return parseWelcomeMessage(welcomeMessageLoggedOut? welcomeMessageLoggedOut : texts.welcome_message_logged_out)
+      return parseWelcomeMessage(
+        welcomeMessageLoggedOut ? welcomeMessageLoggedOut : texts.welcome_message_logged_out
+      );
     }
-  }
+  };
 
-  const welcomeMessage = getWelcomeMessage()
+  const welcomeMessage = getWelcomeMessage();
 
   return (
     <div className={`${classes.welcomeBanner} ${className}`}>
@@ -239,9 +243,7 @@ export default function Dashboard({
             {/* TODO: doing some left spacing here -- trying to keep spacing directly out of the UI components, and isolated within Box components directly  */}
             <Box sx={{ marginLeft: theme.spacing(1), width: "100%" }}>
               <div className={`${classes.welcomeMessage}`}>
-                <Typography style={{ fontWeight: "600" }}>
-                  {welcomeMessage}
-                </Typography>
+                <Typography style={{ fontWeight: "600" }}>{welcomeMessage}</Typography>
               </div>
             </Box>
           </div>

--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
     height: theme.spacing(8),
     borderTop: `1px solid ${theme.palette.grey[100]}`,
     width: "100%",
-    zIndex: "15"
+    zIndex: "9"
   },
   absolutePosition: {
     position: "absolute",

--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
     height: theme.spacing(8),
     borderTop: `1px solid ${theme.palette.grey[100]}`,
     width: "100%",
-    zIndex: "9"
+    zIndex: "9",
   },
   absolutePosition: {
     position: "absolute",

--- a/frontend/src/components/project/EventDateIndicator.tsx
+++ b/frontend/src/components/project/EventDateIndicator.tsx
@@ -9,7 +9,7 @@ const useStyles = makeStyles((theme) => ({
     top: 0,
     right: 20,
     background: props.isInPast ? theme.palette.secondary.extraLight : theme.palette.yellow.main,
-    zIndex: 10,
+    zIndex: 9,
     borderRadius: "0px 0px 8px 8px",
     padding: theme.spacing(1),
     boxShadow: `2px 3px 7px -2px ${theme.palette.secondary.main}`,


### PR DESCRIPTION
## Description
This PR addresses [1329](https://github.com/climateconnect/climateconnect/issues/1329)

## Changes
Adjusted the `z-index` for the `EventDateIndicator` and` Footer` components to prevent the event date from overlapping.

## Before
Date overlapping:
<img width="428" alt="Screenshot 2024-10-08 at 1 43 02 PM" src="https://github.com/user-attachments/assets/6cb5f8b9-bcdb-4b2c-80a7-5340ac69bbdf">


Footer overlapping:
<img width="428" alt="Screenshot 2024-10-08 at 1 43 13 PM" src="https://github.com/user-attachments/assets/2148854d-4dc1-403e-85eb-928c59743440">

## After
Date indicator:
<img width="428" alt="Screenshot 2024-10-08 at 1 43 38 PM" src="https://github.com/user-attachments/assets/f12d449d-8e6c-46da-9aa0-2263e3208cd0">

Footer:
<img width="428" alt="Screenshot 2024-10-08 at 1 43 48 PM" src="https://github.com/user-attachments/assets/168f6d16-32ea-4c55-b609-5aafb7ca2b33">
