### PR TITLE
Fix custom prio one background

### DIFF
--- a/frontend/pages/hubs/[hubUrl].tsx
+++ b/frontend/pages/hubs/[hubUrl].tsx
@@ -361,7 +361,12 @@ export default function Hub({
           </BrowseContext.Provider>
         </div>
         {isSmallScreen && (
-          <FabShareButton locale={locale} hubAmbassador={hubAmbassador} isCustomHub={isCustomHub} hubUrl={hubUrl} />
+          <FabShareButton
+            locale={locale}
+            hubAmbassador={hubAmbassador}
+            isCustomHub={isCustomHub}
+            hubUrl={hubUrl}
+          />
         )}
       </WideLayout>
     </>

--- a/frontend/pages/signin.tsx
+++ b/frontend/pages/signin.tsx
@@ -110,7 +110,7 @@ export default function Signin({ hubSlug, hubThemeData, message, message_type })
         redirectUrl += decodedRedirect;
         setRedirectUrl(redirectUrl);
       } else if (params.hub) {
-        setRedirectUrl(getLocalePrefix(locale) + "/hubs/"+params.hub)
+        setRedirectUrl(getLocalePrefix(locale) + "/hubs/" + params.hub);
       }
       setInitialized(true);
       //TODO: remove router
@@ -161,7 +161,7 @@ export default function Signin({ hubSlug, hubThemeData, message, message_type })
       customTheme={customTheme}
       isHubPage={hubSlug !== ""}
       hubUrl={hubSlug}
-      headerBackground={(hubSlug === "prio1" && mobileScreenSize) ? "#7883ff" : "transparent"}
+      headerBackground={hubSlug === "prio1" && mobileScreenSize ? "#7883ff" : "transparent"}
       footerTextColor={hubSlug && !mobileScreenSize && "white"}
     >
       <Container maxWidth={hugeScreen ? "xl" : "lg"}>

--- a/frontend/pages/signup.tsx
+++ b/frontend/pages/signup.tsx
@@ -180,7 +180,7 @@ export default function Signup({ hubUrl, hubThemeData }) {
       isLoading={isLoading}
       hubUrl={hubUrl}
       customTheme={customTheme}
-      headerBackground={(hubUrl === "prio1" && isSmallScreen) ? "#7883ff" : "transparent"}
+      headerBackground={hubUrl === "prio1" && isSmallScreen ? "#7883ff" : "transparent"}
       footerTextColor={hubUrl && !isSmallScreen && "white"}
     >
       <Container maxWidth={hugeScreen ? "xl" : "lg"}>

--- a/frontend/src/components/browse/MobileBottomMenu.tsx
+++ b/frontend/src/components/browse/MobileBottomMenu.tsx
@@ -33,7 +33,7 @@ export default function MobileBottomMenu({
   handleTabChange,
   TYPES_BY_TAB_VALUE,
   hubAmbassador,
-  hubUrl
+  hubUrl,
 }) {
   const type_icons = {
     projects: AssignmentIcon,

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -336,7 +336,6 @@ export default function Header({
 
   const logo = getLogo();
 
-
   const getLogoLink = () => {
     if (hubUrl) {
       return `${localePrefix}/hubs/${hubUrl}`;

--- a/frontend/src/components/hub/ContactAmbassadorButton.tsx
+++ b/frontend/src/components/hub/ContactAmbassadorButton.tsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export default function ContactAmbassadorButton({ hubAmbassador, mobile, hubUrl=null }) {
+export default function ContactAmbassadorButton({ hubAmbassador, mobile, hubUrl = null }) {
   const classes = useStyles();
   const { locale, user } = useContext(UserContext);
   const cookies = new Cookies();
@@ -50,8 +50,8 @@ export default function ContactAmbassadorButton({ hubAmbassador, mobile, hubUrl=
       let queryString: any = {
         redirect: window.location.pathname + window.location.search,
         errorMessage: texts.please_create_an_account_or_log_in_to_contact_the_ambassador,
-      }
-      if(hubUrl) {
+      };
+      if (hubUrl) {
         queryString.hub = hubUrl;
       }
       return redirect("/signup", queryString);

--- a/frontend/src/components/hub/CustomBackground.tsx
+++ b/frontend/src/components/hub/CustomBackground.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme) => ({
     left: 0,
     right: 0,
     bottom: 0,
-    zIndex: -1,
+    zIndex: -10,
     overflow: "hidden",
   },
 
@@ -105,6 +105,25 @@ export function PrioOneBackgroundBrowse() {
         className={classes.prioOneAccentBackground}
       />
     </div>
+  );
+}
+
+export function PrioOneBackgroundBrowseIcon() {
+  const largeScreenSize = useMediaQuery((theme: Theme) => theme.breakpoints.down("lg"));
+
+  let width = 160;
+  let height = 160;
+  if (largeScreenSize) {
+    width = 130;
+    height = 130;
+  }
+
+  return (
+    <Image
+      src={"/images/custom_hubs/" + PRIO1_SLUG + "_group.svg"}
+      width={width}
+      height={height}
+    ></Image>
   );
 }
 

--- a/frontend/src/components/hub/CustomBackground.tsx
+++ b/frontend/src/components/hub/CustomBackground.tsx
@@ -86,8 +86,9 @@ export function CustomBackground({ hubUrl }: Props) {
   }
 }
 
-export function PrioOneBackgroundBrowse() {
+export function PrioOneBackgroundBrowse({ isLoggedInUser }: { isLoggedInUser: boolean }) {
   const classes = useStyles();
+  const largeScreenSize = useMediaQuery("(max-width: 1550px)");
 
   return (
     <div className={`${classes.background} ${classes.prioOneDefaultBackground}`}>
@@ -104,6 +105,19 @@ export function PrioOneBackgroundBrowse() {
         }}
         className={classes.prioOneAccentBackground}
       />
+      {!isLoggedInUser && !largeScreenSize && (
+        <div
+          style={{
+            position: "absolute",
+            top: "25%",
+            right: "0.5vw",
+            width: "11rem",
+            height: "11rem",
+          }}
+        >
+          <Image src={"/images/custom_hubs/" + PRIO1_SLUG + "_group.svg"} layout="fill"></Image>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/hub/CustomBackground.tsx
+++ b/frontend/src/components/hub/CustomBackground.tsx
@@ -39,6 +39,9 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.background.main,
   },
   prioOneAccentBackground: {
+    backgroundColor: theme.palette.secondary.light,
+  },
+  prioOneAccentBackgroundBorderLeft: {
     borderLeftColor: theme.palette.secondary.light,
   },
 }));
@@ -54,11 +57,9 @@ type Props = { hubUrl: string | undefined };
  * @param hubUrl The URL of the hub.
  *
  */
-export default function CustomBackground({ hubUrl }: Props) {
-  const mediumOrSmallScreenSize = useMediaQuery((theme: Theme) => theme.breakpoints.down("md"));
+export function CustomBackground({ hubUrl }: Props) {
   const mobileScreenSize = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"));
 
-  // TODO: mobileScreenSize is not yet supported
   if (!hubUrl) {
     return null;
   }
@@ -67,12 +68,9 @@ export default function CustomBackground({ hubUrl }: Props) {
   switch (hubUrl.toLowerCase()) {
     case "prio1": {
       if (pathname.endsWith("/hubs/prio1")) {
-        if (mediumOrSmallScreenSize) {
-          return null;
-        }
+        // HubContent itself includes the background in the correct place.
+        // There is no background for the whole page needed. Therefore, return null in this case.
         return null;
-        //temporarily disabled
-        //return <PrioOneBackgroundBrowse />;
       } else if (
         pathname.endsWith("/signup") ||
         pathname.endsWith("/signin") ||
@@ -88,39 +86,24 @@ export default function CustomBackground({ hubUrl }: Props) {
   }
 }
 
-function PrioOneBackgroundBrowse() {
-  const { user } = useContext(UserContext);
-  const loggedIn = !!user;
+export function PrioOneBackgroundBrowse() {
   const classes = useStyles();
-  const height = loggedIn ? 30 : 55.1;
-  const width = 100;
-  const triangleBottom = width * 0.5;
-  const triangleLeft = width * 3;
 
   return (
-    <div
-      className={`${classes.background} ${classes.prioOneDefaultBackground}`}
-      style={{ bottom: "auto", height: `${height}vh` }}
-    >
-      {/* Container within the background */}
-      <div style={{ position: "relative" }}>
-        {/* Upper triangle */}
-        <div
-          style={{
-            width: 0,
-            height: 0,
-            borderBottom: `${triangleBottom}vh` + " solid transparent",
-            borderLeftWidth: `${triangleLeft}vh`,
-            borderLeftStyle: "solid",
+    <div className={`${classes.background} ${classes.prioOneDefaultBackground}`}>
+      {/* upper triangle (top left corner) - actually it is a trapezoid */}
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
 
-            position: "absolute",
-            top: 0,
-            left: 0,
-            transform: "rotate(0deg)",
-          }}
-          className={classes.prioOneAccentBackground}
-        />
-      </div>
+          // Note: clipPath is needed with the traditional way the percentages
+          // are not supported:
+          // boorderBottom: "100% solid blue"
+          clipPath: "polygon(0% 100%, 100% 55%, 100% 0%, 0% 0%)",
+        }}
+        className={classes.prioOneAccentBackground}
+      />
     </div>
   );
 }
@@ -136,7 +119,7 @@ function PrioOneBackgroundAuth({ mobileScreenSize }) {
       <div style={{ position: "relative" }}>
         {/* Upper triangle */}
         <div
-          className={classes.prioOneAccentBackground}
+          className={classes.prioOneAccentBackgroundBorderLeft}
           style={{
             width: 0,
             height: 0,

--- a/frontend/src/components/hub/CustomBackground.tsx
+++ b/frontend/src/components/hub/CustomBackground.tsx
@@ -88,7 +88,7 @@ export function CustomBackground({ hubUrl }: Props) {
 
 export function PrioOneBackgroundBrowse({ isLoggedInUser }: { isLoggedInUser: boolean }) {
   const classes = useStyles();
-  const largeScreenSize = useMediaQuery("(max-width: 1550px)");
+  const largeScreenSize = useMediaQuery("(max-width: 1300px)");
 
   return (
     <div className={`${classes.background} ${classes.prioOneDefaultBackground}`}>

--- a/frontend/src/components/hub/HubContent.tsx
+++ b/frontend/src/components/hub/HubContent.tsx
@@ -16,7 +16,7 @@ import HubHeadlineContainer from "./HubHeadlineContainer";
 import HubSupporters from "./HubSupporters";
 import { DePrio1Willkommen, EnPrio1Welcome } from "../../../devlink";
 import theme from "../../themes/theme";
-import { PrioOneBackgroundBrowse } from "./CustomBackground";
+import { PrioOneBackgroundBrowse, PrioOneBackgroundBrowseIcon } from "./CustomBackground";
 
 type MakeStylesProps = {
   isLocationHub: boolean;
@@ -89,6 +89,7 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     justifyContent: "space-between",
     margin: "16px auto",
+    gap: "1rem",
     alignItems: "end",
   }),
   infoBoxContainer: {
@@ -227,6 +228,9 @@ export default function HubContent({
                       )}
                       {hubSupporters?.length > 0 && (
                         <HubSupporters supportersList={hubSupporters} hubName={hubData?.name} />
+                      )}
+                      {!hubAmbassador && !(hubSupporters?.length > 0) && (
+                        <PrioOneBackgroundBrowseIcon />
                       )}
                     </>
                   ))}

--- a/frontend/src/components/hub/HubContent.tsx
+++ b/frontend/src/components/hub/HubContent.tsx
@@ -178,7 +178,7 @@ export default function HubContent({
         )}
         {isLocationHub ? (
           <div className={classes.topSectionWrapper}>
-            <PrioOneBackgroundBrowse />
+            <PrioOneBackgroundBrowse isLoggedInUser={user ? true : false} />
             <Container>
               <div className={classes.dashboardAndStatboxWrapper}>
                 {user ? (
@@ -229,7 +229,7 @@ export default function HubContent({
                       {hubSupporters?.length > 0 && (
                         <HubSupporters supportersList={hubSupporters} hubName={hubData?.name} />
                       )}
-                      {!hubAmbassador && !(hubSupporters?.length > 0) && (
+                      {!(hubSupporters?.length > 0) && hubUrl === "prio1" && (
                         <PrioOneBackgroundBrowseIcon />
                       )}
                     </>

--- a/frontend/src/components/hub/HubContent.tsx
+++ b/frontend/src/components/hub/HubContent.tsx
@@ -16,6 +16,7 @@ import HubHeadlineContainer from "./HubHeadlineContainer";
 import HubSupporters from "./HubSupporters";
 import { DePrio1Willkommen, EnPrio1Welcome } from "../../../devlink";
 import theme from "../../themes/theme";
+import { PrioOneBackgroundBrowse } from "./CustomBackground";
 
 type MakeStylesProps = {
   isLocationHub: boolean;
@@ -96,7 +97,13 @@ const useStyles = makeStyles((theme) => ({
     float: "right",
   },
   topSectionWrapper: (props: MakeStylesProps) => ({
-    background: props.isLocationHub ? `url('${props.image}')` : "none",
+    // TODO: decide if "props.image" should be checked as well
+    // > pro: it prevents requests to "/undefined"
+    // > con: it might be a bug that should be fixed in the parent component
+    // > con: it will not "report" the bug
+    background: props.isLocationHub && props.image ? `url('${props.image}')` : "none",
+
+    position: "relative",
     backgroundSize: "cover",
     backgroundPosition: "bottom center",
     paddingTop: theme.spacing(2),
@@ -107,6 +114,8 @@ const useStyles = makeStyles((theme) => ({
     },
   }),
   backgroundImageContainer: (props: MakeStylesProps) => ({
+    //TODO dead code?
+    display: "none",
     background: props.isLocationHub ? `url('${props.image}')` : "none",
     backgroundSize: "cover",
     backgroundPosition: "bottom center",
@@ -168,6 +177,7 @@ export default function HubContent({
         )}
         {isLocationHub ? (
           <div className={classes.topSectionWrapper}>
+            <PrioOneBackgroundBrowse />
             <Container>
               <div className={classes.dashboardAndStatboxWrapper}>
                 {user ? (

--- a/frontend/src/components/hub/HubTabsNavigation.tsx
+++ b/frontend/src/components/hub/HubTabsNavigation.tsx
@@ -165,8 +165,8 @@ export default function HubTabsNavigation({
             </div>
           )}
           {isNarrowScreen && (
-            <>                        
-              {(hubUrl === "prio1") && (
+            <>
+              {hubUrl === "prio1" && (
                 <Link
                   className={classes.climateMatchLink}
                   href={"https://prio1-klima.net"}
@@ -182,7 +182,7 @@ export default function HubTabsNavigation({
                 underline="hover"
               >
                 {texts.projects_worldwide}
-              </Link>  
+              </Link>
             </>
           )}
         </div>

--- a/frontend/src/components/layouts/WideLayout.tsx
+++ b/frontend/src/components/layouts/WideLayout.tsx
@@ -11,7 +11,7 @@ import Header from "../header/Header";
 import ElementSpaceToTop from "../hooks/ElementSpaceToTop";
 import DonationCampaignInformation from "../staticpages/donate/DonationCampaignInformation";
 import LayoutWrapper from "./LayoutWrapper";
-import CustomBackground from "../hub/CustomBackground";
+import { CustomBackground } from "../hub/CustomBackground";
 
 type ThemeProps = { noSpaceBottom?: boolean; isStaticPage?: boolean };
 const useStyles = makeStyles<Theme, ThemeProps>((theme) => ({


### PR DESCRIPTION
## Checked the following
- [x] Pages affected by this change work on mobile when logged in
- [x] Pages affected by this change work on mobile when logged out
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
Did not test the last yet. It is custom for the Prio1 Hub and should only show up on its page.

## Pages affected:
- /de/hubs/prio1
- /en/hubs/prio1
- /hubs/prio1

## What and Why

Updated background for the prio1 browse hub page. Now includes:
- correctly renders the triangle / trapezoid shape
- background height is no longer hard coded
- includes Prio1 Icon if logged in and no supporters are present
- includes Prio1 Icon if not logged in and screen width is greater then 1550px (sufficient space)

## Note 
One could improve Browse Page when logged out and (770px < screen width < 900px)

![image](https://github.com/user-attachments/assets/8875e0ed-a012-4077-9d5d-98ed942f69b4)
