### PR TITLE
Color and theme fixes for custom hubs

### DIFF
--- a/frontend/src/components/filter/Filters.tsx
+++ b/frontend/src/components/filter/Filters.tsx
@@ -76,7 +76,7 @@ const useStyles = makeStyles<Theme, { filterElementMargin: number; justifyConten
       },
       openMultiSelectButton: {
         border: `1px solid ${theme.palette.grey[500]} !important`,
-      }
+      },
     };
   }
 );
@@ -211,7 +211,9 @@ export default function Filters({
                   <Button
                     variant="outlined"
                     color="grey"
-                    className={`${classes.openMultiSelectButton} ${classes.filterElement} ${isInOverlay && classes.overlayField}`}
+                    className={`${classes.openMultiSelectButton} ${classes.filterElement} ${
+                      isInOverlay && classes.overlayField
+                    }`}
                     onClick={() => handleClickDialogOpen(filter.key)}
                   >
                     {filter.title}

--- a/frontend/src/components/filter/Filters.tsx
+++ b/frontend/src/components/filter/Filters.tsx
@@ -74,6 +74,9 @@ const useStyles = makeStyles<Theme, { filterElementMargin: number; justifyConten
         textAlign: "center",
         marginBottom: theme.spacing(1),
       },
+      openMultiSelectButton: {
+        border: `1px solid ${theme.palette.grey[500]} !important`,
+      }
     };
   }
 );
@@ -208,7 +211,7 @@ export default function Filters({
                   <Button
                     variant="outlined"
                     color="grey"
-                    className={`${classes.filterElement} ${isInOverlay && classes.overlayField}`}
+                    className={`${classes.openMultiSelectButton} ${classes.filterElement} ${isInOverlay && classes.overlayField}`}
                     onClick={() => handleClickDialogOpen(filter.key)}
                   >
                     {filter.title}

--- a/frontend/src/components/hub/CustomBackground.tsx
+++ b/frontend/src/components/hub/CustomBackground.tsx
@@ -69,7 +69,9 @@ export default function CustomBackground({ hubUrl }: Props) {
         if (mobileScreenSize) {
           return null;
         }
-        return <PrioOneBackgroundBrowse />;
+        return null;
+        //temporarily disabled
+        //return <PrioOneBackgroundBrowse />;
       } else if (
         pathname.endsWith("/signup") ||
         pathname.endsWith("/signin") ||
@@ -89,7 +91,7 @@ function PrioOneBackgroundBrowse() {
   const { user } = useContext(UserContext);
   const loggedIn = !!user;
   const classes = useStyles();
-  const height = loggedIn ? 30 : 52.1;
+  const height = loggedIn ? 30 : 55.1;
   const width = 100;
   const triangleBottom = width * 0.5;
   const triangleLeft = width * 3;

--- a/frontend/src/components/hub/HubContent.tsx
+++ b/frontend/src/components/hub/HubContent.tsx
@@ -133,11 +133,9 @@ export default function HubContent({
   hubAmbassador,
   hubSupporters,
   location,
-  allHubs,
   hubData,
   hubUrl,
   image,
-  source,
 }) {
   const { locale, user } = useContext(UserContext);
   const classes = useStyles({ isLocationHub: isLocationHub, loggedOut: !user, image: image });

--- a/frontend/src/components/organization/OrganizationPreviewHeader.tsx
+++ b/frontend/src/components/organization/OrganizationPreviewHeader.tsx
@@ -12,6 +12,7 @@ const useStyles = makeStyles((theme) => {
       overflow: "hidden",
       wordBreak: "break-word",
       lineHeight: 1.3,
+      color: theme.palette.text.primary,
     },
     headerWrapper: {
       justifyContent: "center",

--- a/frontend/src/themes/theme.ts
+++ b/frontend/src/themes/theme.ts
@@ -115,7 +115,7 @@ const theme = createTheme(coreTheme, {
         {
           props: { variant: "outlined" },
           style: {
-            border: "1px solid !important"
+            border: "1px solid !important",
           },
         },
         {

--- a/frontend/src/themes/theme.ts
+++ b/frontend/src/themes/theme.ts
@@ -113,6 +113,12 @@ const theme = createTheme(coreTheme, {
           },
         },
         {
+          props: { variant: "outlined" },
+          style: {
+            border: "1px solid !important"
+          },
+        },
+        {
           props: { variant: "outlined", color: "grey" },
           style: {
             color: coreTheme.palette.text.primary,

--- a/frontend/src/themes/transformThemeData.ts
+++ b/frontend/src/themes/transformThemeData.ts
@@ -1,3 +1,4 @@
+import { createTheme, alpha, darken, lighten } from "@mui/material";
 import defaultTheme from "./hubTheme";
 
 // transform theme data received from the API into a structured theme object
@@ -12,6 +13,16 @@ export const transformThemeData = (data, baseTheme: any = undefined) => {
         styleOverrides: {
           root: {
             color: data?.background_default?.contrastText,
+          },
+        },
+      },
+      MuiButton: {
+        ...restOfDefaultTheme?.components?.MuiButton,
+        styleOverrides: {
+          contained: {
+            '&:hover': {
+              backgroundColor: darken(data?.primary?.main, 0.2), // Adjust the hover color calculation
+            },
           },
         },
       },
@@ -46,5 +57,5 @@ export const transformThemeData = (data, baseTheme: any = undefined) => {
       },
     },
   };
-  return customTheme;
+  return createTheme(customTheme);
 };

--- a/frontend/src/themes/transformThemeData.ts
+++ b/frontend/src/themes/transformThemeData.ts
@@ -20,7 +20,7 @@ export const transformThemeData = (data, baseTheme: any = undefined) => {
         ...restOfDefaultTheme?.components?.MuiButton,
         styleOverrides: {
           contained: {
-            '&:hover': {
+            "&:hover": {
               backgroundColor: darken(data?.primary?.main, 0.2), // Adjust the hover color calculation
             },
           },


### PR DESCRIPTION
- Outlined buttons didn't have a border anymore because of devlink's global.css. This is now fixed.
- Organizations previews had the wrong header color because of devlink's global.css. This is now fixed
- Contained button hover colors are now fixed
- The complicated header image was removed for now to be able to softlaunch the first custom hub. It will be reintroduced later.
