### PR TITLE
Code Health: Fixed Future Warning of Deprecated Method 

### DIFF
--- a/backend/climateconnect_api/utility/translation.py
+++ b/backend/climateconnect_api/utility/translation.py
@@ -182,9 +182,9 @@ def get_translations(
                             keys_to_ignore_for_translation,
                             depth + 1,
                         )
-                    finished_translations[target_language][
-                        key
-                    ] = translated_text_object["translated_text"]
+                    finished_translations[target_language][key] = (
+                        translated_text_object["translated_text"]
+                    )
     return {"translations": finished_translations, "source_language": source_language}
 
 

--- a/backend/organization/utility/project.py
+++ b/backend/organization/utility/project.py
@@ -258,7 +258,7 @@ def get_similar_projects(url_slug: str, return_count=5):
     # calcaulte skills match %
     # since skills are 1 to Many to projects, we need to group the skills in a list
     skills_df = df.groupby(["url_slug"]).agg({"skills": set})
-    source_skills = skills_df.loc[url_slug][0]
+    source_skills = skills_df.loc[url_slug].iloc[0]
     skills_df["source_skills"] = [source_skills for i in range(0, len(skills_df))]
     skills_df["skills_match"] = skills_df.apply(
         lambda x: sets_match(x["source_skills"], x["skills"]), axis=1
@@ -267,16 +267,8 @@ def get_similar_projects(url_slug: str, return_count=5):
     # calcualte tags match %
     # since tags are 1 to Many to projects, we need to group the tags in a list
     tags_df = df.groupby(["url_slug"]).agg({"tag_project": set})
-    other = (
-        df.groupby(["url_slug"])["tag_project"]
-        .apply(set)
-        .reset_index(name="tag_project")
-    )
+    source_tags = tags_df.loc[url_slug].iloc[0]
 
-    print(tags_df)
-    print(other)
-
-    source_tags = tags_df.loc[url_slug][0]
     tags_df["source_tag_project"] = [source_tags for i in range(0, len(tags_df))]
     tags_df["tags_match"] = tags_df.apply(
         lambda x: sets_match(x["source_tag_project"], x["tag_project"]), axis=1

--- a/backend/organization/utility/project.py
+++ b/backend/organization/utility/project.py
@@ -267,6 +267,15 @@ def get_similar_projects(url_slug: str, return_count=5):
     # calcualte tags match %
     # since tags are 1 to Many to projects, we need to group the tags in a list
     tags_df = df.groupby(["url_slug"]).agg({"tag_project": set})
+    other = (
+        df.groupby(["url_slug"])["tag_project"]
+        .apply(set)
+        .reset_index(name="tag_project")
+    )
+
+    print(tags_df)
+    print(other)
+
     source_tags = tags_df.loc[url_slug][0]
     tags_df["source_tag_project"] = [source_tags for i in range(0, len(tags_df))]
     tags_df["tags_match"] = tags_df.apply(


### PR DESCRIPTION
## Checked the following
- [x] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme
- [x] Run within `/frontend`: `yarn format && yarn lint`
- [x] Run within `/backend`: `make format && make lint`

## What and Why
During development encountered the following warnings. Refactored the code to address the warnings without changing behavior:
```py
FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version,
integer keys will always be treated as labels (consistent with DataFrame behavior).
To access a value by position, use `ser.iloc[pos]`
  source_tags = tags_df.loc[url_slug][0]
```
and 
```py
/home/akbakas/proj/climateconnect/backend/organization/utility/project.py:261:
FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version
integer keys will always be treated as labels (consistent with DataFrame behavior). To access a
value by position, use `ser.iloc[pos]`
  source_skills = skills_df.loc[url_slug][0]
```