### PR TITLE
fixed sub-hub styling issue

### DIFF
--- a/frontend/src/components/hub/HubLinkButton.tsx
+++ b/frontend/src/components/hub/HubLinkButton.tsx
@@ -94,7 +94,7 @@ export default function HubLinkButton({ hub }: { hub: LinkedHub }) {
   };
   const linkUrl = getLinkUrl();
   return (
-    <Link href={linkUrl} className={`btn btn-primary ${classes.linkedHubsContainer}`}>
+    <Link href={linkUrl} className={classes.linkedHubsContainer}>
       <div className={classes.iconContainer}>
         <img className={classes.icon} src={hub.icon} alt="hub icon" />
       </div>


### PR DESCRIPTION
## Description
This PR addresses issue [1756](https://github.com/climateconnect/climateconnect/issues/1756) 
(Fixing sub-hub styling for the Perth & Kinross)

## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
