### PR TITLE
Added redirect for hubs without landingpage on GetServerSideProps

### DIFF
--- a/frontend/pages/hubs/[hubUrl]/index.tsx
+++ b/frontend/pages/hubs/[hubUrl]/index.tsx
@@ -64,6 +64,15 @@ export async function getServerSideProps(ctx: any) {
   }
 
   const hubData = await getHubData(hubUrl, ctx.locale);
+  if (!hubData?.landing_page_component) {
+    return {
+      redirect: {
+        destination: `/hubs/${hubUrl}/browse`,
+        // redirect is based on current hub data, and that might change in the future so permanent: false,
+        permanent: false,
+      },
+    };
+  }
   return {
     props: {
       hubData,
@@ -91,7 +100,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ hubData, hubUrl }) => {
   const texts = getTexts({ page: "landing_page", locale: locale }) as TextsType;
   const [DevlinkComponent, setDevlinkComponent] = useState<DevlinkComponentType>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
-
+  
   useEffect(() => {
     const loadComponent = async () => {
       if (!hubData?.landing_page_component) {


### PR DESCRIPTION
## Checked the following
- [x] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme
- [x] Run within `/frontend`: `yarn format && yarn lint`
- [x] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
