### PR TITLE
Only show related users on custom hubs

### DIFF
--- a/backend/climateconnect_api/management/commands/create_sector_hub_data.py
+++ b/backend/climateconnect_api/management/commands/create_sector_hub_data.py
@@ -24,9 +24,9 @@ class Command(BaseCommand):
                         "language": german_language,
                         "name_translation": "Bauen & Wohnen",
                         "headline_translation": "Ökologisches Bauen als Klimalösung",
-                        "sub_headline_translation": "Wie man mit alternativen Bauweisen den Klimawandel bekämpft"
+                        "sub_headline_translation": "Wie man mit alternativen Bauweisen den Klimawandel bekämpft",
                     }
-                ]
+                ],
             },
             {
                 "name": "Policy & Governance",
@@ -41,9 +41,9 @@ class Command(BaseCommand):
                         "language": german_language,
                         "name_translation": "Politik und Verwaltung",
                         "headline_translation": "Klimapolitik, die die Welt verändert",
-                        "sub_headline_translation": "test"
+                        "sub_headline_translation": "test",
                     }
-                ]
+                ],
             },
             {
                 "name": "Mobility & Transport",
@@ -58,9 +58,9 @@ class Command(BaseCommand):
                         "language": german_language,
                         "name_translation": "Mobilität & Verkehr",
                         "headline_translation": "Mobilität der Zukunft",
-                        "sub_headline_translation": "Mobilitätslösungen zur Bekämpfung des Klimawandels"
+                        "sub_headline_translation": "Mobilitätslösungen zur Bekämpfung des Klimawandels",
                     }
-                ]
+                ],
             },
             {
                 "name": "Food & Agriculture",
@@ -75,9 +75,9 @@ class Command(BaseCommand):
                         "language": german_language,
                         "name_translation": "Ernährung & Landwirtschaft",
                         "headline_translation": "Nachhaltige Lebensmittelproduktion",
-                        "sub_headline_translation": "Nachhaltige Landwirtschaft"
+                        "sub_headline_translation": "Nachhaltige Landwirtschaft",
                     }
-                ]
+                ],
             },
             {
                 "name": "Biodiversity",
@@ -92,9 +92,9 @@ class Command(BaseCommand):
                         "language": german_language,
                         "name_translation": "Biodiversität",
                         "headline_translation": "Schutz und Wiederherstellung von Biodiversität",
-                        "sub_headline_translation": "Biodiversität und Klimawandel"
+                        "sub_headline_translation": "Biodiversität und Klimawandel",
                     }
-                ]
+                ],
             },
             {
                 "name": "Education and Social Action",
@@ -109,9 +109,9 @@ class Command(BaseCommand):
                         "language": german_language,
                         "name_translation": "Bildung und soziales Engagement",
                         "headline_translation": "Bildung für eine nachhaltige Zukunft",
-                        "sub_headline_translation": "Bildung und soziales Engagement"
+                        "sub_headline_translation": "Bildung und soziales Engagement",
                     }
-                ]
+                ],
             },
             {
                 "name": "Energy",
@@ -126,10 +126,10 @@ class Command(BaseCommand):
                         "language": german_language,
                         "name_translation": "Energie",
                         "headline_translation": "Erneuerbare Energien",
-                        "sub_headline_translation": "Erneuerbare Energien und Klimawandel"
+                        "sub_headline_translation": "Erneuerbare Energien und Klimawandel",
                     }
-                ]
-            }
+                ],
+            },
         ]
         for hub in hubs:
             hub_in_db = Hub.objects.create(
@@ -139,7 +139,7 @@ class Command(BaseCommand):
                 sub_headline=hub["sub_headline"],
                 hub_type=hub["hub_type"],
                 segway_text=hub["segway_text"],
-                language=hub["language"]
+                language=hub["language"],
             )
             for translation in hub["translations"]:
                 HubTranslation.objects.create(
@@ -147,6 +147,6 @@ class Command(BaseCommand):
                     language=translation["language"],
                     name_translation=translation["name_translation"],
                     headline_translation=translation["headline_translation"],
-                    sub_headline_translation=translation["sub_headline_translation"]
+                    sub_headline_translation=translation["sub_headline_translation"],
                 )
             print("Inserted hub {}".format(hub["name"]))

