### PR TITLE
hotfix for locaiton lookup, instable api call no longer breaks the search

### DIFF
--- a/backend/climateconnect_api/utility/translation.py
+++ b/backend/climateconnect_api/utility/translation.py
@@ -182,9 +182,9 @@ def get_translations(
                             keys_to_ignore_for_translation,
                             depth + 1,
                         )
-                    finished_translations[target_language][
-                        key
-                    ] = translated_text_object["translated_text"]
+                    finished_translations[target_language][key] = (
+                        translated_text_object["translated_text"]
+                    )
     return {"translations": finished_translations, "source_language": source_language}
 
 

--- a/backend/location/utility.py
+++ b/backend/location/utility.py
@@ -14,8 +14,6 @@ from location.models import Location
 import logging
 import json
 
-# import base64
-
 logger = logging.getLogger("django")
 
 
@@ -289,19 +287,15 @@ def get_location_with_range(query_params):
                 + "\nresponse:"
                 + response.text
             )
+
+            # try to use the location within the query params (provided by the client via the post request)
+            # as a backup if the location could not be fetched from the api
             if "location" not in query_params:
                 raise ValidationError(
                     "Error while fetching location and no backup: " + str(e)
                 )
 
-            # encoded_param = query_params.get("location")
-            # location_data = json.loads(base64.b64decode(encoded_param))
-            # backup_location = json.loads(location_data)
             location_object = query_params.get("location")
