### PR TITLE
fixed supporter name 

### DIFF
--- a/frontend/pages/hubs/[hubUrl].tsx
+++ b/frontend/pages/hubs/[hubUrl].tsx
@@ -361,7 +361,12 @@ export default function Hub({
           </BrowseContext.Provider>
         </div>
         {isSmallScreen && (
-          <FabShareButton locale={locale} hubAmbassador={hubAmbassador} isCustomHub={isCustomHub} hubUrl={hubUrl} />
+          <FabShareButton
+            locale={locale}
+            hubAmbassador={hubAmbassador}
+            isCustomHub={isCustomHub}
+            hubUrl={hubUrl}
+          />
         )}
       </WideLayout>
     </>

--- a/frontend/pages/signin.tsx
+++ b/frontend/pages/signin.tsx
@@ -159,7 +159,7 @@ export default function Signin({ hubSlug, hubThemeData, message, message_type })
       customTheme={customTheme}
       isHubPage={hubSlug !== ""}
       hubUrl={hubSlug}
-      headerBackground={(hubSlug === "prio1" && mobileScreenSize) ? "#7883ff" : "transparent"}
+      headerBackground={hubSlug === "prio1" && mobileScreenSize ? "#7883ff" : "transparent"}
       footerTextColor={hubSlug && !mobileScreenSize && "white"}
     >
       <Container maxWidth={hugeScreen ? "xl" : "lg"}>

--- a/frontend/pages/signup.tsx
+++ b/frontend/pages/signup.tsx
@@ -180,7 +180,7 @@ export default function Signup({ hubUrl, hubThemeData }) {
       isLoading={isLoading}
       hubUrl={hubUrl}
       customTheme={customTheme}
-      headerBackground={(hubUrl === "prio1" && isSmallScreen) ? "#7883ff" : "transparent"}
+      headerBackground={hubUrl === "prio1" && isSmallScreen ? "#7883ff" : "transparent"}
       footerTextColor={hubUrl && !isSmallScreen && "white"}
     >
       <Container maxWidth={hugeScreen ? "xl" : "lg"}>

--- a/frontend/src/components/browse/MobileBottomMenu.tsx
+++ b/frontend/src/components/browse/MobileBottomMenu.tsx
@@ -33,7 +33,7 @@ export default function MobileBottomMenu({
   handleTabChange,
   TYPES_BY_TAB_VALUE,
   hubAmbassador,
-  hubUrl
+  hubUrl,
 }) {
   const type_icons = {
     projects: AssignmentIcon,

--- a/frontend/src/components/dialogs/HubSupportersDialog.tsx
+++ b/frontend/src/components/dialogs/HubSupportersDialog.tsx
@@ -55,9 +55,9 @@ const useStyles = makeStyles((theme) => ({
     fontSize: "17px",
     fontWeight: "600",
     overflow: "hidden",
-    textOverflow: "ellipsis",
     color: "black",
     margin: 0,
+    wordBreak: "break-word",
   }),
   supporterSubtitle: () => ({
     margin: 0,

--- a/frontend/src/components/dialogs/HubSupportersDialog.tsx
+++ b/frontend/src/components/dialogs/HubSupportersDialog.tsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: "50%",
   },
   supporterName: () => ({
-    fontSize: "17px",
+    fontSize: "16px",
     fontWeight: "600",
     overflow: "hidden",
     color: "black",

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -336,7 +336,6 @@ export default function Header({
 
   const logo = getLogo();
 
-
   const getLogoLink = () => {
     if (hubUrl) {
       return `${localePrefix}/hubs/${hubUrl}`;

--- a/frontend/src/components/hub/ContactAmbassadorButton.tsx
+++ b/frontend/src/components/hub/ContactAmbassadorButton.tsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export default function ContactAmbassadorButton({ hubAmbassador, mobile, hubUrl=null }) {
+export default function ContactAmbassadorButton({ hubAmbassador, mobile, hubUrl = null }) {
   const classes = useStyles();
   const { locale, user } = useContext(UserContext);
   const cookies = new Cookies();
@@ -50,8 +50,8 @@ export default function ContactAmbassadorButton({ hubAmbassador, mobile, hubUrl=
       let queryString: any = {
         redirect: window.location.pathname + window.location.search,
         errorMessage: texts.please_create_an_account_or_log_in_to_contact_the_ambassador,
-      }
-      if(hubUrl) {
+      };
+      if (hubUrl) {
         queryString.hub = hubUrl;
       }
       return redirect("/signup", queryString);

--- a/frontend/src/components/hub/HubSupporters.tsx
+++ b/frontend/src/components/hub/HubSupporters.tsx
@@ -21,7 +21,6 @@ const useStyles = makeStyles((theme) => ({
   root: {
     backgroundColor: theme.palette.primary.main,
     borderRadius: 4,
-    paddingBottom: "15px",
     paddingRight: "5px",
     paddingLeft: "5px",
     width: 320,
@@ -40,6 +39,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.background.default,
     borderRadius: "4px",
     position: "relative",
+    marginBottom: "20px",
   },
   customDot: {
     bottom: "-16px",
@@ -84,6 +84,7 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.down("md")]: {
       padding: 0,
     },
+    height: "100%",
   },
   containerInSmallDevices: {
     display: "flex",

--- a/frontend/src/components/hub/HubSupporters.tsx
+++ b/frontend/src/components/hub/HubSupporters.tsx
@@ -128,7 +128,6 @@ const HubSupporters = ({
   mobileVersion,
   hubName,
 }: HubSupporter) => {
-  
   const classes = useStyles({ containerClass: containerClass });
   const isSmallOrMediumScreen = useMediaQuery<Theme>((theme) => theme.breakpoints.down("md"));
   const { locale } = useContext(UserContext);

--- a/frontend/src/components/hub/HubSupporters.tsx
+++ b/frontend/src/components/hub/HubSupporters.tsx
@@ -67,6 +67,7 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: "600",
     color: "black",
     margin: 0,
+    wordBreak: "break-word",
   },
   supporterSubtitle: (containerClass) => ({
     margin: 0,

--- a/frontend/src/components/hub/HubSupporters.tsx
+++ b/frontend/src/components/hub/HubSupporters.tsx
@@ -74,13 +74,8 @@ const useStyles = makeStyles((theme) => ({
     fontSize: "12px",
     fontWeight: "normal",
     color: "#484848",
-    whiteSpace: "nowrap",
-    width: containerClass ? "160px" : "200px",
     overflow: "hidden",
-    textOverflow: "ellipsis",
-    [`@media (min-width: 1200px) and (max-width: 1370px)`]: {
-      width: "150px",
-    },
+    wordBreak: "break-word",
   }),
   carouselEntry: {
     padding: " 8px",

--- a/frontend/src/components/hub/HubSupporters.tsx
+++ b/frontend/src/components/hub/HubSupporters.tsx
@@ -62,16 +62,12 @@ const useStyles = makeStyles((theme) => ({
   supporterImg: {
     borderRadius: "50%",
   },
-  supporterName: (containerClass) => ({
+  supporterName: {
     fontSize: "17px",
     fontWeight: "600",
-    whiteSpace: "nowrap",
-    width: containerClass ? "160px" : "200px",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
     color: "black",
     margin: 0,
-  }),
+  },
   supporterSubtitle: (containerClass) => ({
     margin: 0,
     fontSize: "12px",
@@ -131,6 +127,7 @@ const HubSupporters = ({
   mobileVersion,
   hubName,
 }: HubSupporter) => {
+  
   const classes = useStyles({ containerClass: containerClass });
   const isSmallOrMediumScreen = useMediaQuery<Theme>((theme) => theme.breakpoints.down("md"));
   const { locale } = useContext(UserContext);


### PR DESCRIPTION
## Description
This PR addresses the issue [1456](https://github.com/climateconnect/climateconnect/issues/1456)
## Checked the following
- [x] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme

## changes
On desktop:
<img width="933" alt="Screenshot 2025-02-26 at 11 09 14 AM" src="https://github.com/user-attachments/assets/d8998da9-b912-4888-93ad-0f04bc43ebd0" />
On small devices:
<img width="368" alt="Screenshot 2025-02-26 at 11 10 11 AM" src="https://github.com/user-attachments/assets/1dbfcd5d-2ae8-44f2-bcc8-fc527816ab99" />



<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
