### PR TITLE
Change the email feedback gets sent to to feedback@climateconnect.earth

### DIFF
--- a/backend/climateconnect_api/utility/email_setup.py
+++ b/backend/climateconnect_api/utility/email_setup.py
@@ -223,7 +223,10 @@ def send_feedback_email(email, message, send_response):
                     "Name": "Climate Connect",
                 },
                 "To": [
-                    {"Email": "contact@climateconnect.earth", "Name": "Climate Connect"}
+                    {
+                        "Email": "feedback@climateconnect.earth",
+                        "Name": "Climate Connect",
+                    }
                 ],
                 "TemplateID": int(settings.FEEDBACK_TEMPLATE_ID),
                 "TemplateLanguage": True,


### PR DESCRIPTION
Changed the email which receives notifications about new feedback submissions. This was done in order so team members can choose better which emails they want to receive. Before you had to receive all general emails we receive on our contact email if you wanted to get notifications about feedback submissions.

In order to make the feedback button even more helpful, this should be followed up with #1659 at some point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the feedback email routing destination for improved email handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->