### PR TITLE
fixed chat text color

### DIFF
--- a/frontend/src/components/communication/MessageContent.tsx
+++ b/frontend/src/components/communication/MessageContent.tsx
@@ -8,7 +8,7 @@ import youtubeRegex from "youtube-regex";
 import { getFragmentsWithMentions } from "../../utils/mentions_markdown";
 import UserContext from "../context/UserContext";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   link: {
     color: "inherit",
     "&:visited": {
@@ -18,15 +18,20 @@ const useStyles = makeStyles({
   youtubeWrapper: {
     maxWidth: "640px",
   },
-});
+  messageContext: (received) => ({
+    alignSelf: "flex-start",
+    color: received ? "default" : theme?.palette?.primary?.contrastText,
+  }),
+}));
 
 type Props = {
   content?: any;
   renderYoutubeVideos?: boolean;
+  received?: boolean;
 };
 
-export default function MessageContent({ content, renderYoutubeVideos = false }: Props) {
-  const classes = useStyles();
+export default function MessageContent({ content, renderYoutubeVideos = false, received }: Props) {
+  const classes = useStyles(received);
   const { locale } = useContext(UserContext);
   //workaround to get target="_blank" because setting 'properties' on the Linkify component doesn't work
   const componentDecorator = (href, text, key) => (
@@ -98,7 +103,7 @@ export default function MessageContent({ content, renderYoutubeVideos = false }:
         const fragments = getFragmentsWithMentions(content, true, locale);
         return (
           <div key={index}>
-            <Typography display="inline" style={{ alignSelf: "flex-start" }}>
+            <Typography display="inline" className={classes.messageContext}>
               {fragments}
             </Typography>
           </div>

--- a/frontend/src/components/communication/chat/Message.tsx
+++ b/frontend/src/components/communication/chat/Message.tsx
@@ -54,7 +54,7 @@ export default function Message({ message, classes, isPrivateChat }) {
             </Typography>
           </Link>
         )}
-        <MessageContent content={message.content} />
+        <MessageContent content={message.content} received={received} />
         <div className={ownClasses.timeContainer}>
           <div className={`${ownClasses.time} ${!received && ownClasses.sentTime}`}>
             {message.unconfirmed && (


### PR DESCRIPTION
## Description
This PR addresses the issue [1467](https://github.com/climateconnect/climateconnect/issues/1467)
## Checked the following
- [x] Pages affected by this change work on mobile

## Screenshot:

<img width="584" alt="Screenshot 2025-02-28 at 10 47 15 AM" src="https://github.com/user-attachments/assets/b05d7659-4185-44dd-b8a1-baaab82b8b67" />

<img width="584" alt="Screenshot 2025-02-28 at 10 47 27 AM" src="https://github.com/user-attachments/assets/c89eaf20-20c4-4bfe-80db-15008c03f573" />




<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
