### PR TITLE
Improving filter layout

### DIFF
--- a/frontend/pages/editProject/[projectUrl].tsx
+++ b/frontend/pages/editProject/[projectUrl].tsx
@@ -114,10 +114,7 @@ export default function EditProjectPage({
         customTheme={hubThemeData ? transformThemeData(hubThemeData) : undefined}
         hubUrl={hubUrl}
       >
-        <LoginNudge
-          fullPage
-          whatToDo={texts.to_edit_this_project}
-        />
+        <LoginNudge fullPage whatToDo={texts.to_edit_this_project} />
       </WideLayout>
     );
   else if (!project)

--- a/frontend/src/components/filter/FilterContent.tsx
+++ b/frontend/src/components/filter/FilterContent.tsx
@@ -99,14 +99,7 @@ export default function FilterContent({
   handleUpdateFilters,
   nonFilterParams,
 }) {
-  const isMediumScreen = useMediaQuery<Theme>(theme.breakpoints.between("xs", "lg"));
   const isSmallScreen = useMediaQuery<Theme>(theme.breakpoints.down("sm"));
-
-  const possibleFiltersFirstHalf = possibleFilters.slice(0, Math.ceil(possibleFilters.length / 2));
-  const possibleFiltersSecondHalf = possibleFilters.slice(
-    Math.ceil(possibleFilters.length / 2),
-    possibleFilters.length
-  );
 
   const reducedPossibleFilters = getReducedPossibleFilters(possibleFilters);
 
@@ -284,36 +277,6 @@ export default function FilterContent({
             unexpandFilters={unexpandFilters}
           />
         </>
-      ) : isMediumScreen && possibleFilters.length > 3 ? (
-        <>
-          <Filters
-            errorMessage={errorMessage}
-            handleClickDialogSave={handleClickDialogSave}
-            handleClickDialogClose={handleClickDialogClose}
-            handleClickDialogOpen={handleClickDialogOpen}
-            handleSetLocationOptionsOpen={handleSetLocationOptionsOpen}
-            handleValueChange={handleValueChange}
-            locationInputRef={locationInputRef}
-            locationOptionsOpen={locationOptionsOpen}
-            open={open}
-            possibleFilters={possibleFiltersFirstHalf}
-            selectedItems={selectedItems}
-            setSelectedItems={setSelectedItems}
-          />
-          <Filters
-            handleClickDialogSave={handleClickDialogSave}
-            handleClickDialogClose={handleClickDialogClose}
-            handleClickDialogOpen={handleClickDialogOpen}
-            handleSetLocationOptionsOpen={handleSetLocationOptionsOpen}
-            handleValueChange={handleValueChange}
-            locationInputRef={locationInputRef}
-            locationOptionsOpen={locationOptionsOpen}
-            open={open}
-            possibleFilters={possibleFiltersSecondHalf}
-            selectedItems={selectedItems}
-            setSelectedItems={setSelectedItems}
-          />
-        </>
       ) : (
         <Filters
           errorMessage={errorMessage}
@@ -322,7 +285,7 @@ export default function FilterContent({
           handleClickDialogOpen={handleClickDialogOpen}
           handleSetLocationOptionsOpen={handleSetLocationOptionsOpen}
           handleValueChange={handleValueChange}
-          justifyContent={type === "projects" ? "space-around" : "flex-start"}
+          justifyContent={"center"}
           locationInputRef={locationInputRef}
           locationOptionsOpen={locationOptionsOpen}
           open={open}

--- a/frontend/src/components/filter/Filters.tsx
+++ b/frontend/src/components/filter/Filters.tsx
@@ -9,78 +9,79 @@ import SelectField from "../general/SelectField";
 import LocationSearchBar from "../search/LocationSearchBar";
 import { FilterContext } from "../context/FilterContext";
 
-const useStyles = makeStyles<Theme, { filterElementMargin: number; justifyContent: any }>(
-  (theme) => {
-    return {
-      flexContainer: (props) => ({
-        display: "flex",
-        justifyContent: props.justifyContent,
-        marginBottom: theme.spacing(1),
-      }),
-      verticalFlexContainer: {
-        flexDirection: "column",
-        marginTop: theme.spacing(2),
-      },
-      iconLabel: {
-        display: "flex",
-        alignItems: "center",
-      },
-      field: {
-        display: "flex",
-        width: 190,
-      },
-      locationFieldWrapper: {
-        width: 290,
-        display: "flex",
-        borderRadius: 0,
-        marginRight: theme.spacing(1),
-      },
-      locationField: {
-        borderTopRightRadius: 0,
-        borderBottomRightRadius: 0,
-        borderRight: 0,
-      },
-      overlayLocationField: {
-        flexGrow: 1,
-      },
-      radiusField: {
-        width: 110,
-      },
-      radiusInput: {
-        borderTopLeftRadius: 0,
-        borderBottomLeftRadius: 0,
-        borderLeft: 0,
-      },
-      filterElement: (props) => ({
-        marginRight: theme.spacing(props.filterElementMargin),
-        minHeight: 40,
-      }),
-      overlayField: {
-        marginBottom: theme.spacing(2),
-        width: "100%",
-      },
-      applyButton: {
-        height: 40,
-        display: "flex",
-      },
-      applyButtonContainer: {
-        display: "flex",
-        justifyContent: "flex-end",
-      },
-      outlinedField: {
-        borderColor: theme.palette.primary.main,
-        borderWidth: 2,
-      },
-      errorMessageWrapper: {
-        textAlign: "center",
-        marginBottom: theme.spacing(1),
-      },
-      openMultiSelectButton: {
-        border: `1px solid ${theme.palette.grey[500]} !important`,
-      },
-    };
-  }
-);
+const useStyles = makeStyles<Theme, { justifyContent: any }>((theme) => {
+  return {
+    flexContainer: (props) => ({
+      display: "flex",
+      flexWrap: "wrap",
+      columnGap: theme.spacing(2),
+      rowGap: theme.spacing(1),
+      paddingInline: theme.spacing(2),
+      justifyContent: props.justifyContent,
+      marginBottom: theme.spacing(1),
+    }),
+    verticalFlexContainer: {
+      flexDirection: "column",
+      marginTop: theme.spacing(2),
+    },
+    iconLabel: {
+      display: "flex",
+      alignItems: "center",
+    },
+    field: {
+      display: "flex",
+      width: 190,
+    },
+    locationFieldWrapper: {
+      // width: 290,
+      display: "flex",
+      borderRadius: 0,
+      marginRight: theme.spacing(1),
+    },
+    locationField: {
+      borderTopRightRadius: 0,
+      borderBottomRightRadius: 0,
+      borderRight: 0,
+    },
+    overlayLocationField: {
+      flexGrow: 1,
+    },
+    radiusField: {
+      width: 125,
+    },
+    radiusInput: {
+      borderTopLeftRadius: 0,
+      borderBottomLeftRadius: 0,
+      borderLeft: 0,
+    },
+    filterElement: {
+      minHeight: 40,
+    },
+    overlayField: {
+      marginBottom: theme.spacing(2),
+      width: "100%",
+    },
+    applyButton: {
+      height: 40,
+      display: "flex",
+    },
+    applyButtonContainer: {
+      display: "flex",
+      justifyContent: "flex-end",
+    },
+    outlinedField: {
+      borderColor: theme.palette.primary.main,
+      borderWidth: 2,
+    },
+    errorMessageWrapper: {
+      textAlign: "center",
+      marginBottom: theme.spacing(1),
+    },
+    openMultiSelectButton: {
+      border: `1px solid ${theme.palette.grey[500]} !important`,
+    },
+  };
+});
 
 export default function Filters({
   errorMessage,
@@ -104,7 +105,6 @@ export default function Filters({
   const texts = getTexts({ page: "filter_and_search", locale: locale });
   const classes = useStyles({
     justifyContent: justifyContent ? justifyContent : "space-around",
-    filterElementMargin: justifyContent && justifyContent != "space-around" ? 1 : 0,
   });
   const radiusFilterOptions = getRadiusFilterOptions();
   return (

--- a/frontend/src/components/search/LocationSearchBar.tsx
+++ b/frontend/src/components/search/LocationSearchBar.tsx
@@ -17,9 +17,6 @@ const useStyles = makeStyles((theme) => ({
     width: "100%",
     marginTop: props.hideHelperText ? 0 : theme.spacing(2),
   }),
-  input: {
-    marginBottom: theme.spacing(2),
-  },
   formHelperText: {
     marginTop: theme.spacing(-2),
   },
@@ -325,7 +322,7 @@ export default function LocationSearchBar({
             InputProps={{
               ...params.InputProps,
               endAdornment: <React.Fragment>{params.InputProps.endAdornment}</React.Fragment>,
-              className: `${textFieldClassName} ${classes.input}`,
+              className: `${textFieldClassName}`,
             }}
             FormHelperTextProps={{
               classes: {


### PR DESCRIPTION
## Checked the following
- [x] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme
- [x] Run within `/frontend`: `yarn format && yarn lint`
- [x] Run within `/backend`: `make format && make lint`

## What and Why
Regarding #1505 the layout of filters looked a bit of. Updated it and simplified the flex box. See screenshots.

## mobile
![image](https://github.com/user-attachments/assets/6fb13dbf-1e63-4690-8596-aa1e5604c56c)

## Smaller Screens
![image](https://github.com/user-attachments/assets/de9bb96f-b1c8-4aca-909d-23183bf0805d)
![image](https://github.com/user-attachments/assets/58d2b07a-b1e8-4ad9-a779-7d40313ce53b)


## Large Screen
![image](https://github.com/user-attachments/assets/ec4bb9e4-9395-4c36-b04e-dc821c7ddf71)

