### PR TITLE
Change spelling of organization to British English

### DIFF
--- a/backend/locale/de/LC_MESSAGES/django.po
+++ b/backend/locale/de/LC_MESSAGES/django.po
@@ -20,17 +20,17 @@ msgstr ""
 
 #: organization/views/organization_views.py:283
 #: organization/views/organization_views.py:300
-msgid "Organization not found:"
+msgid "Organisation not found:"
 msgstr "Organisation nicht gefunden:"
 
 #: organization/views/organization_views.py:337
-msgid "Parent organization not found for organization"
+msgid "Parent organisation not found for organisation"
 msgstr "Mutterorganisation der Organisation nicht gefunden"
 
 #: organization/views/organization_views.py:389
-msgid "Passed organization tag id does not exists: "
+msgid "Passed organisation tag id does not exists: "
 msgstr "Dieser Organisationstyp existiert nicht: "
 
 #: organization/views/organization_views.py:392
-msgid "Successfully updated organization."
+msgid "Successfully updated organisation."
 msgstr "Organisation erfolgreich bearbeitet"

--- a/backend/organization/locale/de/LC_MESSAGES/django.po
+++ b/backend/organization/locale/de/LC_MESSAGES/django.po
@@ -25,7 +25,7 @@ msgstr ""
 #: organization/utility/follow.py:109
 #, fuzzy
 #| msgid "Organization not found:"
-msgid "Organization not found."
+msgid "Organisation not found."
 msgstr "Organisation nicht gefunden:"
 
 #: organization/utility/follow.py:111
@@ -33,7 +33,7 @@ msgid "Project not found."
 msgstr "Projekt nicht gefunden."
 
 #: organization/utility/follow.py:120
-msgid "You're already following this organization."
+msgid "You're already following this organisation."
 msgstr "Du folgst dieser Organisation bereits."
 
 #: organization/utility/follow.py:122
@@ -42,7 +42,7 @@ msgstr "Du folgst diesem Projekt bereits"
 
 #: organization/utility/follow.py:136
 msgid ""
-"You are now following this organization. You will be notified when they post "
+"You are now following this organisation. You will be notified when they post "
 "an update!"
 msgstr ""
 "Du folgst der Organisation jetzt. Du wirst benachrichtigt, wenn sie ein "
@@ -56,7 +56,7 @@ msgstr ""
 "Du folgst dem Projekt jetzt. Du wirst benachrichtigt, es ein Update gibt."
 
 #: organization/utility/follow.py:157
-msgid "You weren't following this organization."
+msgid "You weren't following this organisation."
 msgstr "Du hast dieser Organisation nicht gefolgt"
 
 #: organization/utility/follow.py:159
@@ -64,7 +64,7 @@ msgid "You weren't following this project."
 msgstr "Du hast diesem Projekt nicht gefolgt"
 
 #: organization/utility/follow.py:167
-msgid "You are not following this organization anymore."
+msgid "You are not following this organisation anymore."
 msgstr "Du folgst dieser Organisation nicht mehr"
 
 #: organization/utility/follow.py:169
@@ -77,26 +77,26 @@ msgstr "Ungültiger Wert für die Variable \"following\""
 
 #: organization/utility/organization.py:180
 msgid ""
-"Someone has already created the organization {}. Please join the "
-"organization or use a different name. If you're having problems please "
+"Someone has already created the organisation {}. Please join the "
+"organisation or use a different name. If you're having problems please "
 "contact support@climateconnect.earth"
 msgstr "Jemand hat die Organisation {} bereits erstellt. Bitte trete der Organisation bei oder verwende einen anderen Namen. Falls du Probleme hast, wende dich bitte an support@climateconnect.earth"
 
 #: organization/views/organization_views.py:478
 #: organization/views/organization_views.py:500
-msgid "Organization not found:"
+msgid "Organisation not found:"
 msgstr "Organisation nicht gefunden:"
 
 #: organization/views/organization_views.py:566
-msgid "Parent organization not found for organization"
+msgid "Parent organisation not found for organisation"
 msgstr "Mutterorganisation der Organisation nicht gefunden"
 
 #: organization/views/organization_views.py:613
-msgid "Passed organization tag id does not exists: "
+msgid "Passed organisation tag id does not exists: "
 msgstr "Dieser Organisationstyp existiert nicht: "
 
 #: organization/views/organization_views.py:619
-msgid "Successfully updated organization."
+msgid "Successfully updated organisation."
 msgstr "Organisation erfolgreich bearbeitet"
 
 #~ msgid "The name {} is already in use. Please use another name."

--- a/backend/organization/management/commands/organization_translation.py
+++ b/backend/organization/management/commands/organization_translation.py
@@ -18,7 +18,7 @@ def translate_organization(organization: Organization) -> None:
     try:
         translations = get_translations(texts, {}, "en")
     except ValueError:
