### PR TITLE
Visual fixes for custom hubs

### DIFF
--- a/frontend/pages/hubs/[hubUrl].tsx
+++ b/frontend/pages/hubs/[hubUrl].tsx
@@ -360,21 +360,22 @@ export default function Hub({
           </BrowseContext.Provider>
         </div>
         {isSmallScreen && (
-          <FabShareButton locale={locale} hubAmbassador={hubAmbassador} isCustomHub={isCustomHub} />
+          <FabShareButton locale={locale} hubAmbassador={hubAmbassador} isCustomHub={isCustomHub} hubUrl={hubUrl} />
         )}
       </WideLayout>
     </>
   );
 }
 
-const FabShareButton = ({ locale, hubAmbassador, isCustomHub }) => {
+const FabShareButton = ({ locale, hubAmbassador, isCustomHub, hubUrl }) => {
   const fabClass = shareProjectFabStyle({ isCustomHub: isCustomHub });
+  const queryString = hubUrl ? `?hub=${hubUrl}` : "";
   return (
     <Fab
       className={fabClass.fabShareProject}
       size="medium"
       color="primary"
-      href={`${getLocalePrefix(locale)}/share`}
+      href={`${getLocalePrefix(locale)}/share${queryString}`}
       sx={{ bottom: (theme) => (hubAmbassador ? theme.spacing(11.5) : theme.spacing(5)) }}
       // onClick={}
     >

--- a/frontend/pages/signin.tsx
+++ b/frontend/pages/signin.tsx
@@ -52,6 +52,7 @@ export default function Signin({ hubSlug, hubThemeData, message, message_type })
   const { user, signIn, locale } = useContext(UserContext);
   const texts = getTexts({ page: "profile", locale: locale, hubName: hubSlug });
   const hugeScreen = useMediaQuery((theme: Theme) => theme.breakpoints.up("xl"));
+  const mobileScreenSize = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"));
 
   const fields = [
     {
@@ -151,15 +152,15 @@ export default function Signin({ hubSlug, hubThemeData, message, message_type })
   return (
     <WideLayout
       title={texts.log_in}
-      //message={errorMessage}
+      //message={errorMessage}z
       //messageType={errorMessage && "error"}
       messageType={message_type ? message_type : "error"}
       isLoading={isLoading}
       customTheme={customTheme}
       isHubPage={hubSlug !== ""}
       hubUrl={hubSlug}
-      headerBackground="transparent"
-      footerTextColor={hubSlug && "white"}
+      headerBackground={(hubSlug === "prio1" && mobileScreenSize) ? "#7883ff" : "transparent"}
+      footerTextColor={hubSlug && !mobileScreenSize && "white"}
     >
       <Container maxWidth={hugeScreen ? "xl" : "lg"}>
         <ThemeProvider theme={customThemeSignIn}>

--- a/frontend/pages/signup.tsx
+++ b/frontend/pages/signup.tsx
@@ -180,8 +180,8 @@ export default function Signup({ hubUrl, hubThemeData }) {
       isLoading={isLoading}
       hubUrl={hubUrl}
       customTheme={customTheme}
-      headerBackground="transparent"
-      footerTextColor={hubUrl && "white"}
+      headerBackground={(hubUrl === "prio1" && isSmallScreen) ? "#7883ff" : "transparent"}
+      footerTextColor={hubUrl && !isSmallScreen && "white"}
     >
       <Container maxWidth={hugeScreen ? "xl" : "lg"}>
         <ThemeProvider theme={customThemeSignUp}>

--- a/frontend/src/components/browse/BrowseContent.tsx
+++ b/frontend/src/components/browse/BrowseContent.tsx
@@ -521,6 +521,7 @@ export default function BrowseContent({
             TYPES_BY_TAB_VALUE={TYPES_BY_TAB_VALUE}
             //TODO(unused) type_names={type_names}
             hubAmbassador={hubAmbassador}
+            hubUrl={hubUrl}
           />
         )}
 

--- a/frontend/src/components/browse/MobileBottomMenu.tsx
+++ b/frontend/src/components/browse/MobileBottomMenu.tsx
@@ -33,6 +33,7 @@ export default function MobileBottomMenu({
   handleTabChange,
   TYPES_BY_TAB_VALUE,
   hubAmbassador,
+  hubUrl
 }) {
   const type_icons = {
     projects: AssignmentIcon,
@@ -44,7 +45,7 @@ export default function MobileBottomMenu({
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <ContactAmbassadorButton mobile hubAmbassador={hubAmbassador} />
+      <ContactAmbassadorButton mobile hubAmbassador={hubAmbassador} hubUrl={hubUrl} />
       <>
         <Tabs
           variant="fullWidth"

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -74,11 +74,6 @@ const useStyles = makeStyles<Theme, StyleProps>((theme: Theme) => {
         transition: "all 0.25s linear", // use all instead of transform since the background color too is changing at some point. It'll be nice to have a smooth transition.
       };
     },
-    hideHeader: {
-      [theme.breakpoints.down("lg")]: {
-        transform: "translateY(-97px)",
-      },
-    },
     spacingBottom: {
       marginBottom: theme.spacing(2),
     },
@@ -340,23 +335,7 @@ export default function Header({
   };
 
   const logo = getLogo();
-  const [hideHeader, setHideHeader] = useState(false);
-  const [lastScrollY, setLastScrollY] = useState(0);
 
-  useEffect(() => {
-    const handleScroll = () => {
-      setHideHeader(window.scrollY > lastScrollY); // hide when user scrolls down and show when user scrolls up
-
-      // remember last scroll position
-      setLastScrollY(window.scrollY);
-    };
-
-    window.addEventListener("scroll", handleScroll);
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    };
-  }, [lastScrollY]);
 
   const getLogoLink = () => {
     if (hubUrl) {
@@ -369,9 +348,7 @@ export default function Header({
   return (
     <Box
       component="header"
-      className={`${classes.root} ${className} ${!noSpacingBottom && classes.spacingBottom} ${
-        hideHeader ? classes.hideHeader : ""
-      }`}
+      className={`${classes.root} ${className} ${!noSpacingBottom && classes.spacingBottom}`}
     >
       <Container className={classes.container}>
         <Link href={logoLink} className={classes.logoLink} underline="hover">

--- a/frontend/src/components/hub/ContactAmbassadorButton.tsx
+++ b/frontend/src/components/hub/ContactAmbassadorButton.tsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export default function ContactAmbassadorButton({ hubAmbassador, mobile }) {
+export default function ContactAmbassadorButton({ hubAmbassador, mobile, hubUrl=null }) {
   const classes = useStyles();
   const { locale, user } = useContext(UserContext);
   const cookies = new Cookies();
@@ -44,16 +44,21 @@ export default function ContactAmbassadorButton({ hubAmbassador, mobile }) {
 
   const handleClickContact = async (e) => {
     e.preventDefault();
+    const queryString = hubUrl ? `?hub=${hubUrl}` : "";
 
     if (!user) {
-      return redirect("/signup", {
+      let queryString: any = {
         redirect: window.location.pathname + window.location.search,
         errorMessage: texts.please_create_an_account_or_log_in_to_contact_the_ambassador,
-      });
+      }
+      if(hubUrl) {
+        queryString.hub = hubUrl;
+      }
+      return redirect("/signup", queryString);
     }
 
     const chat = await startPrivateChat(hubAmbassador?.user, token, locale);
-    Router.push("/chat/" + chat.chat_uuid + "/");
+    Router.push("/chat/" + chat.chat_uuid + "/" + queryString);
   };
   if (mobile) {
     return (

--- a/frontend/src/components/hub/CustomBackground.tsx
+++ b/frontend/src/components/hub/CustomBackground.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   prioOneMobileBackground: {
-    backgroundColor: theme.palette.secondary.light,
+    backgroundColor: theme.palette.background.main,
   },
   prioOneAccentBackground: {
     borderLeftColor: theme.palette.secondary.light,
@@ -55,7 +55,8 @@ type Props = { hubUrl: string | undefined };
  *
  */
 export default function CustomBackground({ hubUrl }: Props) {
-  const mobileScreenSize = useMediaQuery((theme: Theme) => theme.breakpoints.down("md"));
+  const mediumOrSmallScreenSize = useMediaQuery((theme: Theme) => theme.breakpoints.down("md"));
+  const mobileScreenSize = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"));
 
   // TODO: mobileScreenSize is not yet supported
   if (!hubUrl) {
@@ -66,7 +67,7 @@ export default function CustomBackground({ hubUrl }: Props) {
   switch (hubUrl.toLowerCase()) {
     case "prio1": {
       if (pathname.endsWith("/hubs/prio1")) {
-        if (mobileScreenSize) {
+        if (mediumOrSmallScreenSize) {
           return null;
         }
         return null;

--- a/frontend/src/components/layouts/LayoutWrapper.tsx
+++ b/frontend/src/components/layouts/LayoutWrapper.tsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
   leaveSpaceForFooter: {
     position: "relative",
     //height of footer + spacing(1)
-    paddingBottom: theme.spacing(9),
+    paddingBottom: theme.spacing(12),
     minHeight: "100vh",
   },
   spinnerContainer: {


### PR DESCRIPTION
- On the smallest screensize the background background on signup and signin page is now white
- On the share page the "Next Step" button was partly hidden behind the footer on mobile. Fixed this by adding more margin
- When clicking "Contact local ambassador" or the "+" button in the mobile bottom menu the hub query string would not carry over. This is now fixed.
- The header does not get hidden anymore when scrolling down. This was quite annoying on mobile and had little use in general. This means that the header is now always shown on the index page