### PR TITLE
mapping sectorOptions data to sub sector for Perh hub

### DIFF
--- a/frontend/pages/share.tsx
+++ b/frontend/pages/share.tsx
@@ -4,7 +4,7 @@ import Cookies from "universal-cookie";
 import { apiRequest, sendToLogin } from "../public/lib/apiOperations";
 import { getProjectTypeOptions } from "../public/lib/getOptions";
 import { nullifyUndefinedValues } from "../public/lib/profileOperations";
-import { parseOptions, parseSectorOptions } from "../public/lib/selectOptionsOperations";
+import { parseOptions, parseSectorOptions, transformSectorOptionsToPerthSubHub } from "../public/lib/selectOptionsOperations";
 import getTexts from "../public/texts/texts";
 import UserContext from "../src/components/context/UserContext";
 import LoginNudge from "../src/components/general/LoginNudge";
@@ -68,6 +68,7 @@ export default function Share({
   hubThemeData,
   sectorOptions,
 }) {
+  const transformedData = hubUrl === "perth" ? transformSectorOptionsToPerthSubHub(sectorOptions) : sectorOptions;
   const token = new Cookies().get("auth_token");
   const { user, locale } = useContext(UserContext);
   const texts = getTexts({ page: "project", locale: locale });
@@ -75,7 +76,7 @@ export default function Share({
 
   const handleSetErrorMessage = (newMessage) => setErrorMessage(newMessage);
   const customTheme = hubThemeData ? transformThemeData(hubThemeData) : undefined;
-
+  
   if (!user)
     return (
       <WideLayout
@@ -109,7 +110,7 @@ export default function Share({
           setMessage={handleSetErrorMessage}
           projectTypeOptions={projectTypeOptions}
           hubName={hubUrl}
-          sectorOptions={sectorOptions}
+          sectorOptions={transformedData}
         />
       </WideLayout>
     );

--- a/frontend/public/lib/selectOptionsOperations.ts
+++ b/frontend/public/lib/selectOptionsOperations.ts
@@ -34,3 +34,35 @@ export function parseSectorOptions(options) {
     };
   });
 }
+
+export function transformSectorOptionsToPerthSubHub(originalArray) {
+  // Define the mapping for name changes.
+  const nameMapping = {
+    "Education": "Climate Café",
+    "Food & Agriculture": "Food",
+    "Nature & Biodiversity": "Nature",
+    "Mobility": "Transport",
+    "Resources & Consumption": "Zero Waste"
+  };
+
+  const allowedOriginalNames = [
+    "Energy"
+  ];
+
+  //hasOwnProperty method used to check if nameMapping object has a property with a specified name
+  const filteredArray = originalArray.filter(item => {
+    return nameMapping.hasOwnProperty(item.name) || allowedOriginalNames.includes(item.name);
+  });
+
+  const newArray = filteredArray.map(item => {
+    const newItem = { ...item };
+
+    if (nameMapping.hasOwnProperty(newItem.name)) {
+      newItem.name = nameMapping[newItem.name];
+      newItem.original_name = nameMapping[item.name];
+    }
+    return newItem;
+  });
+
+  return newArray;
+}


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