-            print(
-                location_object["boundingbox"],
-                location_object["display_name"],
-            )
 
         location = get_location(format_location(location_object, False))
         location_in_db = (

--- a/backend/location/utility.py
+++ b/backend/location/utility.py
@@ -1,4 +1,4 @@
-import json
+import base64, json
 
 import requests
 from django.conf import settings
@@ -282,30 +282,25 @@ def get_location_with_range(query_params):
         try:
             location_object = json.loads(response.text)[0]
         except ValueError as e:
-            logger.error("#" * 40)
-            logger.error("Error while fetching location:")
-            logger.error("-" * 40)
-            logger.error("locations:")
             logger.error(
-                "{}".format(
-                    list(map(lambda x: str(x.place_id), Location.objects.all()))
-                )
+                "Error while fetching location: "
+                + str(e)
+                + "\nresponse:"
+                + response.text
             )
+            if "location" not in query_params:
+                raise ValidationError(
+                    "Error while fetching location and no backup: " + str(e)
+                )
 
-            logger.error("-" * 40)
-            logger.error("place:\t" + filter_place_id)
-            logger.error("location_type:\t" + location_type)
-            logger.error("osm:\t" + query_params.get("osm"))
-            logger.error("URL:\t" + url)
-            logger.error("=" * 40)
-            logger.error("Response:\t" + response.text)
-            logger.error("-" * 40)
-            logger.error("Response Status:\t" + str(response.status_code))
-            logger.error("=" * 40)
-            logger.error("Trace:\n", exc_info=True)
-            logger.error("#" * 40)
-
-            raise ValidationError("Error while fetching location: " + str(e))
+            # encoded_param = query_params.get("location")
+            # location_data = json.loads(base64.b64decode(encoded_param))
+            # backup_location = json.loads(location_data)
+            location_object = query_params.get("location")
+            print(
+                location_object["boundingbox"],
+                location_object["display_name"],
+            )
 
         location = get_location(format_location(location_object, False))
         location_in_db = (

--- a/backend/location/utility.py
+++ b/backend/location/utility.py
@@ -278,21 +278,19 @@ def get_location_with_range(query_params):
         params = "&format=json&addressdetails=1&polygon_geojson=1&accept-language=en-US,en;q=0.9&polygon_threshold=0.001"
         url = url_root + osm_id_param + params
         response = requests.get(url)
-        try:
+        if response.status_code == 200:
             location_object = json.loads(response.text)[0]
-        except ValueError as e:
+        else:
             logger.error(
-                "Error while fetching location: "
-                + str(e)
-                + "\nresponse:"
-                + response.text
+                "Error while fetching location: " + "\nresponse:" + response.text
             )
 
             # try to use the location within the query params (provided by the client via the post request)
             # as a backup if the location could not be fetched from the api
             if "location" not in query_params:
                 raise ValidationError(
-                    "Error while fetching location and no backup: " + str(e)
+                    f"Error while fetching location and no backup option: {response.status_code} | "
+                    + response.text
                 )
 
             location_object = query_params.get("location")

--- a/backend/location/utility.py
+++ b/backend/location/utility.py
@@ -1,5 +1,3 @@
-import base64, json
-
 import requests
 from django.conf import settings
 from django.contrib.gis.geos import (
@@ -14,6 +12,9 @@ from rest_framework.exceptions import ValidationError
 
 from location.models import Location
 import logging
+import json
+
+# import base64
 
 logger = logging.getLogger("django")
 

--- a/backend/organization/models/members.py
+++ b/backend/organization/models/members.py
@@ -76,7 +76,11 @@ class ProjectMember(models.Model):
         unique_together = ("user", "project")
 
     def __str__(self):
-        return "User %s %s member for Project %s" % (self.user.first_name, self.user.last_name, self.project.name)
+        return "User %s %s member for Project %s" % (
+            self.user.first_name,
+            self.user.last_name,
+            self.project.name,
+        )
 
 
 class OrganizationMember(models.Model):
@@ -143,7 +147,7 @@ class OrganizationMember(models.Model):
 
     def __str__(self):
         return "User %s %s member for organization %s" % (
-            self.user.first_name, 
+            self.user.first_name,
             self.user.last_name,
             self.organization.name,
         )

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -140,6 +140,27 @@ class ListProjectsView(ListAPIView):
     pagination_class = ProjectsPagination
     serializer_class = ProjectStubSerializer
 
+    def post(self, request, *args, **kwargs):
+        """
+        Handle POST requests for search functionality.
+        """
+        # Extract location from the POST data
+        location = request.data
+
+        # Add location to the query params
+        query_params = request.query_params.copy()
+
+        if "place_id" in location and "geojson" in location:
+            query_params["location"] = location
+
+        # query_params["radius"] = 15
+
+        # Replace request.query_params with our updated version
+        request._request.GET = query_params
+
+        # Call the standard list method which handles filtering and pagination
+        return self.list(request, *args, **kwargs)
+
     def get_queryset(self):
         user = self.request.user
         user_profile = None
@@ -238,6 +259,7 @@ class ListProjectsView(ListAPIView):
 
         if "place" in self.request.query_params and "osm" in self.request.query_params:
             location_data = get_location_with_range(self.request.query_params)
+            print("radius", location_data["radius"])
             projects = (
                 projects.filter(
                     Q(loc__country=location_data["country"])

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -153,8 +153,6 @@ class ListProjectsView(ListAPIView):
         if "place_id" in location and "geojson" in location:
             query_params["location"] = location
 
-        # query_params["radius"] = 15
-
         # Replace request.query_params with our updated version
         request._request.GET = query_params
 
@@ -259,7 +257,6 @@ class ListProjectsView(ListAPIView):
 
         if "place" in self.request.query_params and "osm" in self.request.query_params:
             location_data = get_location_with_range(self.request.query_params)
-            print("radius", location_data["radius"])
             projects = (
                 projects.filter(
                     Q(loc__country=location_data["country"])

--- a/frontend/public/lib/filterOperations.ts
+++ b/frontend/public/lib/filterOperations.ts
@@ -223,6 +223,7 @@ export async function applyNewFilters({
       page: 1,
       token: token,
       urlEnding: newUrlEnding,
+      location: newFilters.location ?? undefined,
       locale: locale,
     };
     if (idea) {

--- a/frontend/public/lib/getDataOperations.ts
+++ b/frontend/public/lib/getDataOperations.ts
@@ -25,16 +25,6 @@ export async function getDataFromServer({
     // &category=Lowering%20food%20waste&
     url += urlEnding;
   }
-  // if (location instanceof Object && !(location instanceof String)) {
-  //   // use base64 encoding to pass the location object
-
-  //   console.log("help me please, this is a mess");
-  //   const encodedLocation = btoa(JSON.stringify(location));
-  //   const encodedLocation2 = encodeURIComponent(JSON.stringify(location));
-  //   console.log(encodedLocation.length, encodedLocation2.length);
-
-  //   url += `&location=${encodeURIComponent(encodedLocation)}`;
-  // }
 
   try {
     console.log(`Getting data for ${type} at ${url}`);

--- a/frontend/public/lib/getDataOperations.ts
+++ b/frontend/public/lib/getDataOperations.ts
@@ -2,7 +2,16 @@ import { apiRequest } from "./apiOperations";
 import { membersWithAdditionalInfo } from "./getOptions";
 import { parseData } from "./parsingOperations";
 
-export async function getDataFromServer({ type, page, token, urlEnding, hubUrl, locale, idea }) {
+export async function getDataFromServer({
+  type,
+  page,
+  token,
+  urlEnding,
+  hubUrl,
+  locale,
+  idea,
+  location,
+}) {
   let url = `/api/${type}/?page=${page}`;
   if (hubUrl) {
     url += `&hub=${hubUrl}`;
@@ -16,10 +25,24 @@ export async function getDataFromServer({ type, page, token, urlEnding, hubUrl, 
     // &category=Lowering%20food%20waste&
     url += urlEnding;
   }
+  // if (location instanceof Object && !(location instanceof String)) {
+  //   // use base64 encoding to pass the location object
+
+  //   console.log("help me please, this is a mess");
+  //   const encodedLocation = btoa(JSON.stringify(location));
+  //   const encodedLocation2 = encodeURIComponent(JSON.stringify(location));
+  //   console.log(encodedLocation.length, encodedLocation2.length);
+
+  //   url += `&location=${encodeURIComponent(encodedLocation)}`;
+  // }
 
   try {
     console.log(`Getting data for ${type} at ${url}`);
-    const resp = await apiRequest({ method: "get", url, token, locale });
+
+    const resp = location
+      ? await apiRequest({ method: "post", url, payload: location, token, locale })
+      : await apiRequest({ method: "get", url, token, locale });
+
     if (resp.data.length === 0) {
       console.log(`No data of type ${type} found...`);
       return null;


### PR DESCRIPTION
## Draft
Currently, I am using a POST request that will redirect to code of the GET request. This way, we can send the geojson coordinates form the client to the backend which is used for locations that are unknown to the backend. 

Another option that has been (semi-)discarded is to rely on the GET implementation alone and add and encode the location data in the URL itself. This might result in inconsistent behavior due to the number of chars in the URL reaching a length of over 1000. Usually, 1000 chars is fine, but some infrastructure might cut of the URL after a length of 2000. Due to the numerous technologies that handles URL and search params, this might be inconsistent. 

Additionally, GET requests shall not / can not contain a body. Therefore, we can not use the body to transmit data. The POST approach is using the body to transmit data.    

## Checked the following
- [x] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme
- [x] Run within `/frontend`: `yarn format && yarn lint`
- [x] Run within `/backend`: `make format && make lint`

## What and Why

hotfix for locaiton lookup, instable api call no longer breaks the search

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
