### PR TITLE
Skills list causes horizontal scroll on `Share Project` page

### DIFF
--- a/frontend/src/components/shareProject/CollaborateSection.tsx
+++ b/frontend/src/components/shareProject/CollaborateSection.tsx
@@ -1,4 +1,13 @@
-import { Button, Chip, IconButton, List, Tooltip, Typography } from "@mui/material";
+import {
+  Button,
+  Chip,
+  IconButton,
+  List,
+  Tooltip,
+  Typography,
+  useMediaQuery,
+  Theme,
+} from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import React, { useContext } from "react";
 import getTexts from "../../../public/texts/texts";
@@ -12,18 +21,22 @@ const useStyles = makeStyles((theme) => {
       display: "flex",
       border: "1px solid black",
       height: theme.spacing(5),
-      minWidth: 220,
+      [theme.breakpoints.up("lg")]: {
+        minWidth: 220,
+      },
       maxWidth: "100%",
       marginRight: theme.spacing(1),
       background: "none",
       borderRadius: 0,
       fontSize: 16,
+      marginBottom: theme.spacing(1),
     },
     flexContainer: {
       display: "flex",
       flexDirection: "row",
       padding: 0,
       marginBottom: theme.spacing(3),
+      flexWrap: "wrap",
     },
   };
 });
@@ -47,6 +60,7 @@ export default function CollaborateSection({
   const [selectedItems, setSelectedItems] = React.useState(
     projectData.skills ? [...projectData.skills] : []
   );
+
   const handleSkillDelete = (skill) => {
     handleSetProjectData({
       skills: projectData.skills

--- a/frontend/src/components/shareProject/CollaborateSection.tsx
+++ b/frontend/src/components/shareProject/CollaborateSection.tsx
@@ -1,13 +1,4 @@
-import {
-  Button,
-  Chip,
-  IconButton,
-  List,
-  Tooltip,
-  Typography,
-  useMediaQuery,
-  Theme,
-} from "@mui/material";
+import { Button, Chip, IconButton, List, Tooltip, Typography } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import React, { useContext } from "react";
 import getTexts from "../../../public/texts/texts";


### PR DESCRIPTION
## Description
This PR addresses issue [1594](https://github.com/climateconnect/climateconnect/issues/1594)
(Skills list causes horizontal scroll on `Share Project` page)
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout responsiveness by adjusting the minimum width of skill items for large screens only.
  * Added spacing below skill items for better visual separation.
  * Enabled wrapping of items within the container for improved display on various screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->