### PR TITLE
hotfix infinite search due to missing errorhandling

### DIFF
--- a/backend/organization/serializers/project.py
+++ b/backend/organization/serializers/project.py
@@ -185,10 +185,9 @@ class EditProjectSerializer(ProjectSerializer):
 
     def get_helpful_connections(self, obj):
         return obj.helpful_connections
-    
+
     def get_related_hubs(self, obj):
         return [hub.url_slug for hub in obj.related_hubs.all()]
-
 
     class Meta(ProjectSerializer.Meta):
         fields = ProjectSerializer.Meta.fields + ("loc", "translations", "related_hubs")

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -617,7 +617,9 @@ class ProjectAPIView(APIView):
             )[0]
         if "hubUrl" in request.data:
             related_hub_slug = request.data["hubUrl"]
-            if related_hub_slug == "":  # If the slug is an empty string, clear the related_hubs
+            if (
+                related_hub_slug == ""
+            ):  # If the slug is an empty string, clear the related_hubs
                 project.related_hubs.clear()
             else:  # Otherwise, try to find the Hub and add it
                 hub = Hub.objects.filter(url_slug=related_hub_slug).first()

--- a/frontend/pages/editProject/[projectUrl].tsx
+++ b/frontend/pages/editProject/[projectUrl].tsx
@@ -114,10 +114,7 @@ export default function EditProjectPage({
         customTheme={hubThemeData ? transformThemeData(hubThemeData) : undefined}
         hubUrl={hubUrl}
       >
-        <LoginNudge
-          fullPage
-          whatToDo={texts.to_edit_this_project}
-        />
+        <LoginNudge fullPage whatToDo={texts.to_edit_this_project} />
       </WideLayout>
     );
   else if (!project)

--- a/frontend/public/lib/filterOperations.ts
+++ b/frontend/public/lib/filterOperations.ts
@@ -241,6 +241,9 @@ export async function applyNewFilters({
     };
   } catch (e) {
     console.log(e);
-    throw e;
+    // TODO: in the future, throw the error
+    // but make sure that the calling component catches
+    /// the error and gives feedback to the user
+    // throw e;
   }
 }

--- a/frontend/public/lib/filterOperations.ts
+++ b/frontend/public/lib/filterOperations.ts
@@ -246,4 +246,5 @@ export async function applyNewFilters({
     /// the error and gives feedback to the user
     // throw e;
   }
+  return null;
 }


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme
- [x] Run within `/frontend`: `yarn format && yarn lint`
- [x] Run within `/backend`: `make format && make lint`

## Issue on mobile
When selecting a location that is unknown, one can not click the apply filters button/close it.

