### PR TITLE
fixed donate link on the about page

### DIFF
--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -427,7 +427,7 @@ export default function Header({
           />
         )}
       </Container>
-      <div>{isStaticPage && <StaticPageLinks />}</div>
+      <div>{isStaticPage && <StaticPageLinks isCustomHub={isCustomHub} />}</div>
     </Box>
   );
 }

--- a/frontend/src/components/header/StaticPageLinks.tsx
+++ b/frontend/src/components/header/StaticPageLinks.tsx
@@ -52,13 +52,14 @@ const useStyles = makeStyles((theme) => ({
 
 //Component containing the bar below the header listing all the static pages
 //It's only shown if you're already on a static page (e.g. "/about")
-export default function StaticPageLinks() {
+export default function StaticPageLinks({ isCustomHub }) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
   const isNarrowScreen = useMediaQuery<Theme>(theme.breakpoints.down("md"));
 
   const texts = getTexts({ page: "navigation", locale: locale });
-  const STATIC_PAGE_LINKS = getStaticPageLinks(texts, locale, true);
+  const STATIC_PAGE_LINKS = getStaticPageLinks(texts, locale, isCustomHub, true);
+
   const getLinksToShow = () => {
     if (isNarrowScreen) {
       return STATIC_PAGE_LINKS.slice(0, 2);

--- a/frontend/src/components/header/StaticPageLinks.tsx
+++ b/frontend/src/components/header/StaticPageLinks.tsx
@@ -59,7 +59,6 @@ export default function StaticPageLinks({ isCustomHub }) {
 
   const texts = getTexts({ page: "navigation", locale: locale });
   const STATIC_PAGE_LINKS = getStaticPageLinks(texts, locale, isCustomHub, true);
-
   const getLinksToShow = () => {
     if (isNarrowScreen) {
       return STATIC_PAGE_LINKS.slice(0, 2);
@@ -74,7 +73,7 @@ export default function StaticPageLinks({ isCustomHub }) {
           <DirectlyDisplayedLinks links={getLinksToShow()} isNarrowScreen={isNarrowScreen} />
           {isNarrowScreen && (
             <DropDownButton
-              options={STATIC_PAGE_LINKS}
+              options={STATIC_PAGE_LINKS.slice(2)}
               buttonProps={{
                 classes: {
                   root: classes.white,


### PR DESCRIPTION
## Description
fixing issue [1435](https://github.com/climateconnect/climateconnect/issues/1435)
## Checked the following
- [x] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme

## Changes
Donate link on Desktop:
<img width="844" alt="Screenshot 2025-02-10 at 1 20 10 PM" src="https://github.com/user-attachments/assets/94536a38-3621-4d92-9cf6-626368de421a" />

Donate link on small devices:
<img width="379" alt="Screenshot 2025-02-10 at 1 19 37 PM" src="https://github.com/user-attachments/assets/7b12c862-385c-4b05-a625-261de55c025e" />

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
