### PR TITLE
Update backend implementation for fetching translations

### DIFF
--- a/backend/climateconnect_api/utility/translation.py
+++ b/backend/climateconnect_api/utility/translation.py
@@ -63,8 +63,9 @@ def translate(text, target_lang):
     if target_lang == "de":
         payload["formality"] = "less"
 
-    url = "https://api.deepl.com/v2/translate?auth_key=" + settings.DEEPL_API_KEY
-    translation = requests.post(url, payload)
+    url = "https://api.deepl.com/v2/translate"
+    headers = {"Authorization": f"DeepL-Auth-Key {settings.DEEPL_API_KEY}"}
+    translation = requests.post(url, data=payload, headers=headers)
     return json.loads(translation.content)["translations"][0]
 
 


### PR DESCRIPTION
## Checked the following
- [X] Run within `/backend`: `make format && make lint`

## What and Why

Implementation for  #1638
No functional changes, just maintenance. Verified that API calls to DeepL are working with this change. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated translation service authentication mechanism to use standard header-based credentials instead of URL parameters, improving security and API compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->