### PR TITLE
Removed unused props from wide layout

### DIFF
--- a/frontend/pages/browse.tsx
+++ b/frontend/pages/browse.tsx
@@ -71,10 +71,7 @@ export default function Browse({ filterChoices, hubs, initialLocationFilter, pro
 
   return (
     <>
-      <WideLayout
-        showOnScrollUp={showOnScrollUp}
-        subHeader={<HubsSubHeader hubs={hubs} />}
-      >
+      <WideLayout showOnScrollUp={showOnScrollUp} subHeader={<HubsSubHeader hubs={hubs} />}>
         <BrowseContext.Provider value={contextValues}>
           <MainHeadingContainerMobile />
           <FilterProvider

--- a/frontend/pages/browse.tsx
+++ b/frontend/pages/browse.tsx
@@ -72,7 +72,6 @@ export default function Browse({ filterChoices, hubs, initialLocationFilter, pro
   return (
     <>
       <WideLayout
-        // hideHeadline
         showOnScrollUp={showOnScrollUp}
         subHeader={<HubsSubHeader hubs={hubs} />}
       >

--- a/frontend/pages/editProject/[projectUrl].tsx
+++ b/frontend/pages/editProject/[projectUrl].tsx
@@ -133,7 +133,6 @@ export default function EditProjectPage({
     return (
       <WideLayout
         title={texts.not_a_member}
-        hideHeadline={true}
         headerBackground={hubUrl === "prio1" ? "#7883ff" : "#FFF"}
         customTheme={hubThemeData ? transformThemeData(hubThemeData) : undefined}
         hubUrl={hubUrl}
@@ -168,9 +167,7 @@ export default function EditProjectPage({
     const user_role = members.find((m) => m.user && m.user.id === user.id).role;
     return (
       <WideLayout
-        className={classes.root}
         title={texts.edit_project + " " + project.name}
-        hideHeadline
         message={errorMessage}
         messageType={errorMessage && "error"}
         headerBackground={hubUrl === "prio1" ? "#7883ff" : "#FFF"}

--- a/frontend/pages/manageOrganizationMembers/[organizationUrl].tsx
+++ b/frontend/pages/manageOrganizationMembers/[organizationUrl].tsx
@@ -78,19 +78,13 @@ export default function manageOrganizationMembers({
 
   if (!user)
     return (
-      <WideLayout
-        title={texts.please_log_in + " " + texts.to_manage_org_members}
-        {...layoutProps}
-      >
+      <WideLayout title={texts.please_log_in + " " + texts.to_manage_org_members} {...layoutProps}>
         <LoginNudge fullPage whatToDo={texts.to_manage_org_members} />
       </WideLayout>
     );
   else if (!members.find((m) => m.id === user.id))
     return (
-      <WideLayout
-        title={texts.please_log_in + " " + texts.to_manage_org_members}
-        {...layoutProps}
-      >
+      <WideLayout title={texts.please_log_in + " " + texts.to_manage_org_members} {...layoutProps}>
         <Typography variant="h4" color="primary" className={classes.headline}>
           {texts.you_are_not_a_member_of_this_organization}{" "}
           {texts.go_to_org_page_and_click_join_to_join_it}
@@ -102,10 +96,7 @@ export default function manageOrganizationMembers({
     members.find((m) => m.id === user.id).role.role_type !== ROLE_TYPES.read_write_type
   )
     return (
-      <WideLayout
-        title={texts.no_permission_to_manage_members_of_this_org}
-        {...layoutProps}
-      >
+      <WideLayout title={texts.no_permission_to_manage_members_of_this_org} {...layoutProps}>
         <Typography variant="h4" color="primary" className={classes.headline}>
           {texts.need_to_be_admin_to_manage_org_members}
         </Typography>

--- a/frontend/pages/manageOrganizationMembers/[organizationUrl].tsx
+++ b/frontend/pages/manageOrganizationMembers/[organizationUrl].tsx
@@ -81,7 +81,6 @@ export default function manageOrganizationMembers({
       <WideLayout
         title={texts.please_log_in + " " + texts.to_manage_org_members}
         {...layoutProps}
-        // hideHeadline={true}
       >
         <LoginNudge fullPage whatToDo={texts.to_manage_org_members} />
       </WideLayout>
@@ -91,7 +90,6 @@ export default function manageOrganizationMembers({
       <WideLayout
         title={texts.please_log_in + " " + texts.to_manage_org_members}
         {...layoutProps}
-        // hideHeadline={true}
       >
         <Typography variant="h4" color="primary" className={classes.headline}>
           {texts.you_are_not_a_member_of_this_organization}{" "}
@@ -107,7 +105,6 @@ export default function manageOrganizationMembers({
       <WideLayout
         title={texts.no_permission_to_manage_members_of_this_org}
         {...layoutProps}
-        //hideHeadline={true}
       >
         <Typography variant="h4" color="primary" className={classes.headline}>
           {texts.need_to_be_admin_to_manage_org_members}

--- a/frontend/pages/manageProjectMembers/[projectUrl].tsx
+++ b/frontend/pages/manageProjectMembers/[projectUrl].tsx
@@ -65,7 +65,6 @@ export default function manageProjectMembers({
     return (
       <WideLayout
         title={texts.please_log_in + " " + texts.to_manage_the_members_of_this_project}
-        hideHeadline={true}
       >
         <LoginNudge fullPage whatToDo={texts.to_manage_the_members_of_this_project} />
       </WideLayout>
@@ -74,7 +73,6 @@ export default function manageProjectMembers({
     return (
       <WideLayout
         title={texts.please_log_in + " " + texts.to_manage_the_members_of_this_project}
-        hideHeadline={true}
       >
         <Typography variant="h4" color="primary" className={classes.headline}>
           {texts.you_are_not_a_member_of_this_project}{" "}
@@ -86,7 +84,7 @@ export default function manageProjectMembers({
     members.find((m) => m.id === user.id).role.role_type != ROLE_TYPES.read_write_type
   )
     return (
-      <WideLayout title={texts.no_permission_to_manage_members_of_this_project} hideHeadline={true}>
+      <WideLayout title={texts.no_permission_to_manage_members_of_this_project}>
         <Typography variant="h4" color="primary" className={classes.headline}>
           {texts.you_need_to_be_an_administrator_of_the_project_to_manage_project_members}
         </Typography>

--- a/frontend/pages/manageProjectMembers/[projectUrl].tsx
+++ b/frontend/pages/manageProjectMembers/[projectUrl].tsx
@@ -63,17 +63,13 @@ export default function manageProjectMembers({
 
   if (!user)
     return (
-      <WideLayout
-        title={texts.please_log_in + " " + texts.to_manage_the_members_of_this_project}
-      >
+      <WideLayout title={texts.please_log_in + " " + texts.to_manage_the_members_of_this_project}>
         <LoginNudge fullPage whatToDo={texts.to_manage_the_members_of_this_project} />
       </WideLayout>
     );
   else if (!members.find((m) => m.id === user.id))
     return (
-      <WideLayout
-        title={texts.please_log_in + " " + texts.to_manage_the_members_of_this_project}
-      >
+      <WideLayout title={texts.please_log_in + " " + texts.to_manage_the_members_of_this_project}>
         <Typography variant="h4" color="primary" className={classes.headline}>
           {texts.you_are_not_a_member_of_this_project}{" "}
         </Typography>

--- a/frontend/pages/share.tsx
+++ b/frontend/pages/share.tsx
@@ -86,7 +86,6 @@ export default function Share({
     return (
       <WideLayout
         title={texts.share_your_climate_solution}
-        // hideHeadline={true}
         message={errorMessage}
         messageType={errorMessage && "error"}
         customTheme={hubThemeData ? transformThemeData(hubThemeData) : undefined}

--- a/frontend/src/components/webflow/WebflowPage.tsx
+++ b/frontend/src/components/webflow/WebflowPage.tsx
@@ -25,7 +25,6 @@ export default function WebflowPage({
         title={title ? title : texts[pageKey]}
         description={description}
         isStaticPage
-        //TODO(unused) hideHeadline
         noSpaceBottom
         hideFooter={hideFooter}
         noHeader={noHeader}


### PR DESCRIPTION
## Description
Removed the unused `hideHeadline` prop from `WideLayout`

## Checked the following
- [x] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme
- [x] Run within `/frontend`: `yarn format && yarn lint`
- [x] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
