### PR TITLE
compress image after closing dialog-V1

### DIFF
--- a/frontend/src/components/shareProject/AddPhotoSection.tsx
+++ b/frontend/src/components/shareProject/AddPhotoSection.tsx
@@ -93,26 +93,16 @@ export default function AddPhotoSection({
     handleSetOpen({ avatarDialog: false });
     if (image && image instanceof HTMLCanvasElement) {
       whitenTransparentPixels(image);
+
+      // Keep showing the existing tempImage while compressing
+      setIsCompressing(true);
+
       image.toBlob(async function (blob) {
         if (!blob) return;
-        
-        // Show image immediately (uncompressed) for instant feedback
-        const immediateImageUrl = URL.createObjectURL(blob);
-        handleSetProjectData({
-          image: immediateImageUrl,
-          thumbnail_image: immediateImageUrl, // temporary thumbnail
-        });
-        
-        // Compress in background without blocking UI
-        setIsCompressing(true);
+
         try {
           const compressedImageUrl = await getCompressedJPG(blob, 0.5);
-          const thumbnailBlob = await getResizedImage(
-            compressedImageUrl,
-            290,
-            160,
-            "image/jpeg"
-          );
+          const thumbnailBlob = await getResizedImage(compressedImageUrl, 290, 160, "image/jpeg");
           // Update with compressed versions once ready
           handleSetProjectData({
             image: compressedImageUrl,


### PR DESCRIPTION
## Description
This PR addresse issue [1618](https://github.com/climateconnect/climateconnect/issues/1618)
(Large image files cause a significant delay when a user selects an image.)

## Solution
To resolve this issue, I've relocated the image compression process to occur after the user closes the file dialog. This ensures that the selected image appears instantly, providing a much smoother user experience. The compression now runs in the background without causing any UI freezes.
The new workflow is as follows:

1. When a user selects an image, it is immediately displayed in the dialog without any delay.
2. The compression process is then started in the background after the dialog is closed.
3. Implemented state management to track the compression status of the file, allowing other parts of the application to know when the compressed file is ready to be used.

**There are several potential problems with compressing after closing the dialog:**

1. Memory leaks: Multiple object URLs created (`immediateImageUrl`, `compressedImageUrl`) may not be properly cleaned up, especially if user selects multiple images quickly.
2. Race conditions: If user quickly selects another image before compression finishes, the background compression might overwrite the new image data unexpectedly.
3. Network upload issues: If form submission happens before compression completes, large uncompressed images will be uploaded, potentially causing:
Slow uploads
Server timeouts
Higher bandwidth usage
4. 


## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