--- a/backend/climateconnect_api/views/user_views.py
+++ b/backend/climateconnect_api/views/user_views.py
@@ -209,9 +209,10 @@ class ListMemberProfilesView(ListAPIView):
         )
 
         if "hub" in self.request.query_params:
-            hub = Hub.objects.filter(url_slug=self.request.query_params["hub"])
-            if hub.exists():
-                if hub[0].hub_type == Hub.LOCATION_HUB_TYPE:
+            hubs = Hub.objects.filter(url_slug=self.request.query_params["hub"])
+            if hubs.exists():
+                hub = hubs[0]
+                if hub.hub_type == Hub.LOCATION_HUB_TYPE:
                     location = hub[0].location.all()[0]
                     user_profiles = user_profiles.filter(
                         Q(location__country=location.country)
@@ -232,6 +233,8 @@ class ListMemberProfilesView(ListAPIView):
                             "location__centre_point", location.multi_polygon
                         )
                     )
+                elif hub.hub_type == Hub.CUSTOM_HUB_TYPE:
+                    user_profiles = user_profiles.filter(related_hubs=hub)
 
         if "skills" in self.request.query_params:
             skill_names = self.request.query_params.get("skills").split(",")

--- a/frontend/pages/createorganization.tsx
+++ b/frontend/pages/createorganization.tsx
@@ -522,7 +522,7 @@ const parseOrganizationForRequest = async (
     source_language: sourceLanguage,
     parent_organization: undefined,
     school: undefined,
-    created_in_hub: undefined
+    created_in_hub: undefined,
   };
   if (o.parentorganization) organization.parent_organization = o.parentorganization;
   if (o.background_image)

--- a/frontend/src/components/climateMatch/WelcomeToClimateMatch.tsx
+++ b/frontend/src/components/climateMatch/WelcomeToClimateMatch.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles<Theme, { unfixButtonBar: boolean; isLoading: boolea
   },
   text: {
     fontSize: 20,
-    color: "white"
+    color: "white",
   },
   headline: {
     marginBottom: theme.spacing(4),

--- a/frontend/src/components/profile/ProfilePreview.tsx
+++ b/frontend/src/components/profile/ProfilePreview.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme) => {
       padding: theme.spacing(1),
       paddingBottom: 0,
       marginTop: theme.spacing(2),
-      textAlign: "center"
+      textAlign: "center",
     },
     subtitle: {
       color: `${theme.palette.secondary.main}`,

--- a/frontend/src/components/profile/ProfilePreview.tsx
+++ b/frontend/src/components/profile/ProfilePreview.tsx
@@ -26,6 +26,7 @@ const useStyles = makeStyles((theme) => {
       padding: theme.spacing(1),
       paddingBottom: 0,
       marginTop: theme.spacing(2),
+      textAlign: "center"
     },
     subtitle: {
       color: `${theme.palette.secondary.main}`,

--- a/frontend/src/components/project/ProjectMetaData.tsx
+++ b/frontend/src/components/project/ProjectMetaData.tsx
@@ -79,7 +79,7 @@ const useStyles = makeStyles<Theme, { hovering?: boolean }>((theme) => ({
   },
   additionalInfoCounter: {
     marginLeft: theme.spacing(0.5),
-    color: theme.palette.text.primary
+    color: theme.palette.text.primary,
   },
   typeIcon: {
     width: 20,


### PR DESCRIPTION
We already have a flag `related_hubs` on the `UserProfiles` model. I now added the code that only the users that have a custom hub in their `related_hubs` are shown on the custom hub. Also I fixed a small side-effect of devlink's global. css in ProfilePreviews while I was at it.