### PR TITLE
remove getHubTheme from projects page

### DIFF
--- a/frontend/pages/projects/[projectId].tsx
+++ b/frontend/pages/projects/[projectId].tsx
@@ -17,6 +17,7 @@ import { Theme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
 import ProjectSideBar from "../../src/components/project/ProjectSideBar";
 import { transformThemeData } from "../../src/themes/transformThemeData";
+import getHubTheme from "../../src/themes/fetchHubTheme";
 
 type StyleProps = {
   showSimilarProjects: boolean;
@@ -477,17 +478,3 @@ function parseProjectMembers(projectMembers) {
     };
   });
 }
-const getHubTheme = async (url_slug) => {
-  try {
-    const resp = await apiRequest({
-      method: "get",
-      url: `/api/hubs/${url_slug}/theme/`,
-    });
-    return resp.data;
-  } catch (err: any) {
-    if (err.response && err.response.data)
-      console.log("Error in getHubThemeData: " + err.response.data.detail);
-    console.log(err);
-    return null;
-  }
-};


### PR DESCRIPTION
## Description
Removed the `getHubTheme` function from `projects.tsx ` since it's now defined in a separate file. 
No need to keep a duplicate implementation here.

## Checked the following
- [x] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme
- [x] Run within `/frontend`: `yarn format && yarn lint`
- [x] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
