### PR TITLE
Added hubUrl to MiniProfilePreview.tsx

### DIFF
--- a/frontend/src/components/profile/MiniProfilePreview.tsx
+++ b/frontend/src/components/profile/MiniProfilePreview.tsx
@@ -42,7 +42,8 @@ const useStyles = makeStyles((theme) => {
   };
 });
 
-type Props = { className?; profile?; avatarClassName?; size?; nolink?; onDelete? };
+type Props = { className?; profile?; avatarClassName?; size?; nolink?; onDelete?; hubUrl?: string };
+
 export default function MiniProfilePreview({
   className,
   profile,
@@ -50,15 +51,18 @@ export default function MiniProfilePreview({
   size,
   nolink,
   onDelete,
+  hubUrl,
 }: Props) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
+  const queryString = hubUrl ? "?hub=" + hubUrl : "";
+
   if (!nolink)
     return (
       <>
         <Link
           color="inherit"
-          href={getLocalePrefix(locale) + "/profiles/" + profile.url_slug}
+          href={getLocalePrefix(locale) + `/profiles/${profile.url_slug}${queryString}`}
           className={`${"" /*TODO(undefined) classes.avatarWithInfo*/} ${className}`}
           underline="hover"
         >

--- a/frontend/src/components/project/ProjectContent.tsx
+++ b/frontend/src/components/project/ProjectContent.tsx
@@ -228,6 +228,7 @@ export default function ProjectContent({
                     className={classes.creator}
                     profile={project.creator}
                     size="small"
+                    hubUrl={hubUrl}
                   />
                 ) : (
                   <MiniOrganizationPreview


### PR DESCRIPTION
## Description
Added hubUrl link to the Profile preview link on project tab on projects page.
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile links now conditionally include a hub URL as a query parameter when available, improving navigation context for user profiles.

* **Refactor**
  * Updated project profile previews to consistently support hub URL parameters, aligning with organization previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->