### PR TITLE
Remove obsolete project tag code from the frontend

### DIFF
--- a/doc/spec/20260305_1000_remove_project_tags_from_frontend.md
+++ b/doc/spec/20260305_1000_remove_project_tags_from_frontend.md
@@ -20,7 +20,6 @@ The backend serializer (`ProjectSerializer`) already carries a `# TODO (Karol): 
 2. Ensure no regression is introduced in the project create (`/share`), project edit (`/editProject/[projectUrl]`), and manage-members (`/manageProjectMembers/[projectUrl]`) flows.
 3. Remove the `tags` property from the `Project` TypeScript type in `src/types.ts`.
 4. The clean-up must be verifiable — i.e. after the change, searching the source tree for `project_tag`, `project_tags`, and `\.tags` (on a project object) should return zero hits outside of `OrganizationTagging`-related files (which are unrelated to this task).
-5. Produce a clear summary of every file changed so the backend team can confidently proceed with removing the backend models.
 
 ### Non Functional Requirements
 

--- a/frontend/pages/editProject/[projectUrl].tsx
+++ b/frontend/pages/editProject/[projectUrl].tsx
@@ -234,7 +234,6 @@ async function getProjectByIdIfExists(projectUrl, token, locale) {
 const parseProject = (project) => ({
   ...project,
   image: getImageUrl(project.image),
-  tags: project.tags.map((t) => t.project_tag),
   project_parents: project.project_parents[0],
   is_personal_project: !project.project_parents[0].parent_organization,
   sectors: project.sectors.map((item) => ({ ...item.sector, order: item.order })),

--- a/frontend/pages/manageProjectMembers/[projectUrl].tsx
+++ b/frontend/pages/manageProjectMembers/[projectUrl].tsx
@@ -206,7 +206,6 @@ function parseProject(project) {
       ? project.project_parents[0].parent_organization
       : project.project_parents[0].parent_user,
     isPersonalProject: !project.project_parents[0].parent_organization,
-    tags: project.tags.map((t) => t.project_tag.name),
     collaborating_organizations: project.collaborating_organizations.map(
       (o) => o.collaborating_organization
     ),

--- a/frontend/public/lib/getOptions.ts
+++ b/frontend/public/lib/getOptions.ts
@@ -23,24 +23,6 @@ export async function getSkillsOptions(locale, parentSkillsOnly?: boolean) {
   }
 }
 
-export async function getProjectTagsOptions(hub, locale) {
-  const url = hub ? `/api/projecttags/?hub=${hub}` : `/api/projecttags/`;
-  try {
-    const resp = await apiRequest({
-      method: "get",
-      url: url,
-      locale: locale,
-    });
-    if (resp.data.results.length === 0) return null;
-    else {
-      return parseOptions(resp.data.results, "parent_tag");
-    }
-  } catch (err: any) {
-    console.log(err);
-    if (err.response && err.response.data) console.log("Error: " + err.response.data.detail);
-    return null;
-  }
-}
 export async function getSectorOptions(locale, hubUrl?: string) {
   const query = hubUrl ? `?hub=${hubUrl}` : "";
   try {

--- a/frontend/src/components/editProject/EditProjectRoot.tsx
+++ b/frontend/src/components/editProject/EditProjectRoot.tsx
@@ -414,7 +414,6 @@ const parseProjectForRequest = async (project, translationChanges) => {
   if (project.loc) ret.loc = parseLocation(project.loc, true);
   if (project.thumbnail_image)
     ret.thumbnail_image = await blobFromObjectUrl(project.thumbnail_image);
-  if (project.tags) ret.project_tags = project.tags.map((t) => t.id);
   if (project.sectors) ret.sectors = ret.sectors.map((s) => s.key);
   if (project.project_parents && project.project_parents.parent_organization)
     ret.parent_organization = project.project_parents.parent_organization.id;

--- a/frontend/src/components/shareProject/ShareProjectRoot.tsx
+++ b/frontend/src/components/shareProject/ShareProjectRoot.tsx
@@ -431,7 +431,6 @@ const formatProjectForRequest = async (project, translations) => {
       id: m.id,
       role_in_project: m.role_in_project,
     })),
-    project_tags: project?.project_tags?.map((s) => s.key),
     parent_organization: project?.parent_organization?.id,
     collaborating_organizations: project.collaborating_organizations.map((o) => o.id),
     image: await blobFromObjectUrl(project.image),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -43,7 +43,6 @@ export type Project = {
   url_slug?: string;
   name?: string;
   project_parents?: any[];
-  tags?: any[];
   project_type: ProjectType | any;
   start_date?: Date | Dayjs | null;
   end_date?: Date | Dayjs | null;


### PR DESCRIPTION
## Checked the following
- [x] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Implements #1811

As the old project tags were already not used and exposed any longer, no direct impact. 
Verify no regression was introduced.