### PR TITLE
Fix for type error destroy is not a function

### DIFF
--- a/frontend/src/components/project/ProjectTeamContent.tsx
+++ b/frontend/src/components/project/ProjectTeamContent.tsx
@@ -66,8 +66,16 @@ export default function TeamContent({ project, handleReadNotifications, hubUrl }
   const texts = getTexts({ page: "project", locale: locale });
   const classes = useStyles();
 
-  useEffect(async () => {
-    await handleReadNotifications(NOTIFICATION_TYPES.indexOf("project_join_request_approved"));
+  useEffect(() => {
+    const readNotifications = async () => {
+      try {
+        await handleReadNotifications(NOTIFICATION_TYPES.indexOf("project_join_request_approved"));
+      } catch (error) {
+        console.error("Error reading notifications:", error);
+      }
+    };
+    void readNotifications();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Not logged in


### PR DESCRIPTION
## Checked the following
- [X] Pages affected by this change work on mobile
- [X] Pages affected by this change work when logged out
- [X] Pages affected by this change work when logged in
- [X] Pages affected by this change work with custom theme and default theme
- [X] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why
Fix for #1718 
