### PR TITLE
fix: devlink without webflow token (part 1)

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -15,12 +15,13 @@ import theme from "../src/themes/theme";
 import { CcLocale } from "../src/types";
 import * as Sentry from "@sentry/react";
 
-
 //only bundle global.css if ENABLE_DEVLINK in .env is true
 const isDevlinkEnabled = process.env.ENABLE_DEVLINK === "true";
-if (isDevlinkEnabled) {
-  require("../devlink/global.css");
-}
+try {
+  if (isDevlinkEnabled) {
+    require("../devlink/global.css");
+  }
+} catch (error) {}
 
 // initialize sentry
 
@@ -207,7 +208,6 @@ export default function MyApp({ Component, pageProps = {} }) {
       connect(client);
     }
   }, [state.user]);
-
 
   const connect = (initialClient) => {
     const client = initialClient ? initialClient : WebSocketService("/ws/chat/");

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -18,11 +18,13 @@ const Fallback = () => (
 );
 let CCLandingpage: any = Fallback;
 let ENLandingpageClimateConnect: any = Fallback;
-if (process.env.ENABLE_DEVLINK === "true") {
-  const devlink = require("../devlink");
-  CCLandingpage = devlink.CcLandingpage;
-  ENLandingpageClimateConnect = devlink.EnLandingpageClimateConnect;
-}
+try {
+  if (process.env.ENABLE_DEVLINK === "true") {
+    const devlink = require("../devlink");
+    CCLandingpage = devlink.CcLandingpage;
+    ENLandingpageClimateConnect = devlink.EnLandingpageClimateConnect;
+  }
+} catch (error) {}
 
 const useStyles = makeStyles((theme) => ({
   container: {

--- a/frontend/public/data/customHubConfig/prio1.ts
+++ b/frontend/public/data/customHubConfig/prio1.ts
@@ -2,13 +2,16 @@ import { Link } from "../customHubtypes";
 import { getSharedLinks, getStaticLinks, StaticLinkConfig } from "./customHubLinks";
 
 //for usage without webflow token
-let enWelcomeModule: any;
-let deWillkommenModul: any;
-if (process.env.ENABLE_DEVLINK === "true") {
-  const devlink = require("../../../devlink");
-  enWelcomeModule = devlink.EnPrio1Welcome;
-  enWelcomeModule = devlink.DePrio1Willkommen;
-}
+const EmptyModule = () => null;
+let enWelcomeModule: any = EmptyModule;
+let deWillkommenModul: any = EmptyModule;
+try {
+  if (process.env.ENABLE_DEVLINK === "true") {
+    const devlink = require("../../../devlink");
+    enWelcomeModule = devlink.EnPrio1Welcome;
+    enWelcomeModule = devlink.DePrio1Willkommen;
+  }
+} catch (error) {}
 
 const PRIO1_BASE_URL = "https://prio1-klima.net";
 

--- a/frontend/src/components/layouts/layout.tsx
+++ b/frontend/src/components/layouts/layout.tsx
@@ -11,11 +11,14 @@ import Header from "../header/Header";
 import LayoutWrapper from "./LayoutWrapper";
 
 //for usage without webflow token
-let DevLinkProvider: any;
-if (process.env.ENABLE_DEVLINK === "true") {
-  const devlink = require("../../../devlink");
-  DevLinkProvider = devlink.DevLinkProvider;
-}
+const EmptyModule = () => null;
+let DevLinkProvider: any = EmptyModule;
+try {
+  if (process.env.ENABLE_DEVLINK === "true") {
+    const devlink = require("../../../devlink");
+    DevLinkProvider = devlink.DevLinkProvider;
+  }
+} catch (error) {}
 
 interface StyleProps {
   customTheme_default_contrastText?: string;

--- a/frontend/src/declarations.d.ts
+++ b/frontend/src/declarations.d.ts
@@ -3,4 +3,3 @@ declare module "*.svg" {
   const content: ReactSVG;
   export default content;
 }
-


### PR DESCRIPTION
Addresses https://github.com/climateconnect/climateconnect/issues/1635 

## Checked the following
- [ ] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [x] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why
if people don't have a webflow token and still want to collaborate, this is the fix of devlink imports in 3 of the 4 neccessary files
<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a feature flag to enable Devlink-powered pages/components.
  - Added a fallback UI when Devlink is disabled or tokens are missing, including a Browse button.
- Refactor
  - Switched to environment-gated, runtime loading for Devlink components and provider to keep the default experience unchanged unless enabled.
- Style
  - Loads Devlink-specific styles only when the feature flag is on.
- Chores
  - Exposed the ENABLE_DEVLINK environment variable to the client via configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->