### PR TITLE
Fix implementation to support body message

### DIFF
--- a/backend/organization/tests/test_event_registration.py
+++ b/backend/organization/tests/test_event_registration.py
@@ -2634,7 +2634,7 @@ class TestMyInteractionsRegistrationFields(_CancellationTestBase):
 
 class TestAdminCancelGuestRegistration(_CancellationTestBase):
     """
-    Tests for DELETE /api/projects/{url_slug}/registrations/{registration_id}/
+    Tests for PATCH /api/projects/{url_slug}/registrations/{registration_id}/
     (admin cancel guest, spec #1872).
 
     Covers all 12 test cases from the spec:
@@ -2655,7 +2655,7 @@ class TestAdminCancelGuestRegistration(_CancellationTestBase):
     @tag("admin_cancel", "auth")
     def test_unauthenticated_returns_401(self):
         reg = self._register(self.member)
-        response = self.client.delete(self._admin_cancel_url(reg.pk))
+        response = self.client.patch(self._admin_cancel_url(reg.pk))
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     @tag("admin_cancel", "auth")
@@ -2663,7 +2663,7 @@ class TestAdminCancelGuestRegistration(_CancellationTestBase):
         """A user without edit rights on the project → 403 Forbidden."""
         reg = self._register(self.member)
         self.client.login(username="member_cancel", password="testpassword")
-        response = self.client.delete(self._admin_cancel_url(reg.pk))
+        response = self.client.patch(self._admin_cancel_url(reg.pk))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @tag("admin_cancel", "validation")
@@ -2689,14 +2689,14 @@ class TestAdminCancelGuestRegistration(_CancellationTestBase):
             kwargs={"url_slug": event_no_er.url_slug, "registration_id": 9999},
         )
         self.client.login(username="organiser_cancel", password="testpassword")
-        response = self.client.delete(url)
+        response = self.client.patch(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @tag("admin_cancel", "validation")
     def test_registration_id_not_on_this_project_returns_404(self):
         """registration_id that does not belong to this project → 404."""
         self.client.login(username="organiser_cancel", password="testpassword")
-        response = self.client.delete(self._admin_cancel_url(99999))
+        response = self.client.patch(self._admin_cancel_url(99999))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @tag("admin_cancel", "validation")
@@ -2708,7 +2708,7 @@ class TestAdminCancelGuestRegistration(_CancellationTestBase):
         reg.save(update_fields=["cancelled_at", "cancelled_by"])
 
         self.client.login(username="organiser_cancel", password="testpassword")
-        response = self.client.delete(self._admin_cancel_url(reg.pk))
+        response = self.client.patch(self._admin_cancel_url(reg.pk))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @tag("admin_cancel", "happy_path")
@@ -2720,7 +2720,7 @@ class TestAdminCancelGuestRegistration(_CancellationTestBase):
         with mock_patch(
             "organization.views.event_registration_views.send_guest_cancellation_notification"
         ) as mock_email:
-            response = self.client.delete(
+            response = self.client.patch(
                 self._admin_cancel_url(reg.pk), {}, format="json"
             )
 
@@ -2739,7 +2739,7 @@ class TestAdminCancelGuestRegistration(_CancellationTestBase):
         with mock_patch(
             "organization.views.event_registration_views.send_guest_cancellation_notification"
         ) as mock_email:
-            response = self.client.delete(
+            response = self.client.patch(
                 self._admin_cancel_url(reg.pk),
                 {"message": "You have been removed from this event."},
                 format="json",
@@ -2763,7 +2763,7 @@ class TestAdminCancelGuestRegistration(_CancellationTestBase):
         with mock_patch(
             "organization.views.event_registration_views.send_guest_cancellation_notification"
         ):
-            response = self.client.delete(
+            response = self.client.patch(
                 self._admin_cancel_url(reg.pk), {}, format="json"
             )
 
@@ -2782,7 +2782,7 @@ class TestAdminCancelGuestRegistration(_CancellationTestBase):
         with mock_patch(
             "organization.views.event_registration_views.send_guest_cancellation_notification"
         ):
-            response = self.client.delete(
+            response = self.client.patch(
                 self._admin_cancel_url(reg.pk), {}, format="json"
             )
 
@@ -2799,7 +2799,7 @@ class TestAdminCancelGuestRegistration(_CancellationTestBase):
         with mock_patch(
             "organization.views.event_registration_views.send_guest_cancellation_notification"
         ):
-            response = self.client.delete(
+            response = self.client.patch(
                 self._admin_cancel_url(reg.pk), {}, format="json"
             )
 
@@ -2817,7 +2817,7 @@ class TestAdminCancelGuestRegistration(_CancellationTestBase):
         with mock_patch(
             "organization.views.event_registration_views.send_guest_cancellation_notification"
         ):
-            self.client.delete(self._admin_cancel_url(reg1.pk), {}, format="json")
+            self.client.patch(self._admin_cancel_url(reg1.pk), {}, format="json")
 
         list_url = reverse(
             "organization:event-registrations",

--- a/backend/organization/views/event_registration_views.py
+++ b/backend/organization/views/event_registration_views.py
@@ -577,7 +577,7 @@ class SendOrganizerEmailView(APIView):
 
 class AdminCancelRegistrationView(APIView):
     """
-    DELETE /api/projects/{url_slug}/registrations/{registration_id}/
+    PATCH /api/projects/{url_slug}/registrations/{registration_id}/
 
     Allows an event organiser or team admin to cancel a specific guest's
     registration (soft delete: sets ``cancelled_at`` and ``cancelled_by``).
@@ -587,7 +587,7 @@ class AdminCancelRegistrationView(APIView):
 
     Response codes:
         204 No Content  — cancellation successful.
-        400 Bad Request — registration already cancelled.
+        400 Bad Request — registration already cancelled, or message exceeds 1000 chars.
         401 Unauthorized — unauthenticated request.
         403 Forbidden   — authenticated but not an organiser or team admin.
         404 Not Found   — project, registration config, or registration not found.
@@ -598,7 +598,7 @@ class AdminCancelRegistrationView(APIView):
     permission_classes = [IsAuthenticated]
 
     @transaction.atomic
-    def delete(self, request, url_slug, registration_id):
+    def patch(self, request, url_slug, registration_id):
 
         # ── 1. Look up project ──────────────────────────────────────────────
         try:

--- a/doc/api-documentation.md
+++ b/doc/api-documentation.md
@@ -569,7 +569,7 @@ Intended for organisers / team admins to review their guest list and manage canc
 
 **Query optimisation**: the queryset uses `select_related("user__user_profile")` — all participant data is fetched in a single SQL JOIN, regardless of participant count.
 
-#### DELETE `/api/projects/{slug}/registrations/{id}/` — Admin cancel guest registration (issue #1872)
+#### PATCH `/api/projects/{slug}/registrations/{id}/` — Admin cancel guest registration (issue #1872)
 
 Allows an event organiser or team admin to cancel a specific guest's registration. This is a **soft delete** — `cancelled_at` and `cancelled_by` are set on the row. The guest cannot self-re-register after an admin cancellation.
 

--- a/doc/spec/20260407_1000_organizer_cancel_guest_registration.md
+++ b/doc/spec/20260407_1000_organizer_cancel_guest_registration.md
@@ -97,7 +97,7 @@ An event organiser or team admin can cancel the registration of an individual gu
 **Admin cancel a guest registration (new endpoint)**
 
 ```
-DELETE /api/projects/{slug}/registrations/{registration_id}/
+PATCH /api/projects/{slug}/registrations/{registration_id}/
 ```
 
 - Auth required — returns `401 Unauthorized` if unauthenticated.
@@ -106,13 +106,15 @@ DELETE /api/projects/{slug}/registrations/{registration_id}/
 - Returns `400 Bad Request` if the targeted registration is already cancelled (`cancelled_at IS NOT NULL`).
 - Sets `cancelled_at = now()` and `cancelled_by = request.user`, atomically.
 - If `EventRegistrationConfig.status` was `FULL` and active registrations are now below `max_participants`, reverts status to `OPEN` — same logic as in [#1850](https://github.com/climateconnect/climateconnect/issues/1850).
-- Accepts an **optional** `message` field in the request body. If provided and non-empty, sends a cancellation notification email to the guest (synchronous — single email, consistent with "Send test" in [#1866](https://github.com/climateconnect/climateconnect/issues/1866)). If absent or empty, no email is sent.
+- Accepts an **optional** `message` field in the request body (max 1000 characters). If provided and non-empty, sends a cancellation notification email to the guest (synchronous). If absent or empty, no email is sent.
 - Returns `204 No Content` on success.
+
+> **Note on HTTP method**: although the original spec used `DELETE`, the implementation uses `PATCH` because the operation is a partial update of the `EventRegistration` record (setting `cancelled_at`/`cancelled_by`), not a deletion. `PATCH` also avoids a known limitation in the shared `apiRequest` utility where `DELETE` requests with a body silently drop the `Authorization` header.
 
 | Status | Condition |
 |--------|-----------|
 | `204 No Content` | Cancellation successful |
-| `400 Bad Request` | Registration already cancelled |
+| `400 Bad Request` | Registration already cancelled, or message exceeds 1000 characters |
 | `401 Unauthorized` | Unauthenticated request |
 | `403 Forbidden` | Authenticated but not an organiser or team admin |
 | `404 Not Found` | Project not found, registration not enabled, or `registration_id` not found on this project |

--- a/doc/spec/EPIC_event_registration.md
+++ b/doc/spec/EPIC_event_registration.md
@@ -135,7 +135,7 @@ Where `effective_status` is computed lazily by `EventRegistrationSerializer`:
 | `GET /api/members/me/registered-events/` | GET | [#1849](https://github.com/climateconnect/climateconnect/issues/1849) | Authenticated member's upcoming registered events |
 | `GET /api/projects/{slug}/registrations/` | GET | [#1863](https://github.com/climateconnect/climateconnect/issues/1863) | Organiser lists registered guests; extended in [#1872](https://github.com/climateconnect/climateconnect/issues/1872) to return all registrations (active + cancelled) with `id` and `cancelled_at` |
 | `POST /api/projects/{slug}/registrations/email/` | POST | [product-backlog#55](https://github.com/climateconnect/product-backlog/issues/55) | Organiser sends email to all registered guests (`is_test=true` sends to self only; always returns `{"sent_count": N}`) |
-| `DELETE /api/projects/{slug}/registrations/{registration_id}/` | DELETE | [#1872](https://github.com/climateconnect/climateconnect/issues/1872) | Organiser/admin cancels a specific guest's registration (soft delete); optional `message` body triggers cancellation email to the guest |
+| `PATCH /api/projects/{slug}/registrations/{registration_id}/` | PATCH | [#1872](https://github.com/climateconnect/climateconnect/issues/1872) | Organiser/admin cancels a specific guest's registration (soft delete); optional `message` body triggers cancellation email to the guest |
 
 ### `event_registration` API Response Shape
 

--- a/frontend/src/components/project/CancelGuestRegistrationModal.test.tsx
+++ b/frontend/src/components/project/CancelGuestRegistrationModal.test.tsx
@@ -137,7 +137,7 @@ describe("CancelGuestRegistrationModal", () => {
   // ── Confirm with no message ────────────────────────────────────────────────
 
   describe("confirm without message", () => {
-    it("calls DELETE endpoint without a body when message is empty", async () => {
+    it("calls PATCH endpoint without a message body when message is empty", async () => {
       const onCancelled = jest.fn();
       const onClose = jest.fn();
       renderModal({ onCancelled, onClose });
@@ -147,9 +147,9 @@ describe("CancelGuestRegistrationModal", () => {
       await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
 
       const { method, url, payload } = mockApiRequest.mock.calls[0][0];
-      expect(method).toBe("delete");
+      expect(method).toBe("patch");
       expect(url).toBe("/api/projects/test-event/registrations/42/");
-      expect(payload).toBeUndefined();
+      expect(payload).toEqual({});
     });
 
     it("calls onCancelled with the registration id after success", async () => {

--- a/frontend/src/components/project/CancelGuestRegistrationModal.tsx
+++ b/frontend/src/components/project/CancelGuestRegistrationModal.tsx
@@ -95,9 +95,9 @@ export default function CancelGuestRegistrationModal({
     try {
       const trimmedMessage = message.trim();
       await apiRequest({
-        method: "delete",
+        method: "patch",
         url: `/api/projects/${project.url_slug}/registrations/${registration.id}/`,
-        payload: trimmedMessage ? { message: trimmedMessage } : undefined,
+        payload: trimmedMessage ? { message: trimmedMessage } : {},
         token,
         locale,
       });


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [X] Run within `/backend`: `make format && make lint`

## What and Why

Small change for #1872. Originally the API was using DELETE but delete doesn't support a payload body and this is more of an update anyhow, so changed the API to PATCH.
