### PR TITLE
Fix location filter, make project page more robust

### DIFF
--- a/frontend/src/components/filter/SelectedFilter.tsx
+++ b/frontend/src/components/filter/SelectedFilter.tsx
@@ -70,10 +70,10 @@ export default function SelectedFilter({
             typeof filter === "object" ? (filter.name ? filter.name : filter.simple_name) : filter;
 
           // Find matching metadata by original_name or name
-          const matchedOption = filterMetadata.options.find(
+          const matchedOption = filterMetadata?.options?.find(
             (opt) => opt.original_name === filterName || opt.name === filterName
           );
-          const iconUrl = matchedOption?.icon;
+          const iconUrl = matchedOption ? matchedOption?.icon : null;
           return (
             <Tooltip title={filterMetadata.title} key={filterName}>
               <Chip

--- a/frontend/src/components/project/ProjectOverview.tsx
+++ b/frontend/src/components/project/ProjectOverview.tsx
@@ -321,6 +321,7 @@ function SmallScreenOverview({ screenSize, project, projectAdmin, hubUrl }) {
           className={classes.shareButtonContainer}
           project={project}
           projectAdmin={projectAdmin}
+          hubUrl={hubUrl}
         />
         <img
           className={classes.fullWidthImage}

--- a/frontend/src/components/shareContent/ProjectSocialMediaShareButton.tsx
+++ b/frontend/src/components/shareContent/ProjectSocialMediaShareButton.tsx
@@ -22,10 +22,9 @@ export function ProjectSocialMediaShareButton({ className, project, projectAdmin
     project: project,
     creator: projectAdmin,
   });
-
   const projectLinkPath = `${getLocalePrefix(locale)}/projects/${project.url_slug}`;
   const apiEndpointShareButton = `/api/projects/${project.url_slug}/set_shared_project/`;
-  const projectAdminName = project.creator?.name ? project.creator?.name : projectAdmin.name;
+  const projectAdminName = project.creator?.name ? project.creator?.name : projectAdmin?.name;
   const messageTitleShareButton = `${texts.climate_protection_project_by}${projectAdminName}: ${project.name}`;
   const mailBodyShareButton = texts.share_project_email_body;
   const dialogTitleShareButton = texts.tell_others_about_this_project;


### PR DESCRIPTION
This fixes some follow-up bugs from the recent PnK-related changes:
- location search was broken because of an error when trying to display an icon. This is now fixed
- The project page would break if the creator left the project, this is now fixed