### PR TITLE
Using WideLayout for devlink components

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -2,7 +2,7 @@ import makeStyles from "@mui/styles/makeStyles";
 import React, { useContext, useEffect } from "react";
 import { CcLandingpage, EnLandingpageClimateConnect } from "../devlink";
 import UserContext from "../src/components/context/UserContext";
-import Layout from "../src/components/layouts/layout";
+import WideLayout from "../src/components/layouts/WideLayout";
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -27,10 +27,10 @@ export default function Index() {
   }, []);
 
   return (
-    <Layout>
+    <WideLayout>
       <div className={classes.container}>
         {locale === "de" ? <CcLandingpage /> : <EnLandingpageClimateConnect />}
       </div>
-    </Layout>
+    </WideLayout>
   );
 }

--- a/frontend/src/components/layouts/LayoutWrapper.tsx
+++ b/frontend/src/components/layouts/LayoutWrapper.tsx
@@ -13,6 +13,7 @@ import CookieBanner from "../general/CookieBanner";
 import LoadingContainer from "../general/LoadingContainer";
 import CloseSnackbarAction from "../snackbarActions/CloseSnackbarAction";
 import LogInAction from "../snackbarActions/LogInAction";
+import { DevLinkProvider } from "../../../devlink/DevLinkProvider";
 
 declare module "@mui/styles/defaultTheme" {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -156,6 +157,7 @@ export default function LayoutWrapper({
       </Head>
       {/* If theme is falsy, slience the MUI console.warning for having an undefined theme */}
       <ThemeProvider theme={theme}>
+        <DevLinkProvider>
         {loading || isLoading ? (
           <div className={classes.spinnerContainer}>
             <LoadingContainer headerHeight={0} footerHeight={0} />
@@ -192,6 +194,7 @@ export default function LayoutWrapper({
             </div>
           </FeedbackContext.Provider>
         )}
+        </DevLinkProvider>
       </ThemeProvider>
     </>
   );

--- a/frontend/src/components/layouts/layout.tsx
+++ b/frontend/src/components/layouts/layout.tsx
@@ -49,7 +49,6 @@ export default function Layout({
     }
   }, []);
   return (
-    <DevLinkProvider>
       <LayoutWrapper theme={theme} title={title}>
         <Header noSpacingBottom isStaticPage={isStaticPage} />
         {<DonationCampaignInformation />}
@@ -84,6 +83,5 @@ export default function Layout({
         )}
         <Footer />
       </LayoutWrapper>
-    </DevLinkProvider>
   );
 }


### PR DESCRIPTION
## Description

This PR implements the use of WideLayout for DevLink components and resolves the scroll issue on the homepage.
(The issue was occurring when the user changed the language, causing the page scroll to focus on the middle of the page. )

## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
