### PR TITLE
Handle browse content api error with user feedbacked

### DIFF
--- a/backend/organization/serializers/project.py
+++ b/backend/organization/serializers/project.py
@@ -185,10 +185,9 @@ class EditProjectSerializer(ProjectSerializer):
 
     def get_helpful_connections(self, obj):
         return obj.helpful_connections
-    
+
     def get_related_hubs(self, obj):
         return [hub.url_slug for hub in obj.related_hubs.all()]
-
 
     class Meta(ProjectSerializer.Meta):
         fields = ProjectSerializer.Meta.fields + ("loc", "translations", "related_hubs")

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -617,7 +617,9 @@ class ProjectAPIView(APIView):
             )[0]
         if "hubUrl" in request.data:
             related_hub_slug = request.data["hubUrl"]
-            if related_hub_slug == "":  # If the slug is an empty string, clear the related_hubs
+            if (
+                related_hub_slug == ""
+            ):  # If the slug is an empty string, clear the related_hubs
                 project.related_hubs.clear()
             else:  # Otherwise, try to find the Hub and add it
                 hub = Hub.objects.filter(url_slug=related_hub_slug).first()

--- a/frontend/pages/editProject/[projectUrl].tsx
+++ b/frontend/pages/editProject/[projectUrl].tsx
@@ -114,10 +114,7 @@ export default function EditProjectPage({
         customTheme={hubThemeData ? transformThemeData(hubThemeData) : undefined}
         hubUrl={hubUrl}
       >
-        <LoginNudge
-          fullPage
-          whatToDo={texts.to_edit_this_project}
-        />
+        <LoginNudge fullPage whatToDo={texts.to_edit_this_project} />
       </WideLayout>
     );
   else if (!project)

--- a/frontend/public/lib/filterOperations.ts
+++ b/frontend/public/lib/filterOperations.ts
@@ -241,6 +241,9 @@ export async function applyNewFilters({
     };
   } catch (e) {
     console.log(e);
-    throw e;
+    // TODO: in the future, throw the error
+    // but make sure that the calling component catches
+    /// the error and gives feedback to the user
+    // throw e;
   }
 }

--- a/frontend/public/lib/filterOperations.ts
+++ b/frontend/public/lib/filterOperations.ts
@@ -5,6 +5,7 @@ import { getDataFromServer } from "./getDataOperations";
 import { membersWithAdditionalInfo } from "./getOptions";
 import { getInfoMetadataByType, getReducedPossibleFilters } from "./parsingOperations";
 import { encodeQueryParamsFromFilters } from "./urlOperations";
