### PR TITLE
Ux change the styling of the call to action of a donation goal #1668

### DIFF
--- a/frontend/src/components/staticpages/donate/DonationCampaignInformation.tsx
+++ b/frontend/src/components/staticpages/donate/DonationCampaignInformation.tsx
@@ -1,26 +1,13 @@
-import {
-  Button,
-  Collapse,
-  Container,
-  IconButton,
-  Link,
-  Theme,
-  Typography,
-  useMediaQuery,
-} from "@mui/material";
+import { Button, IconButton, Typography } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import CloseIcon from "@mui/icons-material/Close";
-import ExpandLessIcon from "@mui/icons-material/ExpandLess";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import React, { useContext } from "react";
 import Cookies from "universal-cookie";
-import { getLocalePrefix } from "../../../../public/lib/apiOperations";
 import { getCookieProps } from "../../../../public/lib/cookieOperations";
 import getTexts from "../../../../public/texts/texts";
 import theme from "../../../themes/theme";
 import UserContext from "../../context/UserContext";
 import DonationGoal from "./DonationGoal";
-import SendIcon from "@mui/icons-material/Send";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -47,9 +34,6 @@ const useStyles = makeStyles((theme) => ({
       fontSize: 15,
     },
   },
-  linkText: {
-    fontSize: 20,
-  },
   showMoreButton: {
     color: "white",
     width: "100%",
@@ -65,9 +49,6 @@ const useStyles = makeStyles((theme) => ({
   },
   donationGoal: {
     marginBottom: theme.spacing(3),
-  },
-  link: {
-    color: "white",
   },
   textBlock: {
     marginBottom: theme.spacing(1),


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme
- [x] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Implementing changes for #1668. Only replacing a link element with a button link. No functional changes. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the donation call-to-action button with enhanced styling, including improved colors, typography, and hover behavior for a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->