### PR TITLE
feat(frontend): upgrade axios from 0.21.2 to 1.7.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^18.11.18",
     "@webflow/webflow-cli": "^1.6.13",
     "@zeit/next-css": "^1.0.1",
-    "axios": "^0.21.2",
+    "axios": "^1.7.0",
     "babel-plugin-lodash": "^3.3.4",
     "browser-image-compression": "^1.0.12",
     "cheerio": "^1.0.0-rc.10",

--- a/frontend/src/components/search/LocationSearchBar.tsx
+++ b/frontend/src/components/search/LocationSearchBar.tsx
@@ -118,11 +118,6 @@ export default function LocationSearchBar({
 
     (async () => {
       if (searchValue) {
-        const config = {
-          method: "GET",
-          mode: "no-cors",
-          referrerPolicy: "origin",
-        };
         const searchParam = ALIAS_FOR_SEARCH[searchValue.toLowerCase()]
           ? ALIAS_FOR_SEARCH[searchValue.toLowerCase()]
           : searchValue;
@@ -130,7 +125,7 @@ export default function LocationSearchBar({
         if (Object.keys(HUB_COUNTRY_RESTRICTIONS).includes(hubUrl)) {
           url += "&countrycodes=" + HUB_COUNTRY_RESTRICTIONS[hubUrl];
         }
-        const response = await axios(url, config as any);
+        const response = await axios.get(url);
         const bannedClasses = [
           "tourism",
           "railway",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3947,17 +3947,19 @@ axe-core@^4.10.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.11.1.tgz#052ff9b2cbf543f5595028b583e4763b40c78ea7"
   integrity sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==
 
-axios@^0.21.2:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
-  dependencies:
-    follow-redirects "^1.14.0"
-
 axios@^1.12.0:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.2.tgz#9ada120b7b5ab24509553ec3e40123521117f687"
   integrity sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
+
+axios@^1.7.0:
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.4.tgz#15d109a4817fb82f73aea910d41a2c85606076bc"
+  integrity sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.4"
@@ -6226,7 +6228,7 @@ flatted@^3.2.7, flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
-follow-redirects@^1.14.0, follow-redirects@^1.15.6:
+follow-redirects@^1.15.6:
   version "1.15.11"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==


### PR DESCRIPTION
## Checked the following
- [x] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme
- [x] Run within `/frontend`: `yarn format && yarn lint`
- [x] Run within `/backend`: `make format && make lint` — N/A (frontend-only change)

## What and Why

Fixes #1645 - Update axios from 0.21.2 to 1.7.0 (installed 1.13.4)

### Why
axios 0.21.2 has known security vulnerabilities:
- **CVE-2023-45857** - SSRF vulnerability
- **CVE-2021-3749** - ReDoS vulnerability

### What Changed

**Files Modified (3):**
1. `frontend/package.json` - Updated axios version from `^0.21.2` to `^1.7.0`
2. `frontend/yarn.lock` - Updated dependency tree
3. `frontend/src/components/search/LocationSearchBar.tsx` - Refactored axios call

**Code Changes:**
- Changed `axios(url, config as any)` to `axios.get(url)` in LocationSearchBar
- Removed unused config object with deprecated options

### Testing Done
- [x] axios.get() - Works (LocationSearchBar pattern)
- [x] axios.post() with headers - Works (apiOperations pattern)
- [x] axios[method]() dynamic - Works (apiRequest pattern)
- [x] axios.isAxiosError() - Works (error handling)
- [x] Nominatim location search API - Works

### How to Test
1. `cd frontend && yarn install`
2. Search for a location in project creation or filters
3. Verify location autocomplete works
