### PR TITLE
Fixes Overlapping On Memberpage

### DIFF
--- a/frontend/src/components/profile/ProfilePreview.tsx
+++ b/frontend/src/components/profile/ProfilePreview.tsx
@@ -11,7 +11,9 @@ const useStyles = makeStyles((theme) => {
   return {
     avatarWithInfo: {
       textAlign: "center",
-      width: theme.spacing(40),
+      alginSelf: "center",
+      maxWidth: theme.spacing(36),
+      padding: theme.spacing(2),
     },
     avatar: {
       height: theme.spacing(20),

--- a/frontend/src/components/profile/ProfilePreviews.tsx
+++ b/frontend/src/components/profile/ProfilePreviews.tsx
@@ -79,8 +79,15 @@ export default function ProfilePreviews({
 }
 
 function GridItem({ profile, showAdditionalInfo }) {
+  const classes = makeStyles({
+    gridElement: {
+      display: "flex",
+      justifyContent: "space-around",
+    },
+  })();
+
   return (
-    <Grid xs={12} sm={6} md={4} lg={3} component="li">
+    <Grid xs={12} sm={6} md={4} lg={3} component="li" className={classes.gridElement}>
       <ProfilePreview profile={profile} showAdditionalInfo={showAdditionalInfo} />
     </Grid>
   );


### PR DESCRIPTION
## What and Why
Some Location names resulted in an overlapping (see  #1341) of text. Therefore, the following changes were made:
- changed fixed width to maxWidth so that overflow is handled correctly
- added padding so that the grid does not feel too compact/cluttered.
- centered profile previews within the grid elements. 