+import getTexts from "../texts/texts";
 
 const getLocationFilterUrl = (location) => {
   /*Pass place id. If the place id is found in our db we can use it's polygon,
@@ -241,10 +242,9 @@ export async function applyNewFilters({
     };
   } catch (e) {
     console.log(e);
-    // TODO: in the future, throw the error
-    // but make sure that the calling component catches
-    /// the error and gives feedback to the user
-    // throw e;
+    const texts = getTexts({ page: "general", locale: locale });
+
+    handleSetErrorMessage(texts.error_during_search);
+    throw new Error(texts.error_during_search_short);
   }
-  return null;
 }

--- a/frontend/public/lib/filterOperations.ts
+++ b/frontend/public/lib/filterOperations.ts
@@ -246,4 +246,5 @@ export async function applyNewFilters({
     /// the error and gives feedback to the user
     // throw e;
   }
+  return null;
 }

--- a/frontend/public/lib/locationOperations.ts
+++ b/frontend/public/lib/locationOperations.ts
@@ -354,5 +354,6 @@ export async function getLocationFilteredBy(query) {
     return full_location;
   } catch (e) {
     console.log(e);
+    return null;
   }
 }

--- a/frontend/public/texts/general_texts.json
+++ b/frontend/public/texts/general_texts.json
@@ -295,6 +295,14 @@
     "en": "Error: There wasn't a Super Admin. Please contact contact@climateconnect.earth to resolve this issue.",
     "de": "Fehler: Es gab keine(n) Super Admin. Bitte schreibe an contact@climateconnect.earth damit wir das Problem beheben können."
   },
+  "error_during_search": {
+    "en": "Error during search. Maybe try another search. We will work swiftly to solve it :)",
+    "de": "Fehler bei der Suchanfrage. Versuche lieber eine andere. Währenddessen kümmern wir uns um den Fehler :)"
+  },
+  "error_during_search_short": {
+    "en": "Error during search.",
+    "de": "Fehler bei der Suchanfrage."
+  },
   "not_all_your_updates_have_worked": {
     "en": "Not all your updates have worked.",
     "de": "Nicht alle deine Updates haben funktioniert."

--- a/frontend/src/components/browse/BrowseContent.tsx
+++ b/frontend/src/components/browse/BrowseContent.tsx
@@ -69,7 +69,6 @@ export default function BrowseContent({
   initialOrganizations,
   initialProjects,
   customSearchBarLabels,
-  errorMessage,
   filterChoices,
   hideMembers,
   hubName,
@@ -103,12 +102,9 @@ export default function BrowseContent({
 
   const token = new Cookies().get("auth_token");
 
-  const {
-    filters,
-    handleUpdateFilterValues,
-    handleSetErrorMessage,
-    handleApplyNewFilters: applyNewFilters,
-  } = useContext(FilterContext);
+  const { filters, handleSetErrorMessage, handleApplyNewFilters: applyNewFilters } = useContext(
+    FilterContext
+  );
 
   const legacyModeEnabled = process.env.ENABLE_LEGACY_LOCATION_FORMAT === "true";
   const classes = useStyles();
@@ -451,8 +447,6 @@ export default function BrowseContent({
     TYPES_BY_TAB_VALUE: TYPES_BY_TAB_VALUE,
     filtersExpanded: isNarrowScreen ? filtersExandedOnMobile : filtersExpanded,
     handleApplyNewFilters: handleApplyNewFilters,
-    handleUpdateFilterValues: handleUpdateFilterValues,
-    errorMessage: errorMessage,
     isMobileScreen: isNarrowScreen,
     filtersExandedOnMobile: filtersExandedOnMobile,
     handleSetLocationOptionsOpen: handleSetLocationOptionsOpen,

--- a/frontend/src/components/browse/BrowseContent.tsx
+++ b/frontend/src/components/browse/BrowseContent.tsx
@@ -196,7 +196,8 @@ export default function BrowseContent({
       };
       setNonFilterParams(splitQueryObject.nonFilters);
       if (splitQueryObject?.nonFilters?.message) {
-        showFeedbackMessage({
+        // ? is needed due to the context type {showFeedbackMessage?: (..) => void;}
+        showFeedbackMessage?.({
           message: splitQueryObject.nonFilters.message,
         });
       }
@@ -389,7 +390,14 @@ export default function BrowseContent({
       type: type,
       newFilters: newFilters,
       closeFilters: closeFilters,
+    }).catch((e) => {
+      // ? is needed due to the context type {showFeedbackMessage?: (..) => void;}
+      showFeedbackMessage?.({
+        message: e.message ?? texts.error,
+        error: true,
+      });
     });
+
     if (res?.closeFilters) {
       if (isNarrowScreen) setFiltersExpandedOnMobile(false);
       else setFiltersExpanded(false);
@@ -425,7 +433,14 @@ export default function BrowseContent({
       type: type,
       newFilters: newFilters,
       closeFilters: false,
+    }).catch((e) => {
+      // ? is needed due to the context type {showFeedbackMessage?: (..) => void;}
+      showFeedbackMessage?.({
+        message: e.message ?? texts.error,
+        error: true,
+      });
     });
+
     setIsFiltering(false);
     if (newUrl !== window?.location?.href) {
       window.history.pushState({}, "", newUrl);
@@ -446,7 +461,7 @@ export default function BrowseContent({
     tabValue: tabValue,
     TYPES_BY_TAB_VALUE: TYPES_BY_TAB_VALUE,
     filtersExpanded: isNarrowScreen ? filtersExandedOnMobile : filtersExpanded,
-    handleApplyNewFilters: handleApplyNewFilters,
+    handleApplyNewFilters: handleApplyNewFilters, // TOOD: refactor this, so that it does not get propagated
     isMobileScreen: isNarrowScreen,
     filtersExandedOnMobile: filtersExandedOnMobile,
     handleSetLocationOptionsOpen: handleSetLocationOptionsOpen,

--- a/frontend/src/components/browse/TabContentWrapper.tsx
+++ b/frontend/src/components/browse/TabContentWrapper.tsx
@@ -19,8 +19,6 @@ export default function TabContentWrapper({
   type,
   filtersExpanded,
   handleApplyNewFilters,
-  handleUpdateFilterValues,
-  errorMessage,
   isMobileScreen,
   filtersExandedOnMobile,
   handleSetLocationOptionsOpen,
@@ -49,8 +47,6 @@ export default function TabContentWrapper({
           className={classes.tabContent}
           type={TYPES_BY_TAB_VALUE[TYPES_BY_TAB_VALUE.indexOf(type)]}
           applyFilters={handleApplyNewFilters}
-          handleUpdateFilters={handleUpdateFilterValues}
-          errorMessage={errorMessage}
           filtersExpanded={isMobileScreen ? filtersExandedOnMobile : filtersExpanded}
           handleSetLocationOptionsOpen={handleSetLocationOptionsOpen}
           locationInputRef={locationInputRefs[TYPES_BY_TAB_VALUE[TYPES_BY_TAB_VALUE.indexOf(type)]]}

--- a/frontend/src/components/context/FeedbackContext.ts
+++ b/frontend/src/components/context/FeedbackContext.ts
@@ -2,8 +2,15 @@ import { createContext } from "react";
 
 const FeedbackContext = createContext<{
   message?: string | null;
-  showFeedbackMessage?: any;
-  handleUpdateHash?: any;
+  showFeedbackMessage?: (params: {
+    message: string;
+    promptLogIn?: boolean;
+    action?: React.ReactNode;
+    newHash?: string;
+    error?: boolean;
+    success?: boolean;
+  }) => void;
+  handleUpdateHash?: (newHash: string) => void;
 }>({ message: null });
 
 export default FeedbackContext;

--- a/frontend/src/components/feedback/FeedbackButton.tsx
+++ b/frontend/src/components/feedback/FeedbackButton.tsx
@@ -56,7 +56,8 @@ export default function FeedbackButton({ justLink, children }: any) {
         token: token,
         locale: locale,
       });
-      showFeedbackMessage({
+      // ? is needed due to the context type {showFeedbackMessage?: (..) => void;}
+      showFeedbackMessage?.({
         message: response.data,
       });
     } catch (e: any) {

--- a/frontend/src/components/filter/FilterContent.tsx
+++ b/frontend/src/components/filter/FilterContent.tsx
@@ -9,6 +9,7 @@ import FilterOverlay from "./FilterOverlay";
 import Filters from "./Filters";
 import SelectedFilters from "./SelectedFilters";
 import { FilterContext } from "../context/FilterContext";
+import { BrowseTab } from "../../types";
 
 /**
  * Util to return an array of all potential items associated with
@@ -84,10 +85,23 @@ export const reduceFilters = (currentFilters, possibleFilters) => {
   return reduced;
 };
 
+interface FilterContentProps {
+  applyFilters: (params: any) => void;
+  className: string;
+  filtersExpanded: boolean;
+  handleSetLocationOptionsOpen: (open: boolean) => void;
+  locationInputRef: React.RefObject<HTMLInputElement>;
+  locationOptionsOpen: boolean;
+  possibleFilters: any;
+  type: BrowseTab;
+  unexpandFilters: () => void;
+  initialLocationFilter: any;
+  nonFilterParams: any;
+}
+
 export default function FilterContent({
   applyFilters,
   className,
-  errorMessage,
   filtersExpanded,
   handleSetLocationOptionsOpen,
   locationInputRef,
@@ -96,9 +110,8 @@ export default function FilterContent({
   type,
   unexpandFilters,
   initialLocationFilter,
-  handleUpdateFilters,
   nonFilterParams,
-}) {
+}: FilterContentProps) {
   const isMediumScreen = useMediaQuery<Theme>(theme.breakpoints.between("xs", "lg"));
   const isSmallScreen = useMediaQuery<Theme>(theme.breakpoints.down("sm"));
 
@@ -135,7 +148,7 @@ export default function FilterContent({
   const [open, setOpen] = useState<{ prop?: any }>({});
   const [initialized, setInitialized] = useState(false);
 
-  const { filters } = useContext(FilterContext);
+  const { filters, handleUpdateFilterValues } = useContext(FilterContext);
   const reduced = reduceFilters(filters, possibleFilters);
 
   const [selectedItems, setSelectedItems] = useState(reduced);
@@ -169,7 +182,7 @@ export default function FilterContent({
   const handleClickDialogSave = (prop, results) => {
     if (results) {
       const updatedFilters = { ...filters, [prop]: results.map((x) => x.name) };
-      handleUpdateFilters(updatedFilters);
+      handleUpdateFilterValues(updatedFilters);
       applyFilters({
         type: type,
         newFilters: updatedFilters,
@@ -197,7 +210,7 @@ export default function FilterContent({
       closeFilters: isSmallScreen,
       nonFilterParams: nonFilterParams,
     });
-    handleUpdateFilters(updatedFilters);
+    handleUpdateFilterValues(updatedFilters);
   };
 
   const handleApplyFilters = () => {
@@ -250,7 +263,7 @@ export default function FilterContent({
       closeFilters: isSmallScreen,
       nonFilterParams: nonFilterParams,
     });
-    handleUpdateFilters(updatedFilters);
+    handleUpdateFilterValues(updatedFilters);
 
     // Also re-select items
     if (selectedItems[filterKey]) {
@@ -267,7 +280,6 @@ export default function FilterContent({
         <>
           <FilterOverlay
             handleApplyFilters={handleApplyFilters}
-            errorMessage={errorMessage}
             filtersExpanded={filtersExpanded}
             handleClickDialogSave={handleClickDialogSave}
             handleClickDialogClose={handleClickDialogClose}
@@ -287,7 +299,6 @@ export default function FilterContent({
       ) : isMediumScreen && possibleFilters.length > 3 ? (
         <>
           <Filters
-            errorMessage={errorMessage}
             handleClickDialogSave={handleClickDialogSave}
             handleClickDialogClose={handleClickDialogClose}
             handleClickDialogOpen={handleClickDialogOpen}
@@ -316,7 +327,6 @@ export default function FilterContent({
         </>
       ) : (
         <Filters
-          errorMessage={errorMessage}
           handleClickDialogSave={handleClickDialogSave}
           handleClickDialogClose={handleClickDialogClose}
           handleClickDialogOpen={handleClickDialogOpen}

--- a/frontend/src/components/filter/FilterContent.tsx
+++ b/frontend/src/components/filter/FilterContent.tsx
@@ -1,4 +1,4 @@
-import { Theme } from "@mui/material";
+import { Theme, Typography } from "@mui/material";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useRouter } from "next/router";
 import React, { useContext, useEffect, useState } from "react";
@@ -10,6 +10,7 @@ import Filters from "./Filters";
 import SelectedFilters from "./SelectedFilters";
 import { FilterContext } from "../context/FilterContext";
 import { BrowseTab } from "../../types";
+import makeStyles from "@mui/styles/makeStyles";
 
 /**
  * Util to return an array of all potential items associated with
@@ -85,6 +86,15 @@ export const reduceFilters = (currentFilters, possibleFilters) => {
   return reduced;
 };
 
+const useStyles = makeStyles<Theme>((theme) => {
+  return {
+    errorMessageWrapper: {
+      textAlign: "center",
+      marginBottom: theme.spacing(1),
+    },
+  };
+});
+
 interface FilterContentProps {
   applyFilters: (params: any) => void;
   className: string;
@@ -114,6 +124,7 @@ export default function FilterContent({
 }: FilterContentProps) {
   const isMediumScreen = useMediaQuery<Theme>(theme.breakpoints.between("xs", "lg"));
   const isSmallScreen = useMediaQuery<Theme>(theme.breakpoints.down("sm"));
+  const classes = useStyles(theme);
 
   const possibleFiltersFirstHalf = possibleFilters.slice(0, Math.ceil(possibleFilters.length / 2));
   const possibleFiltersSecondHalf = possibleFilters.slice(
@@ -148,7 +159,7 @@ export default function FilterContent({
   const [open, setOpen] = useState<{ prop?: any }>({});
   const [initialized, setInitialized] = useState(false);
 
-  const { filters, handleUpdateFilterValues } = useContext(FilterContext);
+  const { filters, handleUpdateFilterValues, errorMessage } = useContext(FilterContext);
   const reduced = reduceFilters(filters, possibleFilters);
 
   const [selectedItems, setSelectedItems] = useState(reduced);
@@ -298,6 +309,11 @@ export default function FilterContent({
         </>
       ) : isMediumScreen && possibleFilters.length > 3 ? (
         <>
+          {errorMessage && (
+            <div className={classes.errorMessageWrapper}>
+              <Typography color="error">{errorMessage}</Typography>
+            </div>
+          )}
           <Filters
             handleClickDialogSave={handleClickDialogSave}
             handleClickDialogClose={handleClickDialogClose}
@@ -326,20 +342,27 @@ export default function FilterContent({
           />
         </>
       ) : (
-        <Filters
-          handleClickDialogSave={handleClickDialogSave}
-          handleClickDialogClose={handleClickDialogClose}
-          handleClickDialogOpen={handleClickDialogOpen}
-          handleSetLocationOptionsOpen={handleSetLocationOptionsOpen}
-          handleValueChange={handleValueChange}
-          justifyContent={type === "projects" ? "space-around" : "flex-start"}
-          locationInputRef={locationInputRef}
-          locationOptionsOpen={locationOptionsOpen}
-          open={open}
-          possibleFilters={possibleFilters}
-          selectedItems={selectedItems}
-          setSelectedItems={setSelectedItems}
-        />
+        <>
+          {errorMessage && (
+            <div className={classes.errorMessageWrapper}>
+              <Typography color="error">{errorMessage}</Typography>
+            </div>
+          )}
+          <Filters
+            handleClickDialogSave={handleClickDialogSave}
+            handleClickDialogClose={handleClickDialogClose}
+            handleClickDialogOpen={handleClickDialogOpen}
+            handleSetLocationOptionsOpen={handleSetLocationOptionsOpen}
+            handleValueChange={handleValueChange}
+            justifyContent={type === "projects" ? "space-around" : "flex-start"}
+            locationInputRef={locationInputRef}
+            locationOptionsOpen={locationOptionsOpen}
+            open={open}
+            possibleFilters={possibleFilters}
+            selectedItems={selectedItems}
+            setSelectedItems={setSelectedItems}
+          />
+        </>
       )}
       {/* We pass currentFilters like this because if location is not an array, 
       a change in it doesn't cause a rerender and therefore the location chip is not shown */}