-        print("Error getting translation for organization {}".format(organization.name))
+        print("Error getting translation for organisation {}".format(organization.name))
         translations = None
 
     if translations:

--- a/frontend/public/texts/account_texts.json
+++ b/frontend/public/texts/account_texts.json
@@ -4,11 +4,11 @@
     "de": "Typ hinzufügen"
   },
   "choose_type": {
-    "en": "Choose an organization type",
+    "en": "Choose an organisation type",
     "de": "Wähle einen Organisationstyp aus"
   },
   "parent_organization": {
-    "en": "Parent organization",
+    "en": "Parent organisation",
     "de": "Mutterorganisation"
   },
   "please_upload_either_a_png_or_a_jpg_file": {

--- a/frontend/public/texts/chat_texts.json
+++ b/frontend/public/texts/chat_texts.json
@@ -104,7 +104,7 @@
     "de": "Du hast die Teilnehmer*innen dieses Chats erfolgreich aktualisiert!"
   },
   "there_must_be_exactly_one_creator_of_an_organization": {
-    "en": "There must be exactly one Super Admin of an organization.",
+    "en": "There must be exactly one Super Admin of an organisation.",
     "de": "Es muss genau einen Super Admin einer Organisation geben"
   },
   "there_wasnt_a_creator": {

--- a/frontend/public/texts/climatematch_texts.ts
+++ b/frontend/public/texts/climatematch_texts.ts
@@ -31,7 +31,7 @@ export default function getClimatematchTexts({ location, question }) {
     },
     answer_the_next_four_questions_to_get_suggestions: {
       en:
-        "Just answer 4 questions and we show you which organizations, projects and ideas match with your skills and interests",
+        "Just answer 4 questions and we show you which organisations, projects and ideas match with your skills and interests",
       de:
         "Beantworte einfach die 4 folgenden Fragen und wir zeigen dir, welche Organisationen, Projekte und Ideen am besten zu dir passen.",
     },

--- a/frontend/public/texts/dashboard_texts.ts
+++ b/frontend/public/texts/dashboard_texts.ts
@@ -25,7 +25,7 @@ export default function getDashboardTexts({ user, location }) {
       de: "Ein Projekt teilen",
     },
     create_organization: {
-      en: "Create an organization",
+      en: "Create an organisation",
       de: "Eine Organisation erstellen",
     },
     profile: {

--- a/frontend/public/texts/filter_and_search_texts.ts
+++ b/frontend/public/texts/filter_and_search_texts.ts
@@ -23,7 +23,7 @@ export default function getFilterAndSearchTexts({ filterType, hubName, locale })
       de: "Suche nach Klimaprojekten",
     },
     search_organizations: {
-      en: "Search for organizations fighting climate change",
+      en: "Search for organisations fighting climate change",
       de: "Suche nach Organisationen, die den Klimawandel bekämpfen",
     },
     search_active_people: {
@@ -31,7 +31,7 @@ export default function getFilterAndSearchTexts({ filterType, hubName, locale })
       de: "Suche nach Menschen, die gegen den Klimawandel aktiv sind",
     },
     organization_type_tooltip: {
-      en: "Only shows projects created by organizations of the selected type",
+      en: "Only shows projects created by organisations of the selected type",
       de: "Zeige nur Projekte an, die von Organisationen des ausgewählten Typs erstellt wurden",
     },
     categories_tooltip: {

--- a/frontend/public/texts/general_texts.json
+++ b/frontend/public/texts/general_texts.json
@@ -120,7 +120,7 @@
     "de": "Projekt"
   },
   "organizations": {
-    "en": "Organizations",
+    "en": "Organisations",
     "de": "Organisationen"
   },
   "members": {
@@ -136,7 +136,7 @@
     "de": "Bitte wähle eine der Optionen für den Ort. Wähle Deinen Standort, wenn der Ort \"Online\" ist."
   },
   "organization_type": {
-    "en": "Organization type",
+    "en": "Organisation type",
     "de": "Organisationsart"
   },
   "click_here_to_send_or_press_ctrl_enter": {
@@ -204,7 +204,7 @@
     "de": "Meine Projekte"
   },
   "my_organizations": {
-    "en": "My Organizations",
+    "en": "My Organisations",
     "de": "Meine Organisationen"
   },
   "settings": {
@@ -300,7 +300,7 @@
     "de": "Nicht alle deine Updates haben funktioniert."
   },
   "organization": {
-    "en": "Organization",
+    "en": "Organisation",
     "de": "Organisation"
   },
   "page": {
@@ -308,7 +308,7 @@
     "de": "Seite"
   },
   "create_an_organization": {
-    "en": "Create an organization",
+    "en": "Create an organisation",
     "de": "Organisation erstellen"
   },
   "you_are": {

--- a/frontend/public/texts/getHubTexts.ts
+++ b/frontend/public/texts/getHubTexts.ts
@@ -16,11 +16,11 @@ export default function getHubTexts({ hubName, hubAmbassador }) {
       de: "Finde inspirierende Klimaschutz-Ideen aus " + hubName,
     },
     search_for_organizations_in_sector: {
-      en: "Search for climate organizations in the " + hubName + " sector",
+      en: "Search for climate organisations in the " + hubName + " sector",
       de: "Durchsuche Klimaschutzorganisationen im Bereich " + hubName,
     },
     search_organization_in_location: {
-      en: "Search organizations in " + hubName,
+      en: "Search organisations in " + hubName,
       de: "Suche Organisationen in " + hubName,
     },
     search_profiles_in_location: {
@@ -152,7 +152,7 @@ export default function getHubTexts({ hubName, hubAmbassador }) {
       de: `Du siehst Projekte, Ideen und Events zum Thema "${hubName}"`,
     },
     you_are_seeing_organizations_related_to: {
-      en: `You are seeing organizations working on the topic "${hubName}"`,
+      en: `You are seeing organisations working on the topic "${hubName}"`,
       de: `Du siehst Organisationen, die am Thema "${hubName}" arbeiten`,
     },
     you_are_seeing_members_related_to: {

--- a/frontend/public/texts/idea_texts.tsx
+++ b/frontend/public/texts/idea_texts.tsx
@@ -69,11 +69,11 @@ export default function getIdeaTexts({ idea, creator }) {
       de: "Persönliche Idee",
     },
     organizations_idea: {
-      en: "Organization's idea",
+      en: "Organisation's idea",
       de: "Idee einer Organisation",
     },
     choose_your_organization: {
-      en: "Choose your organization",
+      en: "Choose your organisation",
       de: "Wähle deine Organisation",
     },
     create_idea_add_metadata_motivation_text: {

--- a/frontend/public/texts/landing_page_texts.tsx
+++ b/frontend/public/texts/landing_page_texts.tsx
@@ -62,23 +62,23 @@ export default function getLandingPageTexts({ classes, isNarrowScreen }) {
       de: "Entdecke Klimaschutz-Projekte",
     },
     find_a_climate_action_organization_and_get_involved: {
-      en: "Find a climate action organization and get involved",
+      en: "Find a climate action organisation and get involved",
       de: "Finde eine Klimaschutzorganisation und bringe dich ein",
     },
     find_a_climate_action_organization_and_get_involved_text: {
       en: `Find nonprofits, associations, companies, institutes, NGOs, local governments and other
-      types of organizations taking climate action!`,
+      types of organisations taking climate action!`,
       de: `Finde Non-Profit-Organisationen, Verbände, Unternehmen, Institute, Nicht-Regierungs-Organisationen, lokale Regierungen und
       andere Arten von Organisationen, die sich für den Klimaschutz einseten!`,
     },
     find_a_climate_action_organization_and_get_involved_additional_text: {
-      en: `You can directly contact the organization's representative to exchange knowledge,
+      en: `You can directly contact the organisation's representative to exchange knowledge,
       find volunteering opportunities or job opportunites.`,
       de: `Du kannst direkt den Repräsentanten der Organisation kontaktieren um Wissen auszutauschen und
       zu lernen, wie du dich einbringen kannst.`,
     },
     explore_all_organizations: {
-      en: "Explore all organizations",
+      en: "Explore all organisations",
       de: "Entdecke alle Organisationen",
     },
     who_we_are: {

--- a/frontend/public/texts/notification_texts.ts
+++ b/frontend/public/texts/notification_texts.ts
@@ -55,7 +55,7 @@ export default function getNotificationTexts({ idea, project }) {
       de: `Das Project "${project?.name}" hat dich in's Team aufgenommen!`,
     },
     now_follows_your_organization: {
-      en: "now follows your organization",
+      en: "now follows your organisation",
       de: "folgt jetzt deiner Organisation",
     },
     just_shared_project: {

--- a/frontend/public/texts/organization_texts.tsx
+++ b/frontend/public/texts/organization_texts.tsx
@@ -7,11 +7,11 @@ export default function getOrganizationTexts({ organization, locale }) {
   const org_lang_name = getLanguageNames(organization?.language, locale);
   return {
     log_in_to_edit_organization: {
-      en: "You have to log in to edit an organization.",
+      en: "You have to log in to edit an organisation.",
       de: "Du musst dich einloggen, um eine Organisation zu bearbeiten.",
     },
     successfully_edited_organization: {
-      en: "You have successfully edited your organization.",
+      en: "You have successfully edited your organisation.",
       de: "Du hast deine Organisation erfolgreich bearbeitet.",
     },
     image_required_error: {
@@ -20,12 +20,12 @@ export default function getOrganizationTexts({ organization, locale }) {
     },
     type_required_errror: {
       en:
-        'Please choose at least one organization type by clicking the "Add Type" button under the avatar.',
+        'Please choose at least one organisation type by clicking the "Add Type" button under the avatar.',
       de:
         'Bitte wähle mindestens einen Organisationstyp aus, indem du auf den Button "Typ hinzufügen" klickst.',
     },
     name_required_error: {
-      en: "Please type your organization name under the avatar image",
+      en: "Please type your organisation name under the avatar image",
       de: "Bitte gib deinen Organisationsnamen unter dem Profilbild der Organisation an",
     },
     location_required_error: {
@@ -34,43 +34,43 @@ export default function getOrganizationTexts({ organization, locale }) {
     },
     how_to_summarize_organization: {
       en:
-        "Give a short summary or what your organization is doing. Below you'll have more space to describe it. (",
+        "Give a short summary or what your organisation is doing. Below you'll have more space to describe it. (",
       de:
         "Fasse deine Organisation und ihre Aktivitäten kurz zusammen. Unten hast du Platz, sie genauer zu beschreiben. (",
     },
     how_to_describe_organization: {
       en:
-        "Describe what your organization is doing, how you work and what impact you have on climate change. Please only use English!",
+        "Describe what your organisation is doing, how you work and what impact you have on climate change. Please only use English!",
       de:
         "Beschreibe, was deine Organisation macht, wie ihr arbeitet und welchen Einfluss ihr auf den Klimawandel habt.",
     },
     we_are_a_suborganization: {
-      en: "We are a sub-organization of a larger organization (e.g. local group)",
+      en: "We are a sub-organisation of a larger organisation (e.g. local group)",
       de: "Wir sind eine Sub-Organisation einer größeren Organisation (z.B. eine lokale Gruppe)",
     },
     parent_organization: {
-      en: "Parent organization",
+      en: "Parent organisation",
       de: "Übergeordnete Organisation",
     },
     edit_parent_organization_label: {
-      en: "Edit your parent organization",
+      en: "Edit your parent organisation",
       de: "Bearbeite deine übergeordnete Organisation",
     },
     edit_parent_organization_helper_text: {
-      en: "Type the name of your parent organization",
+      en: "Type the name of your parent organisation",
       de: "Gib den Namen der übergeordneten Organisation ein",
     },
     no_organization_found: {
-      en: "No organizations found. Try changing or removing your filter or search query.",
+      en: "No organisations found. Try changing or removing your filter or search query.",
       de:
         "Keine Organisation gefunden. Versuche, den Filter oder deine Suchanfrage zu ändern oder zu entfernen.",
     },
     to_manage_org_members: {
-      en: "to manage the members of this organization",
+      en: "to manage the members of this organisation",
       de: ", um die Mitglieder dieser Organisation zu verwalten",
     },
     you_are_not_a_member_of_this_organization: {
-      en: "You are not a member of this organization.",
+      en: "You are not a member of this organisation.",
       de: "Du bist kein Mitglied dieser Organisation.",
     },
     //Kommt drauf an wie "Join" übersetzt ist?
@@ -82,7 +82,7 @@ export default function getOrganizationTexts({ organization, locale }) {
             href={getLocalePrefix(locale) + "/organizations/" + organization?.url_slug}
             underline="hover"
           >
-            organization page
+            organisation page
           </Link>{" "}
           and click join to join it.
         </>
@@ -101,27 +101,27 @@ export default function getOrganizationTexts({ organization, locale }) {
       ),
     },
     no_permission_to_manage_members_of_this_org: {
-      en: "No Permission to Manage Members of this Organization",
+      en: "No Permission to Manage Members of this Organisation",
       de: "Keine Berechtigung, um Mitglieder dieser Organisation zu verwalten",
     },
     need_to_be_admin_to_manage_org_members: {
-      en: "You need to be an administrator of the organization to manage organization members.",
+      en: "You need to be an administrator of the organisation to manage organisation members.",
       de: "Du musst Admin dieser Organisation sein, um Mitglieder verwalten zu können.",
     },
     manage_organizations_members: {
-      en: "Manage organization's Members",
+      en: "Manage organisation's Members",
       de: "Verwalte die Mitglieder dieser Organisation",
     },
     you_have_to_log_in_to_manage_organization_members: {
-      en: "You have to log in to manage an organization's members.",
+      en: "You have to log in to manage an organisation's members.",
       de: "Du musst dich anmelden, um Mitglieder dieser Organisation verwalten zu können.",
     },
     successfully_updated_org_members: {
-      en: "You have successfully updated your organization members",
+      en: "You have successfully updated your organisation members",
       de: "Du hast die Mitglieder deiner Organisation erfolgreich aktualisiert",
     },
     there_must_be_exactly_one_creator_of_organization: {
-      en: "There must be exactly one Super Admin of an organization.",
+      en: "There must be exactly one Super Admin of an organisation.",
       de: "Es muss genau eine(n) Super Admin einer Organisation geben.",
     },
     manage_members_of_organization_name: {
@@ -129,7 +129,7 @@ export default function getOrganizationTexts({ organization, locale }) {
       de: `Verwalte die Mitglieder von ${organization?.name}`,
     },
     search_for_your_organizations_members: {
-      en: "Search for your organization's members",
+      en: "Search for your organisation's members",
       de: "Suche nach Mitglieder deiner Organisation",
     },
     type_name_of_next_team_member: {
@@ -137,15 +137,15 @@ export default function getOrganizationTexts({ organization, locale }) {
       de: "Gib den Namen deines Team Mitglieds an, den du als nächstes hinzufügen möchtest",
     },
     role_in_organization: {
-      en: "Role in organization",
+      en: "Role in organisation",
       de: "Funktion innerhalb der Organisation",
     },
     edit_organization: {
-      en: "Edit organization",
+      en: "Edit organisation",
       de: "Organisation bearbeiten",
     },
     to_see_this_organizations_full_information: {
-      en: "to see this organization's full information",
+      en: "to see this organisation's full information",
       de: ", um die vollständigen Informationen zu dieser Organisation zu sehen",
     },
     this_organizations_projects: {
@@ -157,11 +157,11 @@ export default function getOrganizationTexts({ organization, locale }) {
       de: `Mitglieder von ${organization?.name}`,
     },
     this_organization_has_not_listed_any_projects_yet: {
-      en: "This organization has not listed any projects yet!",
+      en: "This organisation has not listed any projects yet!",
       de: "Diese Organisation hat noch keine Projekte geteilt!",
     },
     none_of_the_members_of_this_organization_has_signed_up_yet: {
-      en: "None of the members of this organization has signed up yet!",
+      en: "None of the members of this organisation has signed up yet!",
       de: "Keins der Mitglieder dieser Organisation hat sich bisher registriert!",
     },
     organizations_logo: {
@@ -170,12 +170,12 @@ export default function getOrganizationTexts({ organization, locale }) {
     },
     you_have_not_selected_a_parent_organization_either_untick: {
       en:
-        "You have not selected a parent organization. Either untick the sub-organization field or choose/create your parent organization.",
+        "You have not selected a parent organisation. Either untick the sub-organisation field or choose/create your parent organisation.",
       de:
         "Du hast keine übergeordnete Organisation ausgewählt. Deaktiviere entweder das Feld für die Sub-Organisation oder erstelle eine dazugehörige übergeordnete Organisation.",
     },
     an_organization_with_this_name_already_exists: {
-      en: "An organization with this name already exists.",
+      en: "An organisation with this name already exists.",
       de: "Eine Organisation mit dem gleichen Namen existiert bereits.",
     },
     //Context: An organization with this name already exists. Click here to see it.
@@ -184,46 +184,46 @@ export default function getOrganizationTexts({ organization, locale }) {
       de: ", um mehr zu erfahren.",
     },
     you_have_successfully_created_an_organization_you_can_add_members: {
-      en: "You have successfully created an organization! Now you can add the rest of your team.",
+      en: "You have successfully created an organisation! Now you can add the rest of your team.",
       de:
         "Du hast erfolgreich eine Organisation erstellt! Jetzt kannst du den Rest deines Teams hinzufügen.",
     },
     to_create_an_organization: {
-      en: "to create an organization",
+      en: "to create an organisation",
       de: ", um eine Organisation zu erstellen",
     },
     create_an_organization: {
-      en: "Create an Organization",
+      en: "Create an Organisation",
       de: "Organisation erstellen",
     },
     organization_name: {
-      en: "Organization name",
+      en: "Organisation name",
       de: "Organisationsname",
     },
     we_are_a_sub_organization_of_a_larger_organization: {
-      en: "We are a sub-organization of a larger organization (e.g. local group)",
+      en: "We are a sub-organisation of a larger organisation (e.g. local group)",
       de: "Wir sind eine Sub-Organisation einer größeren Organisation (z.B. eine lokale Gruppe)",
     },
     parent_organization_name: {
-      en: "Parent organization name",
+      en: "Parent organisation name",
       de: "Name der übergeordneten Organisation",
     },
     search_for_your_parent_organization: {
-      en: "Search for your parent organization",
+      en: "Search for your parent organisation",
       de: "Suche nach deiner übergeordneten Organisation",
     },
     type_the_name_of_your_parent_organization: {
-      en: "Type the name of your parent organization.",
+      en: "Type the name of your parent organisation.",
       de: "Gib den Namen der übergeordneten Organisation an",
     },
     i_verify_that_i_am_an_authorized_representative_of_this_organization: {
-      en: `I verify that I am an authorized representative of this organization 
+      en: `I verify that I am an authorized representative of this organisation 
       and have the right to act on its behalf in the creation and management of this page.`,
       de: `Ich bestätige, dass ich ein(e) autorisierte*r Vertreter*in dieser Organisation 
       bin und das Recht habe, in deren Namen bei der Erstellung und Verwaltung dieser Seite zu handeln.`,
     },
     almost_done_here_you_can_customize_your_organization_page_and_add_details: {
-      en: "Almost done! Here you can customize your organization page and add details",
+      en: "Almost done! Here you can customize your organisation page and add details",
       de: "Fast geschafft! Hier kannst du deine Organisationsseite anpassen und Details hinzufügen",
     },
     translate_organization_intro: {
@@ -268,16 +268,16 @@ export default function getOrganizationTexts({ organization, locale }) {
       de: "Menschen",
     },
     climate_protection_organization: {
-      en: "Interesting climate organization: ",
+      en: "Interesting climate organisation: ",
       de: "Interessante Klimaschutzorganisation: ",
     },
     tell_others_about_this_organization: {
-      en: "Tell others about this organization!",
+      en: "Tell others about this organisation!",
       de: "Erzähle anderen von dieser Organisation!",
     },
     share_organization_email_body: {
       en: `Hey,
-      I found this awesome climate protection organization: "${organization?.name}". 
+      I found this awesome climate protection organisation: "${organization?.name}". 
       You should check it out here: `,
       de: `Hey,
       Ich habe gerade diese spannende Klimaschutzorganisation gefunden: "${organization?.name}". 
@@ -289,7 +289,7 @@ export default function getOrganizationTexts({ organization, locale }) {
     },
 
     please_log_in_to_follow_an_organization: {
-      en: "Please log in to follow an organization.",
+      en: "Please log in to follow an organisation.",
       de: "Bitte logge dich ein, um einer Organisation zu folgen.",
     },
     do_you_really_want_to_unfollow: {
@@ -299,7 +299,7 @@ export default function getOrganizationTexts({ organization, locale }) {
     are_you_sure_that_you_want_to_unfollow_this_organization: {
       en: (
         <>
-          Are you sure that you want to unfollow this organization?
+          Are you sure that you want to unfollow this organisation?
           <br />
           You {"won't"} receive updates about it anymore
         </>
@@ -329,7 +329,7 @@ export default function getOrganizationTexts({ organization, locale }) {
       de: "Du folgst",
     },
     to_see_this_organizations_followers: {
-      en: " to see this organization's followers",
+      en: " to see this organisation's followers",
       de: ", um die Follower der Organisation zu sehen",
     },
     //Kontext: Followers of Organization
@@ -342,7 +342,7 @@ export default function getOrganizationTexts({ organization, locale }) {
       de: "Folgt seit",
     },
     this_organzation_does_not_have_any_followers_yet: {
-      en: "This organization does not have any followers yet.",
+      en: "This organisation does not have any followers yet.",
       de: "Diese Organisation hat noch keine Follower.",
     },
     follow_for_updates: {
@@ -359,7 +359,7 @@ export default function getOrganizationTexts({ organization, locale }) {
         'z.B. "Offenes Treffen jeden Mittwoch um 18 Uhr im Café Margareta. Interessierte sind immer willkommen!" (',
     },
     add_up_to_two_types: {
-      en: "Organization Type (Up to 2)",
+      en: "Organisation Type (Up to 2)",
       de: "Organisationsart (Bis zu 2)",
     },
     organization_is_active_in_these_sectors: {
@@ -367,21 +367,21 @@ export default function getOrganizationTexts({ organization, locale }) {
       de: `${organization?.name} ist in diesen Bereichen aktiv`,
     },
     add_sectors_in_which_your_organization_is_active: {
-      en: "Add topics in which your organization is active",
+      en: "Add topics in which your organisation is active",
       de: "Füge Themenbereiche hinzu, in denen deine Organisation aktiv ist",
     },
     someone_has_already_created_organization: {
-      en: "Someone has already created the organization ",
+      en: "Someone has already created the organisation ",
       de: "Jemand erstellte bereits die Organisation ",
     },
     please_join_org_or_use_diff_name_if_problems_contact: {
       en:
-        ". Please join the organization or use a different name. If you're having problems please contact ",
+        ". Please join the organisation or use a different name. If you're having problems please contact ",
       de:
         ". Bitte trete der Organisation bei oder verwende einen anderen Namen. Falls du Probleme hast, wende dich bitte an ",
     },
     organization_language: {
-      en: "Your organization's language is set to",
+      en: "Your organisation's language is set to",
       de: "Die Sprache Ihrer Organisation ist",
     },
     edit_in_another_language: {
@@ -393,7 +393,7 @@ export default function getOrganizationTexts({ organization, locale }) {
       de: "Bitte verwenden Sie die Schaltfläche 'Übersetzungen überprüfen'",
     },
     editing_org_in_wrong_language: {
-      en: `Because you shared your organization in ${org_lang_name}, you can only edit the text in ${org_lang_name} here. If you want to change the text in other languages click on \"Check Translations\" below.`,
+      en: `Because you shared your organisation in ${org_lang_name}, you can only edit the text in ${org_lang_name} here. If you want to change the text in other languages click on \"Check Translations\" below.`,
       de: `Weil Du Deine Organisation auf ${org_lang_name} geteilt hast, kannst du hier den Text nur auf ${org_lang_name} bearbeiten. Wenn Du die anderen Sprachen bearbeiten möchtest, klicke auf \"Übersetzungen überprüfen\" weiter unten.`,
     },
   };

--- a/frontend/public/texts/profile_texts.tsx
+++ b/frontend/public/texts/profile_texts.tsx
@@ -48,11 +48,11 @@ export default function getProfileTexts({ profile, hubName, locale }) {
       de: "Rolle im Projekt",
     },
     role_in_organization: {
-      en: "Role in organization",
+      en: "Role in organisation",
       de: "Rolle in der Organisation",
     },
     pick_or_describe_role_in_organization: {
-      en: "Pick or describe what the user's role in the organization is.",
+      en: "Pick or describe what the user's role in the organisation is.",
       de: "Wähle oder beschreibe, welche Rolle der/die Benutzer*in in der Organisation hat.",
     },
     pick_or_describe_role_in_project: {
@@ -68,7 +68,7 @@ export default function getProfileTexts({ profile, hubName, locale }) {
       de: "Beigetragene Wochenstunden",
     },
     pick_how_many_hours_user_contributes_to_org: {
-      en: "Pick how many hours per week the user contributes to this organization on average.",
+      en: "Pick how many hours per week the user contributes to this organisation on average.",
       de:
         "Wähle aus, wie viele Stunden pro Woche der/die Benutzer*in im Durchschnitt zu dieser Organisation beiträgt.",
     },
@@ -82,7 +82,7 @@ export default function getProfileTexts({ profile, hubName, locale }) {
       de: "Willst du wirklich deine Super-Admin-Rechte verlieren?",
     },
     there_is_always_one_org_member_with_creator_privileges: {
-      en: "There is always exactly one organization member with Super Admin privileges.",
+      en: "There is always exactly one organisation member with Super Admin privileges.",
       de: "Es gibt immer genau ein Organisationsmitglied mit Super-Admin-Rechten.",
     },
     there_is_always_one_project_member_with_creator_privileges: {
@@ -102,7 +102,7 @@ export default function getProfileTexts({ profile, hubName, locale }) {
       de: "Willst du das wirklich tun?",
     },
     is_a_suborganization_of: {
-      en: "is a suborganization of",
+      en: "is a suborganisation of",
       de: "ist eine Unterorganisation von",
     },
     persons_profile: {
@@ -139,16 +139,16 @@ export default function getProfileTexts({ profile, hubName, locale }) {
       de: "ist bisher bei keiner Klimaschutzidee dabei!",
     },
     your_organizations: {
-      en: "Your organizations",
+      en: "Your organisations",
       de: "Deine Organisationen",
     },
     this_users_organizations: {
-      en: `${profile?.first_name}'s Organizations`,
+      en: `${profile?.first_name}'s Organisations`,
       de: `Organisationen von ${profile?.first_name}`,
     },
     /*context: You are...*/
     not_involved_in_any_organizations_yet: {
-      en: "not involved in any organizations yet!",
+      en: "not involved in any organisations yet!",
       de: "noch in keiner Organisation engagiert!",
     },
     sign_up_message: {

--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -311,7 +311,7 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       de: "Hilfreiche Fähigkeiten, um mitzuwirken",
     },
     connections_to_these_organizations_could_help_the_project: {
-      en: "Connections to these organizations could help the project",
+      en: "Connections to these organisations could help the project",
       de: "Connections zu diesen Organisationen könnten dem Projekt helfen",
     },
     to_see_this_projects_team_members: {
@@ -351,15 +351,15 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       de: "Füge Fähigkeiten hinzu, die Mitstreiter:innen möglichst haben sollten",
     },
     add_connections_that_would_be_beneficial_for_collaborators_to_have: {
-      en: "Connections to which organizations would be helpful for the project?",
+      en: "Connections to which organisations would be helpful for the project?",
       de: "Connections zu welchen Organisationen wären für das Projekt hilfreich?",
     },
     add_connections_that_would_be_beneficial_for_collaborators_to_have_idea: {
-      en: "Connections to which organizations would be helpful for the project?",
+      en: "Connections to which organisations would be helpful for the project?",
       de: "Connections zu welchen Organisationen wären für die Umsetzung der Idee hilfreich?",
     },
     add_connections_that_would_be_beneficial_for_collaborators_to_have_event: {
-      en: "Connections to these organizations would be helpful for organizing the event?",
+      en: "Connections to these organisations would be helpful for organizing the event?",
       de: "Connections zu welchen Organisationen wären für die Event-Organisation hilfreich?",
     },
     to_share_a_project: {
@@ -432,7 +432,7 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       de: "Persönliches Projekt",
     },
     organizations_project: {
-      en: "Organization's project",
+      en: "Organisation's project",
       de: "Projekt einer Organisation",
     },
     created_by: {
@@ -650,25 +650,25 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
     },
     add_connections_helptext: {
       en:
-        "Add connections that would be helpful for collaborators to have. Specifically this could be connections to organizations that could help accelerate your project.",
+        "Add connections that would be helpful for collaborators to have. Specifically this could be connections to organisations that could help accelerate your project.",
       de:
         "Füge Connections hinzu, die für Unterstützende hilfreich sein könnten. Konkret könnten dies Connections zu Organisationen sein, die dein Projekt beschleunigen könnten.",
     },
     search_for_collaborating_organizations: {
-      en: "Search for collaborating organizations",
+      en: "Search for collaborating organisations",
       de: "Suche nach Organisationen, mit denen du/ihr zusammenarbeitet",
     },
     type_the_name_of_the_collaborating_organization_you_want_to_add_next: {
-      en: "Type the name of the collaborating organization you want to add next.",
+      en: "Type the name of the collaborating organisation you want to add next.",
       de:
         "Gib den Namen der zusammenarbeitenden Organisation ein, die du als nächstes hinzufügen möchtest.",
     },
     use_the_search_bar_to_add_collaborating_organizations: {
-      en: "Use the search bar to add collaborating organizations.",
+      en: "Use the search bar to add collaborating organisations.",
       de: "Verwende die Suchleiste, um zusammenarbeitende Organisationen hinzuzufügen.",
     },
     responsible_organization: {
-      en: "Responsible Organization",
+      en: "Responsible Organisation",
       de: "Verantwortliche Organisation",
     },
     responsible_person_project: {
@@ -680,7 +680,7 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       de: "Ideenersteller*in",
     },
     responsible_person_org: {
-      en: "Reponsible for organization",
+      en: "Reponsible for organisation",
       de: "Verantwortliche*r",
     },
     responsible_person_generic: {
@@ -688,7 +688,7 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       de: "Verantwortliche*r",
     },
     collaborating_organizations: {
-      en: "Collaborating Organizations",
+      en: "Collaborating Organisations",
       de: "Zusammenarbeitende Organisation",
     },
     there_has_been_an_error_when_trying_to_publish_your_project: {
@@ -797,7 +797,7 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
     if_your_organization_does_not_exist_yet_click_here: {
       en: (
         <>
-          If your organization does not exist yet{" "}
+          If your organisation does not exist yet{" "}
           <Link
             href={`${getLocalePrefix(locale)}/createorganization${
               hubName ? `?hub=${hubName}` : ""
@@ -936,7 +936,7 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       de: `Kontaktiere ${creator?.first_name}, um über das Projekt zu reden.`,
     },
     contact_creator_to_know_more_about_organization: {
-      en: `Contact ${creator?.first_name} if you want to chat about this organization.`,
+      en: `Contact ${creator?.first_name} if you want to chat about this organisation.`,
       de: `Kontaktiere ${creator?.first_name}, um über diese Organisation zu reden.`,
     },
     contact_creator_to_know_more_about_idea: {

--- a/frontend/public/texts/settings.json
+++ b/frontend/public/texts/settings.json
@@ -196,11 +196,11 @@
     "de": "Neues Passwort bestätigen"
   },
   "email_on_new_org_follower_text": {
-    "en": "Get notified when somebody follows an organization you're part of",
+    "en": "Get notified when somebody follows an organisation you're part of",
     "de": "Ich möchte benachrichtigt werden, wenn jemand einer Organisation folgt, von der ich Teil bin."
   },
   "email_on_new_org_project_text": {
-    "en": "Get notified when an organization you follow posts an update",
+    "en": "Get notified when an organisation you follow posts an update",
     "de": "Ich möchte benachrichtigt werden, wenn eine Organisation, der ich folge, eine Update postet"
   },
   "you_can_now_log_in": {


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why
Changes for #1643 
<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated text strings across all user interfaces to standardize terminology and maintain consistent presentation throughout the application. Changes apply to UI labels, notifications, error messages, form fields, helper text, and prompts across dashboards, profiles, projects, settings, and organization management areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->