### PR TITLE
disabled links to donorforest for now:

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -49,7 +49,10 @@ module.exports = withBundleAnalyzer({
       },
       {
         source: "/spendenwald",
-        destination: "/de/donorforest",
+        destination: "/de/donate",
+        // disabled redirect to donorforest for now
+        // as the donorforest is not up to date
+        // destination: "/de/donorforest",
         permanent: true,
       },
       {

--- a/frontend/public/data/getStaticPageLinks.ts
+++ b/frontend/public/data/getStaticPageLinks.ts
@@ -31,11 +31,13 @@ export function getStaticPageLinks(texts, locale, isStaticPage = false) {
       text: texts.transparency,
       parent_item: "/about",
     },
-    {
-      href: "/donorforest",
-      text: texts.donorforest,
-      parent_item: "/donate",
-    },
+    // removed donorforest for now
+    // as it is not up to date
+    // {
+    //   href: "/donorforest",
+    //   text: texts.donorforest,
+    //   parent_item: "/donate",
+    // },
     {
       href: "/blog",
       text: texts.blog,

--- a/frontend/src/components/profile/ProfileBadge.tsx
+++ b/frontend/src/components/profile/ProfileBadge.tsx
@@ -28,6 +28,10 @@ const useStyles = makeStyles<Theme, { size: string; image?: string }>((theme) =>
 
 type Props = React.PropsWithChildren<{ className?: string; badge?; size?; contentOnly?: boolean }>;
 export default function ProfileBadge({ className, badge, children, size, contentOnly }: Props) {
+  // deactivated donorforest badge for now
+  // as the donorforest is not up to date
+  badge.is_donorforest_badge = false;
+
   const classes = useStyles({ image: getImageUrl(badge.image), size: size });
   if (contentOnly) {
     return <BadgeContent badge={badge} size={size} className={className} />;
@@ -57,7 +61,8 @@ const BadgeContent = ({ badge, size, className, withLink }: any) => {
   return (
     <Tooltip title={badge.name}>
       <div>
-        {withLink ? (
+        {/* disabled Link to donorforest for now */}
+        {withLink && false ? (
           <Link href={`${getLocalePrefix(locale)}/donorforest`} target="_blank" underline="hover">
             <Content badge={badge} size={size} className={className} />
           </Link>


### PR DESCRIPTION
- in next config: /spendenwald now redirects to /de/donate
- removed donorforest from Static Nav Links
- disabled badge.is_donorforest_badge and the link version of badges for now

## What and Why

Fixes #1393: removes the donorforest for now 
