### PR TITLE
Replace truncate component with light weight CSS solution

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,7 +66,6 @@
     "react-share": "^4.4.0",
     "react-text-loop": "^2.3.0",
     "react-timeago": "^8.3.0",
-    "react-truncate": "^2.4.0",
     "react-youtube": "^7.13.0",
     "typescript": "^4.9.5",
     "universal-cookie": "^4.0.3",

--- a/frontend/src/components/organization/OrganizationPreviewHeader.tsx
+++ b/frontend/src/components/organization/OrganizationPreviewHeader.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Avatar, Box, Chip, Typography } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import { getImageUrl } from "../../../public/lib/imageOperations";
-import Truncate from "react-truncate";
 
 const useStyles = makeStyles((theme) => {
   return {
@@ -13,6 +12,10 @@ const useStyles = makeStyles((theme) => {
       wordBreak: "break-word",
       lineHeight: 1.3,
       color: theme.palette.text.primary,
+      display: "-webkit-box",
+      WebkitLineClamp: 2,
+      // @ts-ignore - WebkitBoxOrient is deprecated but still required for line-clamp to work
+      WebkitBoxOrient: "vertical",
     },
     headerWrapper: {
       justifyContent: "center",
@@ -40,7 +43,6 @@ const useStyles = makeStyles((theme) => {
 
 export default function OrganizationPreviewHeader({ organization }) {
   const classes = useStyles();
-  const TruncateComponent = Truncate as any;
 
   return (
     <div>
@@ -66,7 +68,7 @@ export default function OrganizationPreviewHeader({ organization }) {
       )}
       <Box className={classes.headerWrapper}>
         <Typography variant="h6" component="h2" className={classes.header}>
-          <TruncateComponent lines={2}>{organization.name}</TruncateComponent>
+          {organization.name}
         </Typography>
       </Box>
     </div>

--- a/frontend/src/components/project/ProjectPreview.tsx
+++ b/frontend/src/components/project/ProjectPreview.tsx
@@ -1,7 +1,6 @@
 import { Card, CardContent, CardMedia, Link, Typography } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import React, { useContext } from "react";
-import Truncate from "react-truncate";
 import { getLocalePrefix } from "../../../public/lib/apiOperations";
 import { getImageUrl } from "../../../public/lib/imageOperations";
 import getTexts from "../../../public/texts/texts";
@@ -50,10 +49,11 @@ const useStyles = makeStyles((theme) => {
       lineHeight: 1.5,
       fontSize: 15,
       color: "rgba(0, 0, 0, 0.87)",
-      ["&span"]: {
-        whiteSpace: "nowrap",
-      },
       wordBreak: "break-word",
+      display: "-webkit-box",
+      WebkitLineClamp: 2,
+      // @ts-ignore - WebkitBoxOrient is deprecated but still required for line-clamp to work
+      WebkitBoxOrient: "vertical",
     },
     button: {
       marginTop: theme.spacing(1),
@@ -171,16 +171,14 @@ export default function ProjectPreview({ project, projectRef, hubUrl, className 
     </Link>
   );
 }
-const TruncateComponent = Truncate as any;
+
 const CardContentWithoutDescription = ({ project, hovering }) => {
   const classes = useStyles();
   return (
     <CardContent className={classes.cardContent}>
       <div className={classes.projectNameWrapper}>
-        <Typography component="h2">
-          <TruncateComponent lines={2} className={classes.projectName}>
-            {project.name}
-          </TruncateComponent>
+        <Typography component="h2" className={classes.projectName}>
+          {project.name}
         </Typography>
       </div>
       <ProjectMetaData project={project} hovering={hovering} />
@@ -194,10 +192,8 @@ const CardContentWithDescription = ({ project, hovering }) => {
   return (
     <CardContent className={`${classes.cardContentWithDescription} ${classes.cardContent}`}>
       <div className={classes.projectNameWrapper}>
-        <Typography component="h2">
-          <TruncateComponent lines={2} className={classes.projectName}>
-            {project.name}
-          </TruncateComponent>
+        <Typography component="h2" className={classes.projectName}>
+          {project.name}
         </Typography>
       </div>
       <ProjectMetaData project={project} hovering={hovering} withDescription />

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10116,11 +10116,6 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-truncate@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/react-truncate/-/react-truncate-2.4.0.tgz#3cf5ff09ab86f93e3c078d359f4de6d75aa60510"
-  integrity sha512-3QW11/COYwi6iPUaunUhl06DW5NJBJD1WkmxW5YxqqUu6kvP+msB3jfoLg8WRbu57JqgebjVW8Lknw6T5/QZdA==
-
 react-youtube@^7.13.0:
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/react-youtube/-/react-youtube-7.14.0.tgz#0505d86491521ca94ef0afb74af3f7936dc7bc86"


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [X] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Fix for #1725
