### PR TITLE
Link to Buergerenergie Emmendingen page instead of ClimateMatch on Emmendingen Hub

### DIFF
--- a/frontend/public/texts/navigation_texts.json
+++ b/frontend/public/texts/navigation_texts.json
@@ -107,6 +107,10 @@
     "en": "Projects worldwide",
     "de": "Projekte weltweit"
   },
+  "emmerdingen_buergerenergie": {
+    "en": "Citizen energy Emmendingen",
+    "de": "Bürgerenergie Emmendingen"
+  },
   "PRIO1_logo": {
     "en": "PRIO1 logo",
     "de": "PRIO1 Logo"

--- a/frontend/src/components/hub/HubTabsNavigation.tsx
+++ b/frontend/src/components/hub/HubTabsNavigation.tsx
@@ -124,6 +124,8 @@ export default function HubTabsNavigation({
   }
   const hubTabLink = getCustomHubData({ hubUrl, texts })?.hubTabLinkNarrowScreen;
 
+  const isEmmendingenHub = hubUrl === "em";
+
   return (
     <div className={`${className} ${classes.root}`}>
       <Container maxWidth="lg" className={classes.container}>
@@ -156,8 +158,16 @@ export default function HubTabsNavigation({
                 })}
             </Tabs>
           )}
-
-          {!isCustomHub && (
+          {isEmmendingenHub && (
+            <Link
+              className={classes.climateMatchLink}
+              href="https://climatehub.earth/burgerenergie-em"
+              underline="hover"
+            >
+              {texts.emmerdingen_buergerenergie}
+            </Link>
+          )}
+          {!isCustomHub && !isEmmendingenHub && (
             <div className={classes.climateMatchLinkContainer}>
               <Link
                 className={classes.climateMatchLink}


### PR DESCRIPTION
## Checked the following
- [X] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [X] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why
#1696 

