### PR TITLE
Fix the display of project type names when it is not in the context o…

### DIFF
--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -4,6 +4,19 @@ import { getLocalePrefix } from "../lib/apiOperations";
 
 export default function getProjectTexts({ project, user, url_slug, locale, creator, hubName }) {
   return {
+    // Project type translations (based on type_id)
+    project_type_idea: {
+      en: "Idea",
+      de: "Idee",
+    },
+    project_type_event: {
+      en: "Event",
+      de: "Event",
+    },
+    project_type_project: {
+      en: "Project",
+      de: "Projekt",
+    },
     please_log_in_to_edit_project: {
       en: "Please Log In to Edit a project.",
       de: "Bitte logge dich ein, um ein Projekt zu bearbeiten ",

--- a/frontend/src/components/project/ProjectTypeDisplay.tsx
+++ b/frontend/src/components/project/ProjectTypeDisplay.tsx
@@ -1,7 +1,9 @@
 import { Typography, Tooltip } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import LayersIcon from "@mui/icons-material/Layers";
-import React from "react";
+import React, { useContext } from "react";
+import getTexts from "../../../public/texts/texts";
+import UserContext from "../context/UserContext";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -37,15 +39,28 @@ export default function ProjectTypeDisplay({
   hasChildren,
 }: Props) {
   const classes = useStyles();
+  const { locale } = useContext(UserContext);
+  const texts = getTexts({ page: "project", locale: locale });
+
+  // Get the localized name based on type_id
+  const getLocalizedTypeName = () => {
+    if (projectType?.type_id) {
+      const translationKey = `project_type_${projectType.type_id}`;
+      return texts[translationKey] || projectType.name;
+    }
+    return projectType?.name || "";
+  };
+
+  const typeName = getLocalizedTypeName();
 
   return (
     <div className={`${className} ${classes.root}`}>
       <img
         src={`/images/project_types/${projectType.type_id}.png`}
         className={iconClassName ? iconClassName : classes.typeIcon}
-        alt={projectType.name}
+        alt={typeName}
       />
-      <Typography className={textClassName}>{projectType.name}</Typography>
+      <Typography className={textClassName}>{typeName}</Typography>
       {hasChildren && (
         <Tooltip title="This event contains multiple sub-events">
           <LayersIcon className={classes.layersIcon} />


### PR DESCRIPTION
…f browse

## Checked the following
- [X] Pages affected by this change work on mobile
- [X] Pages affected by this change work when logged out
- [X] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [X] Run within `/frontend`: `yarn format && yarn lint`
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Fixes the display of project type name when the project preview is not used within the context of browse like on the Wasseraktionswochen page. The implementation depended on the type first being fetch from the API and being provided in a browseContext. As these types are fairly static we can get the text from the project text file, so we don't have to make another API call for the active language.  