### PR TITLE
Edit org and (edit) profile page on prio + bugfixes

### DIFF
--- a/backend/climateconnect_api/utility/email_setup.py
+++ b/backend/climateconnect_api/utility/email_setup.py
@@ -94,10 +94,12 @@ def send_email(
         logger.error("%s: Error sending email: %s" % (send_email.__name__, ex))
 
 
-def get_user_verification_url(verification_key, lang_url):
+def get_user_verification_url(verification_key, lang_url, hub=None):
     # TODO: Set expire time for user verification
     verification_key_str = str(verification_key).replace("-", "%2D")
     url = "%s%s/activate/%s" % (settings.FRONTEND_URL, lang_url, verification_key_str)
+    if hub:
+        url += f"?hub={hub}"
 
     return url
 
@@ -126,9 +128,9 @@ def get_reset_password_url(verification_key, lang_url):
     return url
 
 
-def send_user_verification_email(user, verification_key):
+def send_user_verification_email(user, verification_key, hub=None):
     lang_url = get_user_lang_url(get_user_lang_code(user))
-    url = get_user_verification_url(verification_key, lang_url)
+    url = get_user_verification_url(verification_key, lang_url, hub)
 
     subjects_by_language = {
         "en": "Welcome to Climate Connect! Verify your email address",

--- a/backend/climateconnect_api/views/user_views.py
+++ b/backend/climateconnect_api/views/user_views.py
@@ -163,7 +163,7 @@ class SignUpView(APIView):
             user_profile.is_profile_verified = True
             message = "Congratulations! Your account has been created"
         else:
-            send_user_verification_email(user, user_profile.verification_key)
+            send_user_verification_email(user, user_profile.verification_key, request.data["hub"])
             message = "You're almost done! We have sent an email with a confirmation link to {}. Finish creating your account by clicking the link.".format(
                 user.email
             )  # NOQA

--- a/backend/climateconnect_api/views/user_views.py
+++ b/backend/climateconnect_api/views/user_views.py
@@ -163,7 +163,9 @@ class SignUpView(APIView):
             user_profile.is_profile_verified = True
             message = "Congratulations! Your account has been created"
         else:
-            send_user_verification_email(user, user_profile.verification_key, request.data["hub"])
+            send_user_verification_email(
+                user, user_profile.verification_key, request.data["hub"]
+            )
             message = "You're almost done! We have sent an email with a confirmation link to {}. Finish creating your account by clicking the link.".format(
                 user.email
             )  # NOQA

--- a/frontend/pages/activate/[uuid].tsx
+++ b/frontend/pages/activate/[uuid].tsx
@@ -10,8 +10,8 @@ export async function getServerSideProps(ctx) {
   const uuid = encodeURI(ctx.query.uuid);
   const messages = await profileVerification(uuid, ctx.locale);
   const texts = getTexts({ page: "settings", locale: ctx.locale });
-  if(messages?.successMessage){
-    const messageOnRedirect = messages.successMessage + " " + texts.you_can_now_log_in
+  if (messages?.successMessage) {
+    const messageOnRedirect = messages.successMessage + " " + texts.you_can_now_log_in;
     return sendToLogin(ctx, messageOnRedirect, "success");
   }
   return {

--- a/frontend/pages/activate/[uuid].tsx
+++ b/frontend/pages/activate/[uuid].tsx
@@ -1,14 +1,19 @@
 import { Link, Typography } from "@mui/material";
 import React, { useContext, useEffect } from "react";
-import { apiRequest, getLocalePrefix } from "../../public/lib/apiOperations";
+import { apiRequest, getLocalePrefix, sendToLogin } from "../../public/lib/apiOperations";
 import { redirectOnLogin } from "../../public/lib/profileOperations";
 import getTexts from "../../public/texts/texts";
 import UserContext from "../../src/components/context/UserContext";
 import Layout from "../../src/components/layouts/layout";
 
-export async function getServerSideProps({ query, locale }) {
-  const uuid = encodeURI(query.uuid);
-  const messages = await profileVerification(uuid, locale);
+export async function getServerSideProps(ctx) {
+  const uuid = encodeURI(ctx.query.uuid);
+  const messages = await profileVerification(uuid, ctx.locale);
+  const texts = getTexts({ page: "settings", locale: ctx.locale });
+  if(messages?.successMessage){
+    const messageOnRedirect = messages.successMessage + " " + texts.you_can_now_log_in
+    return sendToLogin(ctx, messageOnRedirect, "success");
+  }
   return {
     props: {
       successMessage: messages["successMessage"] ? messages["successMessage"] : null,

--- a/frontend/pages/editprofile.tsx
+++ b/frontend/pages/editprofile.tsx
@@ -10,13 +10,17 @@ import WideLayout from "../src/components/layouts/WideLayout";
 import getProfileInfoMetadata from "./../public/data/profile_info_metadata";
 import { nullifyUndefinedValues, parseProfile } from "./../public/lib/profileOperations";
 import EditProfileRoot from "./../src/components/profile/EditProfileRoot";
+import getHubTheme from "../src/themes/fetchHubTheme";
+import { transformThemeData } from "../src/themes/transformThemeData";
 
 export async function getServerSideProps(ctx) {
   const { auth_token } = Cookies(ctx);
-  const [skillsOptions, availabilityOptions, userProfile] = await Promise.all([
+  const hubUrl = ctx.query.hub;
+  const [skillsOptions, availabilityOptions, userProfile, hubThemeData] = await Promise.all([
     getSkillsOptions(auth_token, ctx.locale),
     getAvailabilityOptions(auth_token, ctx.locale),
     getUserProfile(auth_token, ctx.locale),
+    getHubTheme(hubUrl),
   ]);
 
   return {
@@ -24,11 +28,13 @@ export async function getServerSideProps(ctx) {
       skillsOptions: skillsOptions,
       availabilityOptions: availabilityOptions,
       user: userProfile,
+      hubUrl: hubUrl,
+      hubThemeData: hubThemeData,
     }),
   };
 }
 
-export default function EditProfilePage({ skillsOptions, availabilityOptions, user }) {
+export default function EditProfilePage({ skillsOptions, availabilityOptions, user, hubUrl, hubThemeData }) {
   const { locale } = useContext(UserContext);
   let infoMetadata: any = getProfileInfoMetadata(locale);
   const texts = getTexts({ page: "profile", locale: locale });
@@ -54,15 +60,24 @@ export default function EditProfilePage({ skillsOptions, availabilityOptions, us
     },
   };
   const profile = user ? parseProfile(user, true) : null;
+
+  const customTheme = hubThemeData ? transformThemeData(hubThemeData) : undefined;
+  const layoutProps = {
+    hubUrl: hubUrl,
+    customTheme: customTheme,
+    headerBackground: hubUrl === "prio1" ? "#7883ff" : "#FFF",
+  };
+
   if (!profile)
     return (
-      <WideLayout title={texts.please_log_in + " " + texts.to_edit_your_profile}>
+      <WideLayout {...layoutProps} title={texts.please_log_in + " " + texts.to_edit_your_profile}>
         <LoginNudge fullPage whatToDo={texts.to_edit_your_profile} />
       </WideLayout>
     );
   else
     return (
       <WideLayout
+        {...layoutProps}
         title={texts.edit_profile}
         message={errorMessage}
         messageType={errorMessage && "error"}
@@ -77,6 +92,7 @@ export default function EditProfilePage({ skillsOptions, availabilityOptions, us
           handleSetLocationOptionsOpen={handleSetLocationOptionsOpen}
           setErrorMessage={setErrorMessage}
           availabilityOptions={availabilityOptions}
+          hubUrl={hubUrl}
         />
       </WideLayout>
     );

--- a/frontend/pages/editprofile.tsx
+++ b/frontend/pages/editprofile.tsx
@@ -34,7 +34,13 @@ export async function getServerSideProps(ctx) {
   };
 }
 
-export default function EditProfilePage({ skillsOptions, availabilityOptions, user, hubUrl, hubThemeData }) {
+export default function EditProfilePage({
+  skillsOptions,
+  availabilityOptions,
+  user,
+  hubUrl,
+  hubThemeData,
+}) {
   const { locale } = useContext(UserContext);
   let infoMetadata: any = getProfileInfoMetadata(locale);
   const texts = getTexts({ page: "profile", locale: locale });

--- a/frontend/pages/profiles/[profileUrl].tsx
+++ b/frontend/pages/profiles/[profileUrl].tsx
@@ -39,7 +39,15 @@ export async function getServerSideProps(ctx) {
   };
 }
 
-export default function ProfilePage({ profile, projects, organizations, ideas, projectTypes, hubUrl, hubThemeData }) {
+export default function ProfilePage({
+  profile,
+  projects,
+  organizations,
+  ideas,
+  projectTypes,
+  hubUrl,
+  hubThemeData,
+}) {
   const token = new Cookies().get("auth_token");
   const { user, locale } = useContext(UserContext);
   const infoMetadata = getProfileInfoMetadata(locale);

--- a/frontend/pages/signin.tsx
+++ b/frontend/pages/signin.tsx
@@ -73,7 +73,7 @@ export default function Signin({ hubSlug, hubThemeData, message, message_type })
     bottomMessage: (
       <span>
         {texts.new_to_climate_connect}{" "}
-        <Link style={{ textDecoration: "underline" }} href={getLocalePrefix(locale) + "/signup"}>
+        <Link style={{ textDecoration: "underline" }} href={`${getLocalePrefix(locale)}/signup${hubSlug ? `?hub=${hubSlug}` : ""}`}>
           {texts.click_here_to_create_an_account}
         </Link>
       </span>
@@ -82,7 +82,7 @@ export default function Signin({ hubSlug, hubThemeData, message, message_type })
 
   const bottomLink = {
     text: texts.forgot_your_password,
-    href: getLocalePrefix(locale) + "/resetpassword",
+    href: `${getLocalePrefix(locale)}/resetpassword${hubSlug ? `?hub=${hubSlug}` : ""}`,
   };
 
   const [errorMessage, setErrorMessage] = React.useState<JSX.Element | null>(message_type !== "success" && message);

--- a/frontend/pages/signin.tsx
+++ b/frontend/pages/signin.tsx
@@ -73,7 +73,10 @@ export default function Signin({ hubSlug, hubThemeData, message, message_type })
     bottomMessage: (
       <span>
         {texts.new_to_climate_connect}{" "}
-        <Link style={{ textDecoration: "underline" }} href={`${getLocalePrefix(locale)}/signup${hubSlug ? `?hub=${hubSlug}` : ""}`}>
+        <Link
+          style={{ textDecoration: "underline" }}
+          href={`${getLocalePrefix(locale)}/signup${hubSlug ? `?hub=${hubSlug}` : ""}`}
+        >
           {texts.click_here_to_create_an_account}
         </Link>
       </span>
@@ -85,7 +88,9 @@ export default function Signin({ hubSlug, hubThemeData, message, message_type })
     href: `${getLocalePrefix(locale)}/resetpassword${hubSlug ? `?hub=${hubSlug}` : ""}`,
   };
 
-  const [errorMessage, setErrorMessage] = React.useState<JSX.Element | null>(message_type !== "success" && message);
+  const [errorMessage, setErrorMessage] = React.useState<JSX.Element | null>(
+    message_type !== "success" && message
+  );
   const [isLoading, setIsLoading] = React.useState(false);
 
   const [initialized, setInitialized] = React.useState(false);

--- a/frontend/pages/signin.tsx
+++ b/frontend/pages/signin.tsx
@@ -15,11 +15,15 @@ import Login from "../src/components/signup/Login";
 export async function getServerSideProps(ctx) {
   const hubSlug = ctx.query.hub;
   const message = ctx.query.message;
+  const message_type = ctx.query.message_type;
 
   // early return to avoid fetching /undefined/theme
   if (!hubSlug) {
     return {
-      props: {},
+      props: {
+        message: message || null,
+        message_type: message_type || null,
+      },
     };
   }
   const hubThemeData = await getHubTheme(hubSlug);
@@ -27,7 +31,10 @@ export async function getServerSideProps(ctx) {
   // early return to avoid a hubSlug, that is not supported within the backend
   if (!hubThemeData) {
     return {
-      props: {},
+      props: {
+        message: message || null,
+        message_type: message_type || null,
+      },
     };
   }
 
@@ -36,11 +43,12 @@ export async function getServerSideProps(ctx) {
       hubSlug: hubSlug || null, // undefined is not allowed in JSON, so we use null
       hubThemeData: hubThemeData || null, // undefined is not allowed in JSON, so we use null
       message: message || null,
+      message_type: message_type || null,
     },
   };
 }
 
-export default function Signin({ hubSlug, hubThemeData, message }) {
+export default function Signin({ hubSlug, hubThemeData, message, message_type }) {
   const { user, signIn, locale } = useContext(UserContext);
   const texts = getTexts({ page: "profile", locale: locale, hubName: hubSlug });
   const hugeScreen = useMediaQuery((theme: Theme) => theme.breakpoints.up("xl"));
@@ -77,7 +85,7 @@ export default function Signin({ hubSlug, hubThemeData, message }) {
     href: getLocalePrefix(locale) + "/resetpassword",
   };
 
-  const [errorMessage, setErrorMessage] = React.useState<JSX.Element | null>(message);
+  const [errorMessage, setErrorMessage] = React.useState<JSX.Element | null>(message_type !== "success" && message);
   const [isLoading, setIsLoading] = React.useState(false);
 
   const [initialized, setInitialized] = React.useState(false);
@@ -135,13 +143,12 @@ export default function Signin({ hubSlug, hubThemeData, message }) {
   const customThemeSignIn = hubThemeData
     ? transformThemeData(hubThemeData, themeSignUp)
     : themeSignUp;
-
   return (
     <WideLayout
       title={texts.log_in}
       //message={errorMessage}
       //messageType={errorMessage && "error"}
-      messageType="error"
+      messageType={message_type ? message_type : "error"}
       isLoading={isLoading}
       customTheme={customTheme}
       isHubPage={hubSlug !== ""}

--- a/frontend/pages/signup.tsx
+++ b/frontend/pages/signup.tsx
@@ -195,6 +195,7 @@ export default function Signup({ hubUrl, hubThemeData }) {
                   errorMessage={errorMessages[steps[0]]}
                   isSmallScreen={isSmallScreen}
                   texts={texts}
+                  hub={hubUrl}
                 />
               ) : (
                 curStep === "personalinfo" && (

--- a/frontend/public/lib/apiOperations.ts
+++ b/frontend/public/lib/apiOperations.ts
@@ -75,7 +75,7 @@ export const redirect = (
 export const sendToLogin = async (
   { resolvedUrl, locale, res }: GetServerSidePropsContext,
   message: string,
-  message_type:string="error"
+  message_type: string = "error"
 ) => {
   const pathName = resolvedUrl.slice(1);
   const queryString = resolvedUrl.split("?")[1];
@@ -86,7 +86,7 @@ export const sendToLogin = async (
   if (queryObject.hub) {
     url += "&hub=" + queryObject.hub;
   }
-  if(message_type){
+  if (message_type) {
     url += "&message_type=" + message_type;
   }
   res.writeHead(302, { Location: url });

--- a/frontend/public/lib/apiOperations.ts
+++ b/frontend/public/lib/apiOperations.ts
@@ -74,7 +74,8 @@ export const redirect = (
 
 export const sendToLogin = async (
   { resolvedUrl, locale, res }: GetServerSidePropsContext,
-  message: string
+  message: string,
+  message_type:string="error"
 ) => {
   const pathName = resolvedUrl.slice(1);
   const queryString = resolvedUrl.split("?")[1];
@@ -84,6 +85,9 @@ export const sendToLogin = async (
     languagePrefix + "/signin?redirect=" + encodeURIComponent(pathName) + "&message=" + message;
   if (queryObject.hub) {
     url += "&hub=" + queryObject.hub;
+  }
+  if(message_type){
+    url += "&message_type=" + message_type;
   }
   res.writeHead(302, { Location: url });
   res.end();

--- a/frontend/public/lib/profileOperations.ts
+++ b/frontend/public/lib/profileOperations.ts
@@ -57,7 +57,7 @@ export function redirectOnLogin(user, redirectUrl, locale) {
       pathname: "/editprofile",
       query: {
         message: SIGN_UP_MESSAGE,
-        hub: hub
+        hub: hub,
       },
     });
   } else if (redirectUrl) {

--- a/frontend/public/lib/profileOperations.ts
+++ b/frontend/public/lib/profileOperations.ts
@@ -49,12 +49,15 @@ const convertUndefinedToNull = (inputObject) => {
 export function redirectOnLogin(user, redirectUrl, locale) {
   const texts = getTexts({ page: "profile", locale: locale });
   const SIGN_UP_MESSAGE = texts.sign_up_message;
+  const urlParams = new URLSearchParams(window.location.search);
+  const hub = urlParams.get("hub");
 
   if (user.has_logged_in < 2) {
     Router.push({
       pathname: "/editprofile",
       query: {
         message: SIGN_UP_MESSAGE,
+        hub: hub
       },
     });
   } else if (redirectUrl) {

--- a/frontend/public/texts/settings.json
+++ b/frontend/public/texts/settings.json
@@ -202,5 +202,9 @@
   "email_on_new_org_project_text": {
     "en": "Get notified when an organization you follow posts an update",
     "de": "Ich möchte benachrichtigt werden, wenn eine Organisation, der ich folge, eine Update postet"
+  },
+  "you_can_now_log_in": {
+    "en": "You can now log in.",
+    "de": "Du kannst dich jetzt einloggen."
   }
 }

--- a/frontend/src/components/general/MultiLevelSelector.tsx
+++ b/frontend/src/components/general/MultiLevelSelector.tsx
@@ -106,6 +106,7 @@ const useStyles = makeStyles<
     selectedItemsHeader: {
       fontWeight: "bold",
       fontSize: "16px",
+      color: theme.palette.background.default_contrastText,
     },
     selectedItem: {
       background: theme.palette.background.default_contrastText,

--- a/frontend/src/components/hub/LocalAmbassadorInfoBox.tsx
+++ b/frontend/src/components/hub/LocalAmbassadorInfoBox.tsx
@@ -68,7 +68,7 @@ export default function LocalAmbassadorInfoBox({ hubAmbassador, hubData, hubSupp
       return redirect("/signup", {
         redirect: window.location.pathname + window.location.search,
         errorMessage: texts.please_create_an_account_or_log_in_to_contact_the_ambassador,
-        hub: hubData.url_slug
+        hub: hubData.url_slug,
       });
     }
 

--- a/frontend/src/components/hub/LocalAmbassadorInfoBox.tsx
+++ b/frontend/src/components/hub/LocalAmbassadorInfoBox.tsx
@@ -68,6 +68,7 @@ export default function LocalAmbassadorInfoBox({ hubAmbassador, hubData, hubSupp
       return redirect("/signup", {
         redirect: window.location.pathname + window.location.search,
         errorMessage: texts.please_create_an_account_or_log_in_to_contact_the_ambassador,
+        hub: hubData.url_slug
       });
     }
 

--- a/frontend/src/components/layouts/LayoutWrapper.tsx
+++ b/frontend/src/components/layouts/LayoutWrapper.tsx
@@ -127,7 +127,7 @@ export default function LayoutWrapper({
       error: error,
       success: success,
       action: promptLogIn ? (
-        <LogInAction onClose={handleSnackbarClose}/>
+        <LogInAction onClose={handleSnackbarClose} />
       ) : action ? (
         action
       ) : (

--- a/frontend/src/components/layouts/LayoutWrapper.tsx
+++ b/frontend/src/components/layouts/LayoutWrapper.tsx
@@ -127,7 +127,7 @@ export default function LayoutWrapper({
       error: error,
       success: success,
       action: promptLogIn ? (
-        <LogInAction onClose={handleSnackbarClose} />
+        <LogInAction onClose={handleSnackbarClose}/>
       ) : action ? (
         action
       ) : (

--- a/frontend/src/components/profile/EditProfileRoot.tsx
+++ b/frontend/src/components/profile/EditProfileRoot.tsx
@@ -34,7 +34,7 @@ export default function EditAccountRoot({
   handleSetLocationOptionsOpen,
   setErrorMessage,
   availabilityOptions,
-  hubUrl
+  hubUrl,
 }) {
   const { locale, locales } = useContext(UserContext);
   const cookies = new Cookies();
@@ -112,7 +112,7 @@ export default function EditAccountRoot({
           pathname: `/profiles/${response.data.url_slug}`,
           query: {
             message: texts.you_have_successfully_updated_your_profile,
-            hub: hubUrl
+            hub: hubUrl,
           },
         });
       })

--- a/frontend/src/components/profile/EditProfileRoot.tsx
+++ b/frontend/src/components/profile/EditProfileRoot.tsx
@@ -34,6 +34,7 @@ export default function EditAccountRoot({
   handleSetLocationOptionsOpen,
   setErrorMessage,
   availabilityOptions,
+  hubUrl
 }) {
   const { locale, locales } = useContext(UserContext);
   const cookies = new Cookies();
@@ -55,7 +56,7 @@ export default function EditAccountRoot({
   };
 
   const handleCancel = () => {
-    Router.push("/profiles/" + profile.url_slug);
+    Router.push(`/profiles/${profile.url_slug}${hubUrl ? `?hub=${hubUrl}` : ""}`);
   };
 
   const handleGoToPreviousStep = () => {
@@ -108,9 +109,10 @@ export default function EditAccountRoot({
     })
       .then(function (response) {
         Router.push({
-          pathname: "/profiles/" + response.data.url_slug,
+          pathname: `/profiles/${response.data.url_slug}`,
           query: {
             message: texts.you_have_successfully_updated_your_profile,
+            hub: hubUrl
           },
         });
       })

--- a/frontend/src/components/profile/ProfileRoot.tsx
+++ b/frontend/src/components/profile/ProfileRoot.tsx
@@ -96,7 +96,7 @@ export default function ProfileRoot({
   token,
   texts,
   locale,
-  hubUrl
+  hubUrl,
 }) {
   const { showFeedbackMessage } = useContext(FeedbackContext);
   const classes = useStyles();
@@ -163,7 +163,10 @@ export default function ProfileRoot({
         <div className={classes.sectionHeadlineWithButtonContainer}>
           <h2>{isOwnAccount ? texts.your_projects : texts.this_users_projects}</h2>
           {isTinyScreen ? (
-            <IconButton href={`${getLocalePrefix(locale)}/share${hubUrl ? `?hub=${hubUrl}`: ""}`} size="large">
+            <IconButton
+              href={`${getLocalePrefix(locale)}/share${hubUrl ? `?hub=${hubUrl}` : ""}`}
+              size="large"
+            >
               <ControlPointSharpIcon
                 className={classes.button}
                 variant="contained"
@@ -171,7 +174,11 @@ export default function ProfileRoot({
               />
             </IconButton>
           ) : (
-            <Button variant="contained" color="primary" href={`${getLocalePrefix(locale)}/share${hubUrl ? `?hub=${hubUrl}`: ""}`}>
+            <Button
+              variant="contained"
+              color="primary"
+              href={`${getLocalePrefix(locale)}/share${hubUrl ? `?hub=${hubUrl}` : ""}`}
+            >
               <ControlPointSharpIcon className={classes.innerIcon} />
               {texts.share_a_project}
             </Button>
@@ -207,7 +214,12 @@ export default function ProfileRoot({
         <div className={classes.sectionHeadlineWithButtonContainer}>
           <h2>{isOwnAccount ? texts.your_organizations : texts.this_users_organizations}</h2>
           {isTinyScreen ? (
-            <IconButton href={`${getLocalePrefix(locale)}/createorganization${hubUrl ? `?hub=${hubUrl}`: ""}`} size="large">
+            <IconButton
+              href={`${getLocalePrefix(locale)}/createorganization${
+                hubUrl ? `?hub=${hubUrl}` : ""
+              }`}
+              size="large"
+            >
               <ControlPointSharpIcon
                 className={classes.button}
                 variant="contained"
@@ -218,7 +230,9 @@ export default function ProfileRoot({
             <Button
               variant="contained"
               color="primary"
-              href={`${getLocalePrefix(locale)}/createorganization${hubUrl ? `?hub=${hubUrl}`: ""}`}
+              href={`${getLocalePrefix(locale)}/createorganization${
+                hubUrl ? `?hub=${hubUrl}` : ""
+              }`}
             >
               <ControlPointSharpIcon className={classes.innerIcon} />
               {texts.create_an_organization}

--- a/frontend/src/components/profile/ProfileRoot.tsx
+++ b/frontend/src/components/profile/ProfileRoot.tsx
@@ -96,6 +96,7 @@ export default function ProfileRoot({
   token,
   texts,
   locale,
+  hubUrl
 }) {
   const { showFeedbackMessage } = useContext(FeedbackContext);
   const classes = useStyles();
@@ -141,7 +142,7 @@ export default function ProfileRoot({
     <AccountPage
       account={profile}
       default_background={DEFAULT_BACKGROUND_IMAGE}
-      editHref={getLocalePrefix(locale) + "/editprofile"}
+      editHref={`${getLocalePrefix(locale)}/editprofile${hubUrl ? `?hub=${hubUrl}` : ""}`}
       isOwnAccount={isOwnAccount}
       isOrganization={false}
       infoMetadata={infoMetadata}
@@ -162,7 +163,7 @@ export default function ProfileRoot({
         <div className={classes.sectionHeadlineWithButtonContainer}>
           <h2>{isOwnAccount ? texts.your_projects : texts.this_users_projects}</h2>
           {isTinyScreen ? (
-            <IconButton href={getLocalePrefix(locale) + "/share"} size="large">
+            <IconButton href={`${getLocalePrefix(locale)}/share${hubUrl ? `?hub=${hubUrl}`: ""}`} size="large">
               <ControlPointSharpIcon
                 className={classes.button}
                 variant="contained"
@@ -170,7 +171,7 @@ export default function ProfileRoot({
               />
             </IconButton>
           ) : (
-            <Button variant="contained" color="primary" href={getLocalePrefix(locale) + "/share"}>
+            <Button variant="contained" color="primary" href={`${getLocalePrefix(locale)}/share${hubUrl ? `?hub=${hubUrl}`: ""}`}>
               <ControlPointSharpIcon className={classes.innerIcon} />
               {texts.share_a_project}
             </Button>
@@ -206,7 +207,7 @@ export default function ProfileRoot({
         <div className={classes.sectionHeadlineWithButtonContainer}>
           <h2>{isOwnAccount ? texts.your_organizations : texts.this_users_organizations}</h2>
           {isTinyScreen ? (
-            <IconButton href={getLocalePrefix(locale) + "/createorganization"} size="large">
+            <IconButton href={`${getLocalePrefix(locale)}/createorganization${hubUrl ? `?hub=${hubUrl}`: ""}`} size="large">
               <ControlPointSharpIcon
                 className={classes.button}
                 variant="contained"
@@ -217,7 +218,7 @@ export default function ProfileRoot({
             <Button
               variant="contained"
               color="primary"
-              href={getLocalePrefix(locale) + "/createorganization"}
+              href={`${getLocalePrefix(locale)}/createorganization${hubUrl ? `?hub=${hubUrl}`: ""}`}
             >
               <ControlPointSharpIcon className={classes.innerIcon} />
               {texts.create_an_organization}

--- a/frontend/src/components/signup/BasicInfo.tsx
+++ b/frontend/src/components/signup/BasicInfo.tsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function BasicInfo({ handleSubmit, errorMessage, values, texts, isSmallScreen }) {
+export default function BasicInfo({ handleSubmit, errorMessage, values, texts, isSmallScreen, hub }) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
   const fields = [
@@ -73,7 +73,7 @@ export default function BasicInfo({ handleSubmit, errorMessage, values, texts, i
 
   const bottomLink = {
     text: texts.log_in,
-    href: getLocalePrefix(locale) + "/signin",
+    href: `${getLocalePrefix(locale)}/signin${hub ? `?hub=${hub}` : ""}`,
   };
 
   const StepIndicator = () => (

--- a/frontend/src/components/signup/BasicInfo.tsx
+++ b/frontend/src/components/signup/BasicInfo.tsx
@@ -39,7 +39,14 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function BasicInfo({ handleSubmit, errorMessage, values, texts, isSmallScreen, hub }) {
+export default function BasicInfo({
+  handleSubmit,
+  errorMessage,
+  values,
+  texts,
+  isSmallScreen,
+  hub,
+}) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
   const fields = [

--- a/frontend/src/components/snackbarActions/LogInAction.tsx
+++ b/frontend/src/components/snackbarActions/LogInAction.tsx
@@ -16,6 +16,8 @@ export default function LogInAction({ onClose }) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "general", locale: locale });
+  const urlParams = new URLSearchParams(window.location.search);
+  const hub = urlParams.get("hub");
 
   const onClickSignUp = () => {
     let redirectUrl = window.location.href
@@ -24,7 +26,7 @@ export default function LogInAction({ onClose }) {
     if (redirectUrl[0] === "/") {
       redirectUrl = redirectUrl.slice(1, redirectUrl.length);
     }
-    redirect("/signin", { redirect: redirectUrl });
+    redirect("/signin", { redirect: redirectUrl, hub: hub });
   };
 
   return (


### PR DESCRIPTION
- Fixed faulty redirects from #1430
- Custom hub themes now work on the profile page and the edit profile page
- During sign up flow you don't leave the Prio1 theme anymore when you come from Prio1, also adapted the email for that