### PR TITLE
Fix header redirects on custom hubs

### DIFF
--- a/frontend/pages/hubs/[hubUrl].tsx
+++ b/frontend/pages/hubs/[hubUrl].tsx
@@ -47,13 +47,18 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+type ShareProjectMakeStyleProps = {
+  isCustomHub: boolean;
+};
+
 const shareProjectFabStyle = makeStyles((theme) => ({
-  fabShareProject: {
+  fabShareProject: (props: ShareProjectMakeStyleProps) => ({
     position: "fixed",
-    background: theme.palette.primary.light,
+    background: props.isCustomHub ? theme.palette.background.default_contrastText : theme.palette.primary.light,
+    color: props.isCustomHub ? theme.palette.background.default : "default",
     // bottom: theme.spacing(5),
     right: theme.spacing(3),
-  },
+  }),
 }));
 
 const DESCRIPTION_WEBFLOW_LINKS = {
@@ -151,7 +156,6 @@ export default function Hub({
   welcomeMessageLoggedOut,
   initialLocationFilter,
   filterChoices,
-  sectorHubs,
   allHubs,
   initialIdeaUrlSlug,
   hubLocation,
@@ -160,9 +164,9 @@ export default function Hub({
   projectTypes,
   hubThemeData,
 }) {
+  const { locale, CUSTOM_HUB_URLS } = useContext(UserContext);
+  const isCustomHub = CUSTOM_HUB_URLS.includes(hubUrl)
   const classes = useStyles();
-  let fabClass = shareProjectFabStyle(false);
-  const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "hub", locale: locale, hubName: name });
   const token = new Cookies().get("auth_token");
   const [hubAmbassador, setHubAmbassador] = useState(null);
@@ -381,20 +385,31 @@ export default function Hub({
           </BrowseContext.Provider>
         </div>
         {isSmallScreen && (
-          <Fab
-            className={fabClass.fabShareProject}
-            size="medium"
-            color="primary"
-            href={`${getLocalePrefix(locale)}/share`}
-            sx={{ bottom: (theme) => (hubAmbassador ? theme.spacing(11.5) : theme.spacing(5)) }}
-            // onClick={}
-          >
-            <AddIcon />
-          </Fab>
+          <FabShareButton 
+            locale={locale} 
+            hubAmbassador={hubAmbassador} 
+            isCustomHub={isCustomHub}
+          />
         )}
       </WideLayout>
     </>
   );
+}
+
+const FabShareButton = ({locale, hubAmbassador, isCustomHub}) => {
+  const fabClass = shareProjectFabStyle({isCustomHub: isCustomHub});
+  return (
+    <Fab
+      className={fabClass.fabShareProject}
+      size="medium"
+      color="primary"
+      href={`${getLocalePrefix(locale)}/share`}
+      sx={{ bottom: (theme) => (hubAmbassador ? theme.spacing(11.5) : theme.spacing(5)) }}
+      // onClick={}
+    >
+      <AddIcon />
+    </Fab>
+  )
 }
 
 const HubDescription = ({ hub, texts }) => {

--- a/frontend/pages/hubs/[hubUrl].tsx
+++ b/frontend/pages/hubs/[hubUrl].tsx
@@ -54,7 +54,9 @@ type ShareProjectMakeStyleProps = {
 const shareProjectFabStyle = makeStyles((theme) => ({
   fabShareProject: (props: ShareProjectMakeStyleProps) => ({
     position: "fixed",
-    background: props.isCustomHub ? theme.palette.background.default_contrastText : theme.palette.primary.light,
+    background: props.isCustomHub
+      ? theme.palette.background.default_contrastText
+      : theme.palette.primary.light,
     color: props.isCustomHub ? theme.palette.background.default : "default",
     // bottom: theme.spacing(5),
     right: theme.spacing(3),
@@ -165,7 +167,7 @@ export default function Hub({
   hubThemeData,
 }) {
   const { locale, CUSTOM_HUB_URLS } = useContext(UserContext);
-  const isCustomHub = CUSTOM_HUB_URLS.includes(hubUrl)
+  const isCustomHub = CUSTOM_HUB_URLS.includes(hubUrl);
   const classes = useStyles();
   const texts = getTexts({ page: "hub", locale: locale, hubName: name });
   const token = new Cookies().get("auth_token");
@@ -385,19 +387,15 @@ export default function Hub({
           </BrowseContext.Provider>
         </div>
         {isSmallScreen && (
-          <FabShareButton 
-            locale={locale} 
-            hubAmbassador={hubAmbassador} 
-            isCustomHub={isCustomHub}
-          />
+          <FabShareButton locale={locale} hubAmbassador={hubAmbassador} isCustomHub={isCustomHub} />
         )}
       </WideLayout>
     </>
   );
 }
 
-const FabShareButton = ({locale, hubAmbassador, isCustomHub}) => {
-  const fabClass = shareProjectFabStyle({isCustomHub: isCustomHub});
+const FabShareButton = ({ locale, hubAmbassador, isCustomHub }) => {
+  const fabClass = shareProjectFabStyle({ isCustomHub: isCustomHub });
   return (
     <Fab
       className={fabClass.fabShareProject}
@@ -409,8 +407,8 @@ const FabShareButton = ({locale, hubAmbassador, isCustomHub}) => {
     >
       <AddIcon />
     </Fab>
-  )
-}
+  );
+};
 
 const HubDescription = ({ hub, texts }) => {
   const classes = useStyles();

--- a/frontend/pages/signup.tsx
+++ b/frontend/pages/signup.tsx
@@ -1,7 +1,7 @@
 import Router from "next/router";
 import React, { useContext, useEffect, useRef, useState } from "react";
 import Cookies from "universal-cookie";
-import { apiRequest } from "../public/lib/apiOperations";
+import { apiRequest, getLocalePrefix } from "../public/lib/apiOperations";
 import { getParams } from "../public/lib/generalOperations";
 import {
   getLocationValue,
@@ -85,7 +85,8 @@ export default function Signup({ hubUrl, hubThemeData }) {
 
   useEffect(function () {
     if (user) {
-      redirectOnLogin(user, "/", locale);
+      const redirectUrl = hubUrl ? `${getLocalePrefix(locale)}/hubs/${hubUrl}` : "/";
+      redirectOnLogin(user, redirectUrl, locale);
     }
   });
 

--- a/frontend/public/lib/headerLink.ts
+++ b/frontend/public/lib/headerLink.ts
@@ -35,7 +35,9 @@ const COMMON_LINKS = {
   },
   AUTH_LINKS: (path_to_redirect, texts, queryString) => [
     {
-      href: `/signin?redirect=${encodeURIComponent(path_to_redirect)}${queryString ? `&${queryString}` : ""}`,
+      href: `/signin?redirect=${encodeURIComponent(path_to_redirect)}${
+        queryString ? `&${queryString}` : ""
+      }`,
       text: texts.log_in,
       iconForDrawer: AccountCircleIcon,
       isOutlinedInHeader: true,

--- a/frontend/public/lib/headerLink.ts
+++ b/frontend/public/lib/headerLink.ts
@@ -35,7 +35,7 @@ const COMMON_LINKS = {
   },
   AUTH_LINKS: (path_to_redirect, texts, queryString) => [
     {
-      href: `/signin?redirect=${path_to_redirect}${queryString ? `&${queryString}` : ""}`,
+      href: `/signin?redirect=${encodeURIComponent(path_to_redirect)}${queryString ? `&${queryString}` : ""}`,
       text: texts.log_in,
       iconForDrawer: AccountCircleIcon,
       isOutlinedInHeader: true,
@@ -52,19 +52,20 @@ const COMMON_LINKS = {
   ],
 };
 
-const getPrio1Links = (path_to_redirect, texts, isLocationHub) => [
+const getPrio1Links = (path_to_redirect, texts) => [
   {
-    href: "/prio1-klima",
+    href: "https://prio1-klima.net",
     text: texts.PRIO1_klima,
     iconForDrawer: InfoIcon,
     showStaticLinksInDropdown: true,
     hideOnStaticPages: true,
+    isExternalLink: true,
     className: "btnIconTextColor",
   },
   {
     ...COMMON_LINKS.SHARE,
     text: texts.share_a_project,
-    hideOnMediumScreen: isLocationHub,
+    hideOnMediumScreen: true,
   },
   {
     type: "languageSelect",
@@ -118,8 +119,8 @@ const getDefaultLinks = (path_to_redirect, texts, isLocationHub) => [
 
 const getLinks = (path_to_redirect, texts, isLocationHub, isCustomHub) => {
   return isCustomHub
-    ? getPrio1Links(path_to_redirect, texts, isLocationHub)
-    : getDefaultLinks(path_to_redirect, texts, isLocationHub);
+    ? getPrio1Links(path_to_redirect, texts)
+    : getDefaultLinks(path_to_redirect, texts, isLocationHub || isCustomHub);
 };
 
 const getLoggedInLinks = ({ loggedInUser, texts }) => {

--- a/frontend/src/components/browse/MobileBottomMenu.tsx
+++ b/frontend/src/components/browse/MobileBottomMenu.tsx
@@ -7,8 +7,9 @@ import AssignmentIcon from "@mui/icons-material/Assignment";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import GroupIcon from "@mui/icons-material/Group";
 import DateRangeRoundedIcon from "@mui/icons-material/DateRangeRounded";
+import { Theme } from "@mui/material/styles";
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme: Theme) => ({
   root: {
     position: "fixed",
     bottom: 0,
@@ -17,6 +18,13 @@ const useStyles = makeStyles(() => ({
     zIndex: 20,
     background: "#f0f2f5",
   },
+  tabs: {
+    "& .MuiTabs-indicator": {
+      backgroundColor: theme.palette.background.default_contrastText
+    },  },
+  tab: {
+    color: theme.palette.background.default_contrastText
+  }
 }));
 
 export default function MobileBottomMenu({
@@ -42,8 +50,7 @@ export default function MobileBottomMenu({
           variant="fullWidth"
           value={tabValue}
           onChange={handleTabChange}
-          indicatorColor="primary"
-          textColor="primary"
+          className={classes.tabs}
           centered={true}
         >
           {TYPES_BY_TAB_VALUE.map((t, index) => {
@@ -54,7 +61,7 @@ export default function MobileBottomMenu({
               icon: type_icons[t],
             };
             if (index === 1) tabProps.ref = organizationsTabRef;
-            return <Tab label={<typeIcon.icon />} {...tabProps} key={index} />;
+            return <Tab label={<typeIcon.icon className={classes.tab}/>} {...tabProps} key={index} />;
           })}
         </Tabs>
       </>

--- a/frontend/src/components/browse/MobileBottomMenu.tsx
+++ b/frontend/src/components/browse/MobileBottomMenu.tsx
@@ -20,11 +20,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   tabs: {
     "& .MuiTabs-indicator": {
-      backgroundColor: theme.palette.background.default_contrastText
-    },  },
+      backgroundColor: theme.palette.background.default_contrastText,
+    },
+  },
   tab: {
-    color: theme.palette.background.default_contrastText
-  }
+    color: theme.palette.background.default_contrastText,
+  },
 }));
 
 export default function MobileBottomMenu({
@@ -61,7 +62,9 @@ export default function MobileBottomMenu({
               icon: type_icons[t],
             };
             if (index === 1) tabProps.ref = organizationsTabRef;
-            return <Tab label={<typeIcon.icon className={classes.tab}/>} {...tabProps} key={index} />;
+            return (
+              <Tab label={<typeIcon.icon className={classes.tab} />} {...tabProps} key={index} />
+            );
           })}
         </Tabs>
       </>

--- a/frontend/src/components/header/DropDownButton.tsx
+++ b/frontend/src/components/header/DropDownButton.tsx
@@ -36,7 +36,7 @@ export default function DropDownButton({ buttonProps, options, children, href }:
         onMouseLeave={handleHideOptions}
         {...buttonProps}
         className={buttonProps ? `${classes.button} ${buttonProps.className}` : `${classes.button}`}
-        href={href}
+        href={href ? href : buttonProps.href}
       >
         {children}
         <ArrowDropDownIcon />

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -106,7 +106,7 @@ const useStyles = makeStyles<Theme, StyleProps>((theme: Theme) => {
     },
     logo: (props) => ({
       [theme.breakpoints.down("md")]: {
-        height: props.isLocationHub ? 35 : "auto",
+        height: (props.isLocationHub || props.isCustomHub) ? 35 : "auto",
       },
       height: 60,
       maxWidth: 180,
@@ -282,7 +282,7 @@ export default function Header({
   background,
   isHubPage,
   hubUrl,
-  isLocationHub,
+  isLocationHub, //->isLocationHub || isCustomhub -> is hubUrl also used by static links?!
 }: HeaderProps) {
   const { user, signOut, notifications, pathName, locale, CUSTOM_HUB_URLS } = useContext(
     UserContext
@@ -358,22 +358,13 @@ export default function Header({
     };
   }, [lastScrollY]);
 
-  const CUSTOM_HOME_LINKS = {
-    prio1: "https://prio1-klima.net/",
-  };
-
   const getLogoLink = () => {
     if (hubUrl) {
-      if (isCustomHub && hubUrl in CUSTOM_HOME_LINKS) {
-        return CUSTOM_HOME_LINKS[hubUrl];
-      } else {
-        return `${localePrefix}/hubs/${hubUrl}`;
-      }
+      return `${localePrefix}/hubs/${hubUrl}`;
     }
     return `${localePrefix}/`;
   };
   const logoLink = getLogoLink();
-  const logoTarget = hubUrl && hubUrl in CUSTOM_HOME_LINKS ? "_blank" : "_self";
 
   return (
     <Box
@@ -383,7 +374,7 @@ export default function Header({
       }`}
     >
       <Container className={classes.container}>
-        <Link href={logoLink} target={logoTarget} className={classes.logoLink} underline="hover">
+        <Link href={logoLink} className={classes.logoLink} underline="hover">
           <img
             src={logo}
             alt={texts.climate_connect_logo}
@@ -401,7 +392,7 @@ export default function Header({
             />
           </Link>
         )}
-        {isNarrowScreen || (isLocationHub && isMediumScreen) ? (
+        {isNarrowScreen || ((isLocationHub || isCustomHub) && isMediumScreen) ? (
           <NarrowScreenLinks
             loggedInUser={user}
             handleLogout={signOut}
@@ -978,7 +969,14 @@ const getLinkButtonProps = ({
   if (!transparentHeader) buttonProps.color = "primary";
   else if (!contained && link.type !== "notificationsButton") buttonProps.color = "inherit";
   if (link.type === "notificationsButton") buttonProps.onClick = toggleShowNotifications;
-  if (link.href) buttonProps.href = localePrefix + link.href;
+  if (link.href) {
+    if(link.isExternalLink) {
+      buttonProps.href = link.href;
+      buttonProps.target = "_blank";      
+    } else {
+      buttonProps.href = localePrefix + link.href;
+    }
+  }
   if (isNarrowScreen && index === linksOutsideDrawer.length - 1) {
     buttonProps.className = classes.marginRight;
   }

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -106,7 +106,7 @@ const useStyles = makeStyles<Theme, StyleProps>((theme: Theme) => {
     },
     logo: (props) => ({
       [theme.breakpoints.down("md")]: {
-        height: (props.isLocationHub || props.isCustomHub) ? 35 : "auto",
+        height: props.isLocationHub || props.isCustomHub ? 35 : "auto",
       },
       height: 60,
       maxWidth: 180,
@@ -970,9 +970,9 @@ const getLinkButtonProps = ({
   else if (!contained && link.type !== "notificationsButton") buttonProps.color = "inherit";
   if (link.type === "notificationsButton") buttonProps.onClick = toggleShowNotifications;
   if (link.href) {
-    if(link.isExternalLink) {
+    if (link.isExternalLink) {
       buttonProps.href = link.href;
-      buttonProps.target = "_blank";      
+      buttonProps.target = "_blank";
     } else {
       buttonProps.href = localePrefix + link.href;
     }


### PR DESCRIPTION
- The logo in the header on custom hubs now redirects to the hub rather to the external prio1 page. This seems to be the more intuitive behavior, otherwise there would be no easy option to get back to the hub from any subpage that has the custom hub's header
- Fixed the colors in the mobile bottom menu
- Fixed redirects on signup and signin page for custom hubs