### PR TITLE
Add notification option to event registration config

### DIFF
--- a/backend/organization/migrations/0125_add_notify_admins_to_eventregistrationconfig.py
+++ b/backend/organization/migrations/0125_add_notify_admins_to_eventregistrationconfig.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("organization", "0124_add_cancelled_fields_to_eventregistration"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="eventregistrationconfig",
+            name="notify_admins",
+            field=models.BooleanField(
+                default=True,
+                help_text=(
+                    "When True, team admins receive an email notification whenever "
+                    "a participant registers or cancels. "
+                    "Consumed by the admin notification task (see GitHub issue #1888)."
+                ),
+                verbose_name="Notify Admins",
+            ),
+        ),
+    ]

--- a/backend/organization/models/event_registration.py
+++ b/backend/organization/models/event_registration.py
@@ -121,6 +121,16 @@ class EventRegistrationConfig(models.Model):
         auto_now=True,
     )
 
+    notify_admins = models.BooleanField(
+        default=True,
+        help_text=(
+            "When True, team admins receive an email notification whenever "
+            "a participant registers or cancels. "
+            "Consumed by the admin notification task (see GitHub issue #1888)."
+        ),
+        verbose_name="Notify Admins",
+    )
+
     class Meta:
         app_label = "organization"
         verbose_name = "Event Registration Config"

--- a/backend/organization/serializers/event_registration.py
+++ b/backend/organization/serializers/event_registration.py
@@ -100,6 +100,7 @@ class EventRegistrationConfigSerializer(EventRegistrationConfigBaseSerializer):
             "registration_end_date",
             "status",
             "available_seats",
+            "notify_admins",
         ]
         extra_kwargs = {
             # PositiveIntegerField gives us min_value via the model, but we set
@@ -108,6 +109,10 @@ class EventRegistrationConfigSerializer(EventRegistrationConfigBaseSerializer):
             "registration_end_date": {"required": False, "allow_null": True},
             # Organisers may set OPEN or CLOSED; FULL is reserved for the system.
             "status": {"required": False, "default": RegistrationStatus.OPEN},
+            # Writable on creation (POST /api/projects/); defaults to True when omitted.
+            # Editing after creation is done via PATCH /registration-config/ using
+            # EditEventRegistrationConfigSerializer.
+            "notify_admins": {"required": False},
         }
 
     def get_available_seats(self, obj):
@@ -120,6 +125,19 @@ class EventRegistrationConfigSerializer(EventRegistrationConfigBaseSerializer):
         if not self.context.get("include_seat_count", False):
             return None
         return super().get_available_seats(obj)
+
+    def to_representation(self, instance):
+        """
+        Exclude ``notify_admins`` from list responses.
+
+        ``notify_admins`` is only included when ``context["include_seat_count"]``
+        is True (i.e. the detail endpoint).  The list endpoint omits it to keep
+        the payload lean and avoid leaking organiser-only settings to all callers.
+        """
+        data = super().to_representation(instance)
+        if not self.context.get("include_seat_count", False):
+            data.pop("notify_admins", None)
+        return data
 
     def validate_status(self, value):
         """Prevent organisers from directly setting system-managed statuses."""
@@ -308,11 +326,13 @@ class EditEventRegistrationConfigSerializer(EventRegistrationConfigBaseSerialize
             "registration_end_date",
             "status",
             "available_seats",
+            "notify_admins",
         ]
         extra_kwargs = {
             "max_participants": {"required": False, "allow_null": True, "min_value": 1},
             "registration_end_date": {"required": False, "allow_null": True},
             "status": {"required": False},
+            "notify_admins": {"required": False},
         }
 
     def validate_status(self, value):

--- a/backend/organization/tests/test_event_registration.py
+++ b/backend/organization/tests/test_event_registration.py
@@ -2857,3 +2857,288 @@ class TestAdminCancelGuestRegistration(_CancellationTestBase):
             self.assertIn("id", row)
             self.assertIn("cancelled_at", row)
             self.assertIsNotNone(row["id"])
+
+
+# ---------------------------------------------------------------------------
+# Tests for notify_admins field (#1882)
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyAdminsField(APITestCase):
+    """
+    Tests for the ``notify_admins`` boolean field on EventRegistrationConfig.
+
+    Covers spec test cases 1–6 (backend):
+    1. GET /api/projects/{slug}/ includes registration_config.notify_admins
+    2. GET /api/projects/ (list) does NOT include notify_admins
+    3. POST /api/projects/ with notify_admins=false creates config with notify_admins=False
+    4. POST /api/projects/ without notify_admins defaults to True
+    5. PATCH /api/projects/{slug}/registration-config/ with notify_admins=false updates field
+    6. PATCH /api/projects/{slug}/registration-config/ without notify_admins leaves value unchanged
+    """
+
+    def setUp(self):
+        self.project_status, _ = ProjectStatus.objects.update_or_create(
+            id=2,
+            defaults={
+                "name": "active_notify_admins",
+                "name_de_translation": "aktiv",
+                "has_end_date": True,
+                "has_start_date": True,
+            },
+        )
+        self.default_language, _ = Language.objects.get_or_create(
+            language_code="en",
+            defaults={"name": "English", "native_name": "English"},
+        )
+
+        self.organiser = User.objects.create_user(
+            username="organiser_notify_admins", password="testpassword"
+        )
+        self.role = Role.objects.create(
+            name="Admin_notify_admins",
+            role_type=Role.ALL_TYPE,
+        )
+
+        # Published event with an EventRegistrationConfig (notify_admins=True by default).
+        self.event = Project.objects.create(
+            name="Notify Admins Event",
+            url_slug="notify-admins-event",
+            is_active=True,
+            is_draft=False,
+            status=self.project_status,
+            language=self.default_language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=30),
+            end_date=timezone.now() + timedelta(days=90),
+        )
+        self.er = EventRegistrationConfig.objects.create(
+            project=self.event,
+            max_participants=50,
+            registration_end_date=timezone.now() + timedelta(days=60),
+            notify_admins=True,
+        )
+        ProjectMember.objects.create(
+            user=self.organiser,
+            project=self.event,
+            role=self.role,
+        )
+
+    def _detail_url(self, slug):
+        return reverse("organization:project-api-view", kwargs={"url_slug": slug})
+
+    def _edit_config_url(self, slug):
+        return reverse("organization:edit-registration-config", kwargs={"url_slug": slug})
+
+    # ------------------------------------------------------------------
+    # Test case 1: GET detail includes notify_admins
+    # ------------------------------------------------------------------
+
+    @tag("notify_admins", "registration_config")
+    def test_get_detail_includes_notify_admins(self):
+        """GET /api/projects/{slug}/ returns registration_config.notify_admins."""
+        response = self.client.get(self._detail_url("notify-admins-event"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("registration_config", data)
+        er = data["registration_config"]
+        self.assertIsNotNone(er)
+        self.assertIn("notify_admins", er)
+        self.assertTrue(er["notify_admins"])
+
+    # ------------------------------------------------------------------
+    # Test case 2: GET list does NOT include notify_admins
+    # ------------------------------------------------------------------
+
+    @tag("notify_admins", "registration_config")
+    def test_get_list_does_not_include_notify_admins(self):
+        """GET /api/projects/ list response does not include notify_admins in registration_config."""
+        url = reverse("organization:list-projects")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json().get("results", [])
+        event_result = next(
+            (r for r in results if r["url_slug"] == "notify-admins-event"), None
+        )
+        self.assertIsNotNone(event_result, "notify-admins-event not found in list")
+        er = event_result.get("registration_config")
+        self.assertIsNotNone(er)
+        self.assertNotIn(
+            "notify_admins",
+            er,
+            "notify_admins must not appear in list endpoint registration_config",
+        )
+
+    # ------------------------------------------------------------------
+    # Test cases 5 & 6: PATCH /registration-config/
+    # ------------------------------------------------------------------
+
+    @tag("notify_admins", "registration_config", "edit_settings")
+    def test_patch_notify_admins_false_updates_field(self):
+        """PATCH with notify_admins=false persists False and response includes updated value."""
+        self.client.login(username="organiser_notify_admins", password="testpassword")
+
+        response = self.client.patch(
+            self._edit_config_url("notify-admins-event"),
+            {"notify_admins": False},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.er.refresh_from_db()
+        self.assertFalse(self.er.notify_admins)
+        self.assertIn("notify_admins", response.data)
+        self.assertFalse(response.data["notify_admins"])
+
+    @tag("notify_admins", "registration_config", "edit_settings")
+    def test_patch_without_notify_admins_leaves_value_unchanged(self):
+        """PATCH without notify_admins in body leaves the existing value unchanged."""
+        # Ensure the stored value is True before the PATCH.
+        self.er.notify_admins = True
+        self.er.save(update_fields=["notify_admins"])
+
+        self.client.login(username="organiser_notify_admins", password="testpassword")
+
+        response = self.client.patch(
+            self._edit_config_url("notify-admins-event"),
+            {"max_participants": 60},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.er.refresh_from_db()
+        self.assertTrue(self.er.notify_admins, "notify_admins must remain True when not in PATCH body")
+
+    @tag("notify_admins", "registration_config", "edit_settings")
+    def test_patch_notify_admins_true_updates_field(self):
+        """PATCH with notify_admins=true persists True."""
+        # Start with False.
+        self.er.notify_admins = False
+        self.er.save(update_fields=["notify_admins"])
+
+        self.client.login(username="organiser_notify_admins", password="testpassword")
+
+        response = self.client.patch(
+            self._edit_config_url("notify-admins-event"),
+            {"notify_admins": True},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.er.refresh_from_db()
+        self.assertTrue(self.er.notify_admins)
+        self.assertTrue(response.data["notify_admins"])
+
+
+@override_settings(ENABLE_LEGACY_LOCATION_FORMAT="True")
+class TestNotifyAdminsCreateProject(APITestCase):
+    """
+    Tests for notify_admins during event creation via POST /api/projects/.
+
+    Covers spec test cases 3 & 4 (backend):
+    3. POST with notify_admins=false creates config with notify_admins=False
+    4. POST without notify_admins defaults to True
+    """
+
+    def setUp(self):
+        self.url = reverse("organization:create-project-api")
+
+        self.project_status, _ = ProjectStatus.objects.update_or_create(
+            id=2,
+            defaults={
+                "name": "active_notify_create",
+                "name_de_translation": "aktiv",
+                "has_end_date": True,
+                "has_start_date": True,
+            },
+        )
+        self.user = User.objects.create_user(
+            username="testuser_notify_create",
+            password="testpassword",
+        )
+        Location.objects.get_or_create(
+            city="Test City",
+            country="Testland",
+            defaults={"name": "Test City, Testland", "place_id": 9999},
+        )
+        self.default_language, _ = Language.objects.get_or_create(
+            language_code="en",
+            defaults={"name": "English", "native_name": "English"},
+        )
+        self.image = _make_black_image_b64()
+        self.location_data = {
+            "place_id": 9999,
+            "country": "Testland",
+            "city": "Test City",
+            "name": "Test City",
+            "type": "city",
+            "lon": 13.0,
+            "lat": 52.0,
+        }
+        self.event_project_type = {
+            "name": "Event",
+            "original_name": "Event",
+            "help_text": "Your Project will show up in the Event calendar",
+            "icon": "",
+            "type_id": "event",
+        }
+        self.base_event_data = {
+            "name": "Notify Admins Create Event",
+            "status": self.project_status.id,
+            "short_description": "A short description",
+            "collaborators_welcome": False,
+            "team_members": [],
+            "project_tags": [],
+            "sectors": [],
+            "loc": self.location_data,
+            "image": self.image,
+            "source_language": self.default_language.language_code,
+            "translations": {},
+            "project_type": self.event_project_type,
+            "hubName": None,
+            "end_date": "2026-08-01T20:00:00Z",
+            "start_date": "2026-07-01T10:00:00Z",
+        }
+
+    @tag("notify_admins", "registration_config", "projects")
+    def test_create_with_notify_admins_false_stores_false(self):
+        """POST with registration_config.notify_admins=false creates config with notify_admins=False."""
+        self.client.login(username="testuser_notify_create", password="testpassword")
+        data = {
+            **self.base_event_data,
+            "registration_config": {
+                "max_participants": 50,
+                "registration_end_date": "2026-07-31T23:59:00Z",
+                "notify_admins": False,
+            },
+        }
+
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        project = Project.objects.get(url_slug=response.data["url_slug"])
+        er = EventRegistrationConfig.objects.get(project=project)
+        self.assertFalse(er.notify_admins)
+
+    @tag("notify_admins", "registration_config", "projects")
+    def test_create_without_notify_admins_defaults_to_true(self):
+        """POST without notify_admins in registration_config creates config with notify_admins=True."""
+        self.client.login(username="testuser_notify_create", password="testpassword")
+        data = {
+            **self.base_event_data,
+            "name": "Notify Admins Default Event",
+            "registration_config": {
+                "max_participants": 50,
+                "registration_end_date": "2026-07-31T23:59:00Z",
+                # notify_admins intentionally omitted
+            },
+        }
+
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        project = Project.objects.get(url_slug=response.data["url_slug"])
+        er = EventRegistrationConfig.objects.get(project=project)
+        self.assertTrue(er.notify_admins)

--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -1310,6 +1310,10 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       de:
         "Die Anmeldung ist ausgebucht. Erhöhe die maximale Teilnehmerzahl, um sie wieder zu öffnen.",
     },
+    notify_admins_on_registration: {
+      en: "Send a notification to team admins when someone registers or cancels.",
+      de: "Sende eine Benachrichtigung an Team-Admins, wenn sich jemand an- oder abmeldet.",
+    },
     your_project_has_been_saved_as_a_draft: {
       en: "Your project has been saved as a draft!",
       de: "Dein Projekt wurde als Entwurf gespeichert!",

--- a/frontend/src/components/project/EditEventRegistrationModal.test.tsx
+++ b/frontend/src/components/project/EditEventRegistrationModal.test.tsx
@@ -71,6 +71,7 @@ function makeRegistration(overrides: Partial<EventRegistrationData> = {}): Event
     available_seats: 20,
     registration_end_date: FUTURE_DATE,
     status: "open",
+    notify_admins: true,
     ...overrides,
   };
 }
@@ -129,26 +130,27 @@ describe("EditEventRegistrationModal", () => {
 
     it("shows the switch as ON when status is open", () => {
       renderModal({ eventRegistration: makeRegistration({ status: "open" }) });
-      expect(screen.getByRole("checkbox")).toBeChecked();
+      expect(screen.getByRole("checkbox", { name: /status/i })).toBeChecked();
       expect(screen.getByText(/registration is open/i)).toBeInTheDocument();
     });
 
     it("shows the switch as OFF when status is closed", () => {
       renderModal({ eventRegistration: makeRegistration({ status: "closed" }) });
-      expect(screen.getByRole("checkbox")).not.toBeChecked();
+      expect(screen.getByRole("checkbox", { name: /status/i })).not.toBeChecked();
       expect(screen.getByText(/registration is closed/i)).toBeInTheDocument();
     });
 
     it("shows the 'Full' chip and switch when status is full", () => {
       renderModal({ eventRegistration: makeRegistration({ status: "full" }) });
       expect(screen.getByText(/full/i)).toBeInTheDocument();
-      expect(screen.getByRole("checkbox")).toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: /status/i })).toBeInTheDocument();
     });
 
-    it("shows an 'Ended' chip and no switch when status is ended", () => {
+    it("shows an 'Ended' chip and no status switch when status is ended", () => {
       renderModal({ eventRegistration: makeRegistration({ status: "ended" }) });
       expect(screen.getByText(/ended/i)).toBeInTheDocument();
-      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+      // Status switch is hidden for "ended"
+      expect(screen.queryByRole("checkbox", { name: /status/i })).not.toBeInTheDocument();
     });
   });
 
@@ -157,13 +159,13 @@ describe("EditEventRegistrationModal", () => {
   describe("status switch", () => {
     it("toggles label from open to closed", () => {
       renderModal({ eventRegistration: makeRegistration({ status: "open" }) });
-      fireEvent.click(screen.getByRole("checkbox"));
+      fireEvent.click(screen.getByRole("checkbox", { name: /status/i }));
       expect(screen.getByText(/registration is closed/i)).toBeInTheDocument();
     });
 
     it("toggles label from closed to open", () => {
       renderModal({ eventRegistration: makeRegistration({ status: "closed" }) });
-      fireEvent.click(screen.getByRole("checkbox"));
+      fireEvent.click(screen.getByRole("checkbox", { name: /status/i }));
       expect(screen.getByText(/registration is open/i)).toBeInTheDocument();
     });
   });
@@ -176,7 +178,7 @@ describe("EditEventRegistrationModal", () => {
 
     it("blocks switching to open when max_participants is not increased", () => {
       renderModal({ eventRegistration: fullReg });
-      const checkbox = screen.getByRole("checkbox");
+      const checkbox = screen.getByRole("checkbox", { name: /status/i });
       fireEvent.click(checkbox); // → closed
       expect(screen.getByText(/registration is closed/i)).toBeInTheDocument();
       // Try to turn it back on without raising max — should be blocked
@@ -191,7 +193,7 @@ describe("EditEventRegistrationModal", () => {
 
     it("allows switching to open after max_participants is raised above participant count", () => {
       renderModal({ eventRegistration: fullReg });
-      const checkbox = screen.getByRole("checkbox");
+      const checkbox = screen.getByRole("checkbox", { name: /status/i });
       fireEvent.click(checkbox); // → closed
       // Raise max above 30 (current participant count)
       fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "31" } });
@@ -346,7 +348,7 @@ describe("EditEventRegistrationModal", () => {
 
     it("sends status=closed after toggling the switch off", async () => {
       renderModal({ eventRegistration: makeRegistration({ status: "open" }) });
-      fireEvent.click(screen.getByRole("checkbox")); // open → closed
+      fireEvent.click(screen.getByRole("checkbox", { name: /status/i })); // open → closed
       fireEvent.click(screen.getByRole("button", { name: /save/i }));
       await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
       const { payload } = mockApiRequest.mock.calls[0][0];

--- a/frontend/src/components/project/EditEventRegistrationModal.tsx
+++ b/frontend/src/components/project/EditEventRegistrationModal.tsx
@@ -92,6 +92,7 @@ export default function EditEventRegistrationModal({
   const [maxParticipants, setMaxParticipants] = useState<string>("");
   const [registrationEndDate, setRegistrationEndDate] = useState<Dayjs | null>(null);
   const [selectedStatus, setSelectedStatus] = useState<"open" | "closed">("open");
+  const [notifyAdmins, setNotifyAdmins] = useState<boolean>(true);
   const [errors, setErrors] = useState<FormErrors>({});
   const [saving, setSaving] = useState(false);
 
@@ -107,6 +108,7 @@ export default function EditEventRegistrationModal({
           : null
       );
       setSelectedStatus(initSelectedStatus(eventRegistration.status));
+      setNotifyAdmins(eventRegistration.notify_admins);
       setErrors({});
     }
   }, [open, eventRegistration]);
@@ -178,6 +180,7 @@ export default function EditEventRegistrationModal({
     if (!isStatusEnded) {
       payload.status = selectedStatus;
     }
+    payload.notify_admins = notifyAdmins;
 
     try {
       const resp = await apiRequest({
@@ -324,6 +327,21 @@ export default function EditEventRegistrationModal({
             </Box>
           )}
         </Box>
+      </Box>
+
+      {/* Notify admins toggle */}
+      <Box sx={{ width: "100%", mt: 2 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={notifyAdmins}
+              onChange={(e) => setNotifyAdmins(e.target.checked)}
+              color="primary"
+              aria-label={texts.notify_admins_on_registration}
+            />
+          }
+          label={texts.notify_admins_on_registration}
+        />
       </Box>
 
       {errors.general && (

--- a/frontend/src/components/shareProject/EventRegistrationSection.tsx
+++ b/frontend/src/components/shareProject/EventRegistrationSection.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { Box, TextField, Typography } from "@mui/material";
+import { Box, FormControlLabel, Switch, TextField, Typography } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import { useTheme } from "@mui/styles";
 import dayjs, { Dayjs } from "dayjs";
@@ -53,6 +53,10 @@ export default function EventRegistrationSection({
     handleSetProjectData({ registration_end_date: value });
   };
 
+  const handleNotifyAdminsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleSetProjectData({ notify_admins: e.target.checked });
+  };
+
   return (
     <>
       <Typography component="h2" variant="subtitle2" color="primary" className={classes.subHeader}>
@@ -87,6 +91,19 @@ export default function EventRegistrationSection({
             error={errors.registration_end_date as any}
           />
         </Box>
+      </Box>
+      <Box sx={{ width: "100%", mt: 1 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={projectData.notify_admins !== false}
+              onChange={handleNotifyAdminsChange}
+              color="primary"
+              aria-label={texts.notify_admins_on_registration}
+            />
+          }
+          label={texts.notify_admins_on_registration}
+        />
       </Box>
     </>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,6 +6,8 @@ export type EventRegistrationData = {
   available_seats: number | null;
   registration_end_date: string | null; // ISO 8601 string from API
   status: "open" | "closed" | "full" | "ended";
+  /** When true, team admins receive an email on registration/cancellation. */
+  notify_admins: boolean;
 };
 
 export type User = {
@@ -71,6 +73,7 @@ export type Project = {
   registrationEnabled?: boolean;
   max_participants?: number | null;
   registration_end_date?: Dayjs | null;
+  notify_admins?: boolean;
   // Event registration data from the API (detail view)
   registration_config?: EventRegistrationData | null;
 };


### PR DESCRIPTION
## Checked the following
- [X] Pages affected by this change work on mobile
- [X] Pages affected by this change work when logged out
- [X] Pages affected by this change work when logged in
- [X] Pages affected by this change work with custom theme and default theme
- [X] Run within `/backend`: `make format && make lint`

## What and Why

implements #1882
