### PR TITLE
Automatically redirect to hub after login if no redirect is se

### DIFF
--- a/frontend/pages/signin.tsx
+++ b/frontend/pages/signin.tsx
@@ -109,6 +109,8 @@ export default function Signin({ hubSlug, hubThemeData, message, message_type })
 
         redirectUrl += decodedRedirect;
         setRedirectUrl(redirectUrl);
+      } else if (params.hub) {
+        setRedirectUrl(getLocalePrefix(locale) + "/hubs/"+params.hub)
       }
       setInitialized(true);
       //TODO: remove router


### PR DESCRIPTION
If you go to /login?hub=<hub_name> and log in you'd be redirected to the browse page afterwards which is quite unexpected.
This PR makes a change so that your default redirect url is /hubs/<hub_name> if hub is set in the query string and there is no explicitly defined redirect url.