### PR TITLE
URI encode search value

### DIFF
--- a/frontend/src/components/search/LocationSearchBar.tsx
+++ b/frontend/src/components/search/LocationSearchBar.tsx
@@ -121,7 +121,9 @@ export default function LocationSearchBar({
         const searchParam = ALIAS_FOR_SEARCH[searchValue.toLowerCase()]
           ? ALIAS_FOR_SEARCH[searchValue.toLowerCase()]
           : searchValue;
-        let url = `https://nominatim.openstreetmap.org/search?q=${searchParam}&format=json&addressdetails=1&polygon_geojson=1&polygon_threshold=0.001&accept-language=en-US,en;q=0.9`;
+        let url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(
+          searchParam
+        )}&format=json&addressdetails=1&polygon_geojson=1&polygon_threshold=0.001&accept-language=en-US,en;q=0.9`;
         if (Object.keys(HUB_COUNTRY_RESTRICTIONS).includes(hubUrl)) {
           url += "&countrycodes=" + HUB_COUNTRY_RESTRICTIONS[hubUrl];
         }


### PR DESCRIPTION
## Checked the following
- [X] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [X] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why
Minor change to harden location search. Noticed it in the previous pull request.
