### PR TITLE
added hub to the redirect url on delete project

### DIFF
--- a/frontend/pages/editProject/[projectUrl].tsx
+++ b/frontend/pages/editProject/[projectUrl].tsx
@@ -85,19 +85,19 @@ export default function EditProjectPage({
   hubThemeData,
   hubUrl,
 }) {
+  
   const classes = useStyles();
   const [curProject, setCurProject] = React.useState({
     ...project,
     status: statusOptions.find((s) => s.name === project?.status),
-    hubUrl: project.related_hubs?.length > 0 ? project.related_hubs[0] : null,
+    hubUrl: hubUrl || null,
   });
   project = {
     ...project,
     status: statusOptions.find((s) => s.name === project?.status),
   };
   const [errorMessage, setErrorMessage] = React.useState("");
-  const { user, locale, CUSTOM_HUB_URLS } = useContext(UserContext);
-  const isCustomHub = CUSTOM_HUB_URLS.includes(hubUrl);
+  const { user, locale } = useContext(UserContext);
   const texts = getTexts({ page: "project", locale: locale });
 
   const handleSetErrorMessage = (newErrorMessage) => {
@@ -129,7 +129,7 @@ export default function EditProjectPage({
         </Typography>
       </Layout>
     );
-  else if (!members.find((m) => m.user && m.user.id === user.id))
+  else if (!members?.find((m) => m.user && m.user.id === user.id))
     return (
       <WideLayout
         title={texts.not_a_member}
@@ -189,6 +189,7 @@ export default function EditProjectPage({
           handleSetErrorMessage={handleSetErrorMessage}
           initialTranslations={project.translations}
           projectTypeOptions={projectTypeOptions}
+          hubUrl={hubUrl}
         />
       </WideLayout>
     );

--- a/frontend/src/components/editProject/EditProjectRoot.tsx
+++ b/frontend/src/components/editProject/EditProjectRoot.tsx
@@ -55,6 +55,7 @@ type Props = {
   handleSetErrorMessage: any;
   initialTranslations: any;
   projectTypeOptions: any;
+  hubUrl: string;
 };
 
 export default function EditProjectRoot({
@@ -68,6 +69,7 @@ export default function EditProjectRoot({
   handleSetErrorMessage,
   initialTranslations,
   projectTypeOptions,
+  hubUrl,
 }: Props) {
   const classes = useStyles();
   const token = new Cookies().get("auth_token");
@@ -257,11 +259,15 @@ export default function EditProjectRoot({
       locale: locale,
     })
       .then(function () {
+        const query: any = {
+          message: texts.you_have_successfully_deleted_your_project,
+        };
+        if (hubUrl) {
+          query.hub = hubUrl;
+        }
         Router.push({
           pathname: "/profiles/" + user.url_slug,
-          query: {
-            message: texts.you_have_successfully_deleted_your_project,
-          },
+          query,
         });
       })
       .catch(function (error) {


### PR DESCRIPTION
## Description
This PR addresses issue [1514](https://github.com/climateconnect/climateconnect/issues/1514)

## Notice
> On a project in a custom hub when saving after beining in the manage members menue the user is leving the custom hub and url slug is lost.
This issue has been fixed in  [PR 1518](https://github.com/climateconnect/climateconnect/pull/1518)

## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