--- a/frontend/src/components/filter/FilterOverlay.tsx
+++ b/frontend/src/components/filter/FilterOverlay.tsx
@@ -6,7 +6,6 @@ import Filters from "./Filters";
 import SelectedFilters from "./SelectedFilters";
 
 export default function FilterOverlay({
-  errorMessage,
   filtersExpanded,
   handleApplyFilters,
   handleClickDialogClose,
@@ -40,7 +39,6 @@ export default function FilterOverlay({
       useApplyButton
     >
       <Filters
-        errorMessage={errorMessage}
         handleApplyFilters={handleApplyFilters}
         handleClickDialogClose={handleClickDialogClose}
         handleClickDialogOpen={handleClickDialogOpen}

--- a/frontend/src/components/filter/Filters.tsx
+++ b/frontend/src/components/filter/Filters.tsx
@@ -83,7 +83,6 @@ const useStyles = makeStyles<Theme, { filterElementMargin: number; justifyConten
 );
 
 export default function Filters({
-  errorMessage,
   handleClickDialogClose,
   handleClickDialogOpen,
   handleClickDialogSave,
@@ -99,7 +98,7 @@ export default function Filters({
   setSelectedItems,
 }: any) {
   const { locale } = useContext(UserContext);
-  const { filters: currentFilters } = useContext(FilterContext);
+  const { filters: currentFilters, errorMessage } = useContext(FilterContext);
 
   const texts = getTexts({ page: "filter_and_search", locale: locale });
   const classes = useStyles({

--- a/frontend/src/components/filter/Filters.tsx
+++ b/frontend/src/components/filter/Filters.tsx
@@ -71,10 +71,6 @@ const useStyles = makeStyles<Theme, { filterElementMargin: number; justifyConten
         borderColor: theme.palette.primary.main,
         borderWidth: 2,
       },
-      errorMessageWrapper: {
-        textAlign: "center",
-        marginBottom: theme.spacing(1),
-      },
       openMultiSelectButton: {
         border: `1px solid ${theme.palette.grey[500]} !important`,
       },
@@ -98,7 +94,7 @@ export default function Filters({
   setSelectedItems,
 }: any) {
   const { locale } = useContext(UserContext);
-  const { filters: currentFilters, errorMessage } = useContext(FilterContext);
+  const { filters: currentFilters } = useContext(FilterContext);
 
   const texts = getTexts({ page: "filter_and_search", locale: locale });
   const classes = useStyles({
@@ -108,12 +104,6 @@ export default function Filters({
   const radiusFilterOptions = getRadiusFilterOptions();
   return (
     <>
-      {errorMessage && (
-        <div className={classes.errorMessageWrapper}>
-          <Typography color="error">{errorMessage}</Typography>
-        </div>
-      )}
-
       <div className={`${classes.flexContainer} ${isInOverlay && classes.verticalFlexContainer}`}>
         {/* Map over the potential filters for each specific tab. For example, on the Members tab,
          the possible filters might be the location filter object, and the skills filter object. */}

--- a/frontend/src/components/layouts/LayoutWrapper.tsx
+++ b/frontend/src/components/layouts/LayoutWrapper.tsx
@@ -53,6 +53,15 @@ const useStyles = makeStyles<Theme>((theme) => ({
   },
 }));
 
+interface SnackbarPropsInterface {
+  open: boolean;
+  message: string;
+  action: React.ReactNode;
+  hash: string;
+  error: boolean;
+  success: boolean;
+}
+
 export default function LayoutWrapper({
   title,
   children,
@@ -64,7 +73,7 @@ export default function LayoutWrapper({
   image,
   useFloodStdFont,
 }: any) {
-  const [snackbarProps, setSnackbarProps] = useState({
+  const [snackbarProps, setSnackbarProps] = useState<SnackbarPropsInterface>({
     open: false,
     message: "",
     action: <></>,
@@ -112,13 +121,27 @@ export default function LayoutWrapper({
 
   //if promptLogIn is true, the user will be shown a button to log in.
   //Otherwise the caller of the function can also set a custom action that should be shown to the user
-  const showFeedbackMessage = ({ message, promptLogIn, action, newHash, error, success }) => {
+  const showFeedbackMessage = ({
+    message,
+    promptLogIn,
+    action,
+    newHash,
+    error,
+    success,
+  }: {
+    message: string;
+    promptLogIn?: boolean;
+    action?: React.ReactNode;
+    newHash?: string;
+    error?: boolean;
+    success?: boolean;
+  }) => {
     const newStateValue = {
       ...snackbarProps,
       open: true,
       message: message,
-      error: error,
-      success: success,
+      error: error ?? false,
+      success: success || false,
       action: promptLogIn ? (
         <LogInAction onClose={handleSnackbarClose} />
       ) : action ? (


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why
The user is now getting informed, if the search on a browse page fails. Additionally, performed some refactoring.
