### PR TITLE
Optimize image handling by compressing on submit

### DIFF
--- a/frontend/public/lib/imageOperations.ts
+++ b/frontend/public/lib/imageOperations.ts
@@ -76,7 +76,7 @@ export function whitenTransparentPixels(canvas) {
   ctx.putImageData(imgd, 0, 0);
 }
 
-export async function getCompressedJPG(file, maxSizeMB): Promise<string> {
+export async function convertToJPGWithAspectRatio(file): Promise<string> {
   const canvas = document.createElement("canvas");
   const image = new Image();
   return new Promise(function (resolve, reject) {

--- a/frontend/src/components/account/EditAccountPage.tsx
+++ b/frontend/src/components/account/EditAccountPage.tsx
@@ -17,7 +17,7 @@ import Alert from "@mui/material/Alert";
 import React, { useContext, useRef, useState, useEffect } from "react";
 import { getLocalePrefix } from "../../../public/lib/apiOperations";
 import {
-  getCompressedJPG,
+  convertToJPGWithAspectRatio,
   getImageDialogHeight,
   whitenTransparentPixels,
 } from "../../../public/lib/imageOperations";
@@ -608,7 +608,7 @@ export default function EditAccountPage({
     try {
       setIsLoading(true);
       handleDialogClickOpen("backgroundDialog");
-      const compressedImage = await getCompressedJPG(file, 1);
+      const compressedImage = await convertToJPGWithAspectRatio(file);
       setTempImages(() => {
         return {
           ...tempImages,

--- a/frontend/src/components/account/UserAvatar.tsx
+++ b/frontend/src/components/account/UserAvatar.tsx
@@ -4,7 +4,7 @@ import makeStyles from "@mui/styles/makeStyles";
 import AddAPhotoIcon from "@mui/icons-material/AddAPhoto";
 import CloseIcon from "@mui/icons-material/Close";
 import {
-  getCompressedJPG,
+  convertToJPGWithAspectRatio,
   getImageDialogHeight,
   getResizedImage,
   whitenTransparentPixels,
@@ -87,7 +87,7 @@ export function UserAvatar(props: UserAvatarProps): JSX.Element {
       try {
         setIsLoading(true);
         setDialogStates({ ...dialogStates, uploadOpen: true });
-        const compressedImage = await getCompressedJPG(file, 0.5);
+        const compressedImage = await convertToJPGWithAspectRatio(file);
         setTempImage(() => compressedImage);
       } catch (error) {
         console.error(error);

--- a/frontend/src/components/editProject/EditProjectOverview.tsx
+++ b/frontend/src/components/editProject/EditProjectOverview.tsx
@@ -6,7 +6,7 @@ import React, { useContext } from "react";
 import SelectField from "../general/SelectField";
 // Relative imports
 import {
-  getCompressedJPG,
+  convertToJPGWithAspectRatio,
   getImageDialogHeight,
   getImageUrl,
   getResizedImage,
@@ -482,7 +482,7 @@ const InputImage = ({ project, screenSize, handleChangeImage, texts }) => {
     try {
       setIsImgLoading(true);
       setOpen(true);
-      const image = await getCompressedJPG(file, 0.5);
+      const image = await convertToJPGWithAspectRatio(file);
       setTempImage(image);
     } catch (error) {
       console.log(error);

--- a/frontend/src/components/ideas/UploadImageField.tsx
+++ b/frontend/src/components/ideas/UploadImageField.tsx
@@ -2,7 +2,7 @@ import { Button, Theme, useMediaQuery } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import React, { useContext, useRef, useState } from "react";
 import {
-  getCompressedJPG,
+  convertToJPGWithAspectRatio,
   getImageDialogHeight,
   getResizedImage,
   whitenTransparentPixels,
@@ -89,7 +89,7 @@ export default function UploadImageField({ image, className, updateImages }) {
     try {
       setOpen(true);
       setUploadImageDialogLoading(true);
-      const compressedImage = (await getCompressedJPG(file, 1)) as string;
+      const compressedImage = (await convertToJPGWithAspectRatio(file)) as string;
       setTempImage(compressedImage);
       setUploadImageDialogLoading(false);
     } catch (error) {

--- a/frontend/src/components/shareProject/AddPhotoSection.tsx
+++ b/frontend/src/components/shareProject/AddPhotoSection.tsx
@@ -7,7 +7,7 @@ import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
 import UploadImageDialog from "../dialogs/UploadImageDialog";
 import {
-  getCompressedJPG,
+  convertToJPGWithAspectRatio,
   getResizedImage,
   whitenTransparentPixels,
 } from "./../../../public/lib/imageOperations";
@@ -81,7 +81,7 @@ export default function AddPhotoSection({
     try {
       setIsLoading(true);
       handleDialogClickOpen("avatarDialog");
-      const image = await getCompressedJPG(file, 0.5);
+      const image = await convertToJPGWithAspectRatio(file);
       setTempImage(image);
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
## Description
This PR addresse issue [1618](https://github.com/climateconnect/climateconnect/issues/1618)
(Large image files cause a significant delay when a user selects an image.)
## Solution
To resolve this issue, I've moved the image compression process from the file selection event to the form submission handler.

## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated image conversion pipeline to produce consistent JPEGs with enforced aspect ratio and improved compression for web-friendly uploads.
* **Bug Fixes / Reliability**
  * Improved error handling and logging around image processing to reduce upload failures and handle problematic files more gracefully.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->