### PR TITLE
Fix Bug - Member skills filter throws application error

### DIFF
--- a/frontend/pages/browse.tsx
+++ b/frontend/pages/browse.tsx
@@ -7,6 +7,7 @@ import {
   getOrganizationTagsOptions,
   getProjectTypeOptions,
   getSectorOptions,
+  getSkillsOptions,
 } from "../public/lib/getOptions";
 import { getAllHubs } from "../public/lib/hubOperations";
 import { getLocationFilteredBy } from "../public/lib/locationOperations";
@@ -27,18 +28,21 @@ export async function getServerSideProps(ctx) {
     location_filtered_by,
     projectTypes,
     sectorOptions,
+    skills,
   ] = await Promise.all([
     getOrganizationTagsOptions(ctx.locale),
     getAllHubs(ctx.locale),
     getLocationFilteredBy(ctx.query),
     getProjectTypeOptions(ctx.locale),
     getSectorOptions(ctx.locale),
+    getSkillsOptions(ctx.locale),
   ]);
   return {
     props: nullifyUndefinedValues({
       filterChoices: {
         organization_types: organization_types,
         sectors: sectorOptions,
+        skills: skills,
       },
       hideInfo: hideInfo === "true",
       hubs: hubs,

--- a/frontend/public/data/possibleFilters.ts
+++ b/frontend/public/data/possibleFilters.ts
@@ -73,20 +73,22 @@ const getSearchFilter = () => {
 
 const getIdeasFilters = (filterChoices, texts) => [...getLocationFilters(texts)];
 
-const getMembersFilters = (filterChoices, texts) => [
-  getSearchFilter(),
-  ...getLocationFilters(texts),
-  {
-    icon: CreateIcon,
-    iconName: "CreateIcon",
-    title: texts.skills,
-    type: "openMultiSelectDialogButton",
-    key: "skills",
-    itemType: "skills",
-    options: filterChoices?.skills?.map((s) => ({ ...s, key: s.id })),
-    tooltipText: texts.skills_tooltip,
-  },
-];
+const getMembersFilters = (filterChoices, texts) => {
+  return [
+    getSearchFilter(),
+    ...getLocationFilters(texts),
+    {
+      icon: CreateIcon,
+      iconName: "CreateIcon",
+      title: texts.skills,
+      type: "openMultiSelectDialogButton",
+      key: "skills",
+      itemType: "skills",
+      options: filterChoices?.skills?.map((s) => ({ ...s, key: s.id })),
+      tooltipText: texts.skills_tooltip,
+    },
+  ];
+};
 
 const getOrganizationsFilters = (filterChoices, texts) => [
   getSearchFilter(),


### PR DESCRIPTION
## Checked the following
- [x] Pages affected by this change work on mobile
- [x] Pages affected by this change work when logged out
- [x] Pages affected by this change work when logged in
- [x] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Fix for #1782 