### PR TITLE
added hamlet type to the first part of search name

### DIFF
--- a/frontend/public/lib/locationOperations.ts
+++ b/frontend/public/lib/locationOperations.ts
@@ -2,8 +2,8 @@ import { getLocationFilterKeys } from "../data/locationFilters";
 import { apiRequest } from "./apiOperations";
 
 const CUSTOM_NAME_MAPPINGS = {
-  "Scotland (state), Scotland": "Scotland"
-}
+  "Scotland (state), Scotland": "Scotland",
+};
 
 //These countries are wrongly categorized as states in Nominatim. We want to show them as countries as this is more clear
 const MAP_STATE_TO_COUNTRY = ["Scotland", "Wales", "England", "Northern Ireland"];
@@ -22,6 +22,7 @@ export function getNameFromLocation(location) {
     return location.city + "" + location.country;
   if (!location.address || !location.address.country) return location.display_name;
   const firstPartOrder = [
+    "hamlet",
     "village",
     "town",
     "city_district",
@@ -59,14 +60,16 @@ export function getNameFromLocation(location) {
   const middlePartSuffixes = ["city", "state"];
   const firstPart = getFirstPart(location.address, firstPartOrder);
   const middlePart = getMiddlePart(location.address, middlePartOrder, middlePartSuffixes);
-  const lastPart = MAP_STATE_TO_COUNTRY.includes(location?.address?.state) ? location.address.state : location.address.country;
+  const lastPart = MAP_STATE_TO_COUNTRY.includes(location?.address?.state)
+    ? location.address.state
+    : location.address.country;
   const showMiddlePart = firstPart !== middlePart && middlePart !== lastPart;
   let name =
     firstPart +
     ", " +
     (showMiddlePart ? middlePart : "") +
     (showMiddlePart && middlePart?.length > 0 ? ", " : "") +
-    lastPart
+    lastPart;
   //For certain locations our automatic name generation doesn't work. In this case we want to override the name with a custom one
   if (Object.keys(CUSTOM_NAME_MAPPINGS).includes(name)) {
     name = CUSTOM_NAME_MAPPINGS[name];
@@ -110,11 +113,14 @@ export function getNameFromExactLocation(location) {
       : "";
   const middlePart =
     isConcretePlace && location.address.road
-      ? `${location.address.road}${location.address.house_number ? " " + location.address.house_number : ""
-      }, `
+      ? `${location.address.road}${
+          location.address.house_number ? " " + location.address.house_number : ""
+        }, `
       : "";
-  const city = getCityOrCountyName(location.address)
-  const country = MAP_STATE_TO_COUNTRY.includes(location?.address?.state) ? location.address.state : location.address.country
+  const city = getCityOrCountyName(location.address);
+  const country = MAP_STATE_TO_COUNTRY.includes(location?.address?.state)
+    ? location.address.state
+    : location.address.country;
   const cityAndCountry = `${firstPart != city && `${city}, `}${country}`;
   let name = firstPart + middlePart + cityAndCountry;
   //For certain locations our automatic name generation doesn't work. In this case we want to override the name with a custom one


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
