### PR TITLE
Remove an unused className from the Header component.

### DIFF
--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -482,7 +482,7 @@ function NormalScreenLinks({
         )
           return (
             <React.Fragment key={index}>
-              <span className={classes.menuLink}>
+              <span>
                 {link.type === "languageSelect" ? (
                   <LanguageSelect
                     transparentHeader={transparentHeader}
@@ -754,7 +754,7 @@ function NarrowScreenLinks({
                   )}
                 </>
               ) : (
-                <span className={classes.menuLink}>
+                <span>
                   {link.type === "languageSelect" ? (
                     <LanguageSelect
                       transparentHeader={transparentHeader}


### PR DESCRIPTION
## Description
Removes an unused className from the Header component.
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
