### PR TITLE
Fixing check translation warning

### DIFF
--- a/frontend/src/components/editProject/EditProjectRoot.tsx
+++ b/frontend/src/components/editProject/EditProjectRoot.tsx
@@ -39,6 +39,7 @@ const useStyles = makeStyles((theme) => {
     headline: {
       textAlign: "center",
       marginTop: theme.spacing(4),
+      color: theme.palette.background.default_contrastText,
     },
   };
 });

--- a/frontend/src/components/general/TranslateTexts.tsx
+++ b/frontend/src/components/general/TranslateTexts.tsx
@@ -152,7 +152,7 @@ export default function TranslateTexts({
 }: Props) {
   const visibleFooterHeight = VisibleFooterHeight({});
   const classes = useStyles({ visibleFooterHeight: visibleFooterHeight });
-
+  
   const { locale } = useContext(UserContext);
   //For the organization page, we need to retrieve the organization name to get the german text.
   //Therefore we pass organization even it this might not make sense in most cases.
@@ -430,7 +430,6 @@ function TranslationBlockElement({
   characterText,
 }) {
   const classes = useStyles({});
-
   return (
     <div className={classes.translationBlockElement}>
       {!noHeadline && (
@@ -441,11 +440,10 @@ function TranslationBlockElement({
 
       <TextField
         rows={rows}
-        maxRows={50}
         variant="outlined"
         fullWidth
         multiline
-        inputProps={{ maxLength: maxCharacters }}
+        {...(maxCharacters ? {inputProps: { maxLength: maxCharacters }} : {})}
         helperText={
           showCharacterCounter &&
           "( " + content?.length + " / " + maxCharacters + " " + characterText + " ) "

--- a/frontend/src/components/general/TranslateTexts.tsx
+++ b/frontend/src/components/general/TranslateTexts.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles<Theme, { visibleFooterHeight?: number }>((theme) =>
     fontWeight: "bold",
     marginTop: theme.spacing(1.5),
     overflowWrap: "break-word",
-    color : theme.palette.background.default_contrastText,
+    color: theme.palette.background.default_contrastText,
   },
   divider: {
     marginTop: theme.spacing(1),

--- a/frontend/src/components/general/TranslateTexts.tsx
+++ b/frontend/src/components/general/TranslateTexts.tsx
@@ -29,12 +29,14 @@ const useStyles = makeStyles<Theme, { visibleFooterHeight?: number }>((theme) =>
   explanation: {
     margin: "0 auto",
     textAlign: "center",
+    color: theme.palette.grey[800],
   },
   sectionHeader: {
     fontSize: 22,
     fontWeight: "bold",
     marginTop: theme.spacing(1.5),
     overflowWrap: "break-word",
+    color : theme.palette.background.default_contrastText,
   },
   divider: {
     marginTop: theme.spacing(1),

--- a/frontend/src/components/project/ProjectContent.tsx
+++ b/frontend/src/components/project/ProjectContent.tsx
@@ -155,7 +155,6 @@ export default function ProjectContent({
   const texts = getTexts({ page: "project", locale: locale, project: project });
   const [showFullDescription, setShowFullDescription] = useState(false);
   const handleToggleFullDescriptionClick = () => setShowFullDescription(!showFullDescription);
-
   const calculateMaxDisplayedDescriptionLength = (description) => {
     const words = description.split(" ");
     const youtubeLink = words.find((el) => youtubeRegex().test(el));
@@ -191,6 +190,7 @@ export default function ProjectContent({
     return texts.this_project_hasnt_added_a_description_yet;
   };
   const theme = useTheme();
+  
   return (
     <>
       <div className={classes.contentBlock}>


### PR DESCRIPTION
## Description
In edit project page, some warning happened in the check translation component

## Screenshots

- 
<img width="1396" alt="Screenshot 2025-04-09 at 5 12 05 PM" src="https://github.com/user-attachments/assets/5ef448ad-50b4-419d-b5ef-b170f399adfc" />

- 
<img width="1396" alt="Screenshot 2025-04-09 at 4 52 45 PM" src="https://github.com/user-attachments/assets/0f2de72a-abec-4784-9afc-dce0dcb46456" />


## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
