### PR TITLE
Refactor location admin page

### DIFF
--- a/backend/location/admin.py
+++ b/backend/location/admin.py
@@ -1,17 +1,34 @@
 from django.contrib import admin
+from django.utils.html import format_html
 
 from location.models import Location, LocationTranslation
 
 # Register your models here.
 
+# IMPORTANT: Coordinate Storage Format
+# =====================================
+# The database stores coordinates with X and Y swapped from PostGIS standard:
+#   - X coordinate = Latitude (e.g., 52.376666)
+#   - Y coordinate = Longitude (e.g., 9.086021)
+#
+# This is created by location/utility.py functions:
+#   - get_location() line 92-93: Point(coords[1], coords[0]) creates (lat, lon)
+#   - get_location() line 93-95: Point(lat, lon) for LineString
+#   - get_polygon_with_switched_coordinates() line 142-153: swaps polygon coords
+#   - get_multipolygon_from_geojson() line 127-140: uses above for multipolygons
+#
+# Therefore, we do not show any map or let you edit the coordinates.
+# Instead, you can follow a link to OSM.
+
 
 class LocationAdmin(admin.ModelAdmin):
+
     search_fields = (
         "name",
         "osm_id",
     )
 
-    list_filter = ("osm_type",)
+    list_filter = ("osm_type", "is_stub")
 
     list_display = (
         "name",
@@ -21,6 +38,112 @@ class LocationAdmin(admin.ModelAdmin):
         "osm_class_type",
         "place_id",
     )
+
+    readonly_fields = ("nominatim_link", "coordinate_info")
+
+    # Organize fields into logical sections
+    fieldsets = (
+        (
+            "Location Information",
+            {
+                "fields": (
+                    "name",
+                    "place_name",
+                    "display_name",
+                    "exact_address",
+                )
+            },
+        ),
+        (
+            "Geographic Details",
+            {
+                "fields": (
+                    "city",
+                    "state",
+                    "country",
+                )
+            },
+        ),
+        (
+            "OpenStreetMap Data",
+            {
+                "fields": (
+                    "coordinate_info",
+                    "nominatim_link",
+                    "osm_id",
+                    "osm_type",
+                    "osm_class",
+                    "osm_class_type",
+                    "place_id",
+                ),
+            },
+        ),
+        (
+            "Status",
+            {
+                "fields": (
+                    "is_stub",
+                    "is_formatted",
+                )
+            },
+        ),
+    )
+
+    def coordinate_info(self, obj):
+        """
+        Display coordinate information in a readable format.
+        NOTE: Database stores as (lat, lon) but we display as (lon, lat) for accuracy.
+        """
+        info_parts = []
+
+        if obj.centre_point:
+            # Database has X=lat, Y=lon (swapped), so we swap them back for display
+            lon = obj.centre_point.y  # Database Y is actually longitude
+            lat = obj.centre_point.x  # Database X is actually latitude
+            info_parts.append(
+                f"<strong>Centre Point:</strong> Lat {lat:.6f}°, Lon {lon:.6f}° "
+                f"(SRID: {obj.centre_point.srid})<br>"
+                f'<small style="color: #666;">Database stores as ({lat:.6f}, {lon:.6f}) but '
+                f"actual coordinates are ({lon:.6f}, {lat:.6f})</small>"
+            )
+
+        if obj.multi_polygon:
+            centroid = obj.multi_polygon.centroid
+            # Database has X=lat, Y=lon (swapped), so we swap them back for display
+            lon = centroid.y  # Database Y is actually longitude
+            lat = centroid.x  # Database X is actually latitude
+            num_polygons = len(obj.multi_polygon)
+            info_parts.append(
+                f"<strong>Polygon Centroid:</strong> Lat {lat:.6f}°, Lon {lon:.6f}° "
+                f"({num_polygons} polygon{'s' if num_polygons > 1 else ''}, SRID: {obj.multi_polygon.srid})<br>"
+                f'<small style="color: #666;">Database stores as ({lat:.6f}, {lon:.6f}) but '
+                f"actual coordinates are ({lon:.6f}, {lat:.6f})</small>"
+            )
+
+        if not info_parts:
+            return format_html(
+                '<span style="color: #999;">No geographic coordinates set</span>'
+            )
+
+        return format_html("<br>".join(info_parts))
+
+    coordinate_info.short_description = "Coordinate Details"
+
+    def nominatim_link(self, obj):
+        """
+        Display a clickable link to the Nominatim details page for this location.
+        """
+        if obj.osm_id:
+            osm_type = obj.osm_type or ""
+            osm_class = obj.osm_class or ""
+            url = f"https://nominatim.openstreetmap.org/ui/details.html?osmtype={osm_type}&osmid={obj.osm_id}&class={osm_class}"
+            return format_html(
+                '<a href="{}" target="_blank" rel="noopener noreferrer">View on Nominatim</a>',
+                url,
+            )
+        return "N/A (missing OSM ID)"
+
+    nominatim_link.short_description = "Nominatim Link"
 
 
 admin.site.register(Location, LocationAdmin)

--- a/backend/location/location_views.py
+++ b/backend/location/location_views.py
@@ -34,7 +34,8 @@ class GetLocationView(APIView):
                 params = "&format=json&addressdetails=1&polygon_geojson=1&accept-language=en-US,en;q=0.9&polygon_threshold=0.001"
                 url = url_root + osm_id_param + params
                 headers = {
-                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+                }
                 response = requests.get(url, headers=headers)
                 location_object = json.loads(response.text)[0]
                 location = get_location(format_location(location_object, False))

--- a/backend/location/tests/test_utility.py
+++ b/backend/location/tests/test_utility.py
@@ -234,10 +234,7 @@ class TestGetLocation(TestCase):
     @override_settings(ENABLE_LEGACY_LOCATION_FORMAT="True")
     def test_legacy_location_format(self):
         """Test that legacy format still works."""
-        legacy_location = {
-            "city": "Berlin",
-            "country": "Germany"
-        }
+        legacy_location = {"city": "Berlin", "country": "Germany"}
         location = get_location(legacy_location)
 
         self.assertEqual(location.city, "Berlin")

--- a/backend/location/utility.py
+++ b/backend/location/utility.py
@@ -317,7 +317,8 @@ def get_location_with_range(query_params):
         params = "&format=json&addressdetails=1&polygon_geojson=1&accept-language=en-US,en;q=0.9&polygon_threshold=0.001"
         url = url_root + osm_id_param + params
         headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+        }
         response = requests.get(url, headers=headers)
         if response.status_code == 200:
             location_object = json.loads(response.text)[0]


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [X] Run within `/backend`: `make format && make lint`

## What and Why

Just a small change to make the location admin in Django more user friendly. 
Tried to fix the map display. Was able to show the correct map but wasn't able to make saving work, so eventually decided to remove the map completely. Instead, there is now an OSM link, so one can see the location with map and original data.
