### PR TITLE
Change the way locations are parsed to not show UK countries as states

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -15,6 +15,7 @@ import theme from "../src/themes/theme";
 import { CcLocale } from "../src/types";
 import * as Sentry from "@sentry/react";
 import "../devlink/global.css";
+import { getHubslugFromUrl } from "../public/lib/hubOperations";
 
 // initialize sentry
 
@@ -30,7 +31,7 @@ Sentry.init({
 
 declare module "@mui/styles/defaultTheme" {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface DefaultTheme extends Theme {}
+  interface DefaultTheme extends Theme { }
 }
 
 // This is lifted from a Material UI template at https://github.com/mui-org/material-ui/blob/master/examples/nextjs/pages/_app.js.
@@ -268,6 +269,7 @@ export default function MyApp({ Component, pageProps = {} }) {
     CUSTOM_HUB_URLS: CUSTOM_HUB_URLS,
     setNotificationsRead: setNotificationsRead,
     pathName: pathName,
+    hubUrl: getHubslugFromUrl(router.query),
     ReactGA: ReactGA,
     updateCookies: updateCookies,
     socketConnectionState: socketConnectionState,

--- a/frontend/public/lib/hubOperations.ts
+++ b/frontend/public/lib/hubOperations.ts
@@ -12,6 +12,10 @@ export function extractHubUrlsFromContext(ctx: GetServerSidePropsContext) {
   return { hubUrl, subHub: hubUrl + "_" + subHub };
 }
 
+export function getHubslugFromUrl(query) {
+  return query.hubUrl || query.hub
+}
+
 export async function getAllHubs(locale: any, just_sector_hubs?: boolean) {
   const url = just_sector_hubs ? `/api/sector_hubs/` : `/api/hubs/`;
   try {

--- a/frontend/src/components/context/UserContext.ts
+++ b/frontend/src/components/context/UserContext.ts
@@ -27,6 +27,7 @@ const UserContext = createContext<{
   stopLoading?: any;
   hideNotification?: any;
   LOCATION_HUBS?: any;
+  hubUrl: string;
 }>(null!);
 
 export default UserContext;


### PR DESCRIPTION
Currently, UK countries are shown as state, when parsing names, e.g. "Perth, Scotland(state), United Kingdom". 
This PR changes this to show the countries as countries, e.g. "Perth, Scotland" or "London, England", ...

This change applies to all locations that get newly added to the database. A follow-up PR will include a script to convert the already existing locations to the new format