### PR TITLE
Fixed minor logic bug regarding filtering

### DIFF
--- a/backend/climateconnect_api/views/user_views.py
+++ b/backend/climateconnect_api/views/user_views.py
@@ -280,7 +280,10 @@ class ListMemberProfilesView(ListAPIView):
                 .order_by("distance")
             )
 
-        if "country" and "city" in self.request.query_params:
+        if (
+            "country" in self.request.query_params
+            and "city" in self.request.query_params
+        ):
             location_ids = Location.objects.filter(
                 country=self.request.query_params.get("country"),
                 city=self.request.query_params.get("city"),

--- a/backend/organization/views/organization_views.py
+++ b/backend/organization/views/organization_views.py
@@ -244,7 +244,10 @@ class ListOrganizationsAPIView(ListAPIView):
                 .order_by("distance")
             )
 
-        if "country" and "city" in self.request.query_params:
+        if (
+            "country" in self.request.query_params
+            and "city" in self.request.query_params
+        ):
             organizations = organizations.filter(
                 location__country=self.request.query_params.get("country"),
                 location__city=self.request.query_params.get("city"),

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -331,7 +331,10 @@ class ListProjectsView(ListAPIView):
                 .order_by("distance")
             )
 
-        if "country" and "city" in self.request.query_params:
+        if (
+            "country" in self.request.query_params
+            and "city" in self.request.query_params
+        ):
             location_ids = Location.objects.filter(
                 country=self.request.query_params.get("country"),
                 city=self.request.query_params.get("city"),


### PR DESCRIPTION
## Checked the following
- [x] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme
- [x] Run within `/frontend`: `yarn format && yarn lint`
- [x] Run within `/backend`: `make format && make lint`

## What and Why
This pull request fixes a logic error in filtering by both "country" and "city" in three different view files. Previously, the condition would always evaluate as true, but now it correctly checks that both "country" and "city" are present in the query parameters before applying the filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved location filtering issues across member profiles, organizations, and projects by ensuring both country and city parameters are required before applying location-based filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->