### PR TITLE
debug internal ips can be set via env

### DIFF
--- a/backend/climateconnect_main/settings.py
+++ b/backend/climateconnect_main/settings.py
@@ -41,11 +41,21 @@ SECRET_KEY = env("SECRET_KEY")
 DEBUG = env("DEBUG", "false") == "true"  # needs to gravitate towards False!
 ALLOWED_HOSTS = get_allowed_hosts(env("ALLOWED_HOSTS"))
 
+
+DEBUG_INTERNAL_IPS = []
+if env("DEBUG_INTERNAL_IPS"):
+    debug_internal_ips = env("DEBUG_INTERNAL_IPS")
+    if "," in debug_internal_ips:
+        DEBUG_INTERNAL_IPS.extend(list(map(str.strip, debug_internal_ips.split(","))))
+    else:
+        DEBUG_INTERNAL_IPS.append(debug_internal_ips)
+
 INTERNAL_IPS = [
     # ...
     "127.0.0.1",
     # ...
-]
+] + DEBUG_INTERNAL_IPS
+print("INTERNAL IPS:", INTERNAL_IPS)
 
 
 AUTO_VERIFY = True if env("AUTO_VERIFY") in ["True", "true", "TRUE"] else False


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
