### PR TITLE
Fix: Keep locale when redirecting from hub landing page to hub browse page

### DIFF
--- a/frontend/pages/hubs/[hubUrl]/index.tsx
+++ b/frontend/pages/hubs/[hubUrl]/index.tsx
@@ -9,6 +9,7 @@ import LoadingSpinner from "../../../src/components/general/LoadingSpinner";
 import theme from "../../../src/themes/theme";
 import { HubData } from "../../../src/types";
 import { getHubData } from "../../../public/lib/getHubData";
+import { getLocalePrefix } from "../../../public/lib/apiOperations";
 
 //Types
 type DevlinkComponentType = ComponentType<any> | null;
@@ -48,6 +49,7 @@ const NotFoundPage: FC<NotFoundPageProps> = ({ texts, link, showHeader }) => {
 
 export async function getServerSideProps(ctx: any) {
   const hubUrl = ctx?.params?.hubUrl as string | undefined;
+  const locale = ctx?.locale;
 
   if (!hubUrl) {
     return {
@@ -58,12 +60,12 @@ export async function getServerSideProps(ctx: any) {
     };
   }
 
-  const hubData = await getHubData(hubUrl, ctx.locale);
+  const hubData = await getHubData(hubUrl, locale);
   if (!hubData?.landing_page_component) {
-    const localeString = (ctx.locale != "en") ? `/${ctx.locale}` : "";
+    const localePrefix = getLocalePrefix(locale);
     return {
       redirect: {
-        destination: `${localeString}/hubs/${hubUrl}/browse`,
+        destination: `${localePrefix}/hubs/${hubUrl}/browse`,
         // redirect is based on current hub data, and that might change in the future so permanent: false,
         permanent: false,
       },


### PR DESCRIPTION
## The bug
When you visit a link to a hub landing page (e.g. `/de/hubs/kassel`): If no landing page exists, you get redirected to the hub browse page. In this case the locale is currently lost, so you get redirected to the english browse page (`/hubs/kassel/browse`)

## The fix
Now the locale is kept on redirect. `/de/hubs/kassel` now redirects to `/de/hubs/kassel/browse` instead of `/hubs/kassel/browse` if there is no landing page.
