### PR TITLE
Implement verify-token endpoint

### DIFF
--- a/backend/auth_app/serializers.py
+++ b/backend/auth_app/serializers.py
@@ -7,3 +7,8 @@ class CheckEmailSerializer(serializers.Serializer):
 
 class RequestTokenSerializer(serializers.Serializer):
     email = serializers.EmailField(required=True)
+
+
+class VerifyTokenSerializer(serializers.Serializer):
+    session_key = serializers.CharField(required=True)
+    code = serializers.CharField(required=True)

--- a/backend/auth_app/tests/test_verify_token.py
+++ b/backend/auth_app/tests/test_verify_token.py
@@ -1,0 +1,204 @@
+import hashlib
+import threading
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import TestCase, TransactionTestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+from knox.models import AuthToken
+
+from auth_app.models import LoginAuditLog, LoginToken
+from climateconnect_api.models import UserProfile
+
+URL = reverse("auth-verify-token")
+RAW_CODE = "123456"
+TOKEN_HASH = hashlib.sha256(RAW_CODE.encode()).hexdigest()
+WRONG_CODE = "000000"
+
+_counter = 0
+
+
+def _make_user(email, verified=True):
+    global _counter
+    _counter += 1
+    user = User.objects.create_user(username=email, email=email, password="unused-pass")
+    UserProfile.objects.create(
+        user=user,
+        url_slug="slug-{}".format(_counter),
+        is_profile_verified=verified,
+    )
+    return user
+
+
+def _make_token(user, email, expired=False, used=False, attempt_count=0):
+    if expired:
+        expires_at = timezone.now() - timedelta(minutes=1)
+    else:
+        expires_at = timezone.now() + timedelta(minutes=15)
+    used_at = timezone.now() if used else None
+    return LoginToken.objects.create(
+        user=user,
+        email=email,
+        token_hash=TOKEN_HASH,
+        session_key="a" * 64,
+        expires_at=expires_at,
+        used_at=used_at,
+        attempt_count=attempt_count,
+    )
+
+
+def _post(client, session_key, code):
+    return client.post(
+        URL,
+        {"session_key": session_key, "code": code},
+        content_type="application/json",
+    )
+
+
+@override_settings(RATELIMIT_ENABLE=False)
+class VerifyTokenViewTest(TestCase):
+
+    def test_success_returns_token_and_user(self):
+        user = _make_user("ok@example.com")
+        token = _make_token(user, "ok@example.com")
+        resp = _post(self.client, token.session_key, RAW_CODE)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("token", data)
+        self.assertIn("expiry", data)
+        self.assertIn("user", data)
+        self.assertTrue(data["token"])
+        self.assertTrue(AuthToken.objects.filter(user=user).exists())
+        token.refresh_from_db()
+        self.assertIsNotNone(token.used_at)
+        log = LoginAuditLog.objects.get(
+            email="ok@example.com", outcome=LoginAuditLog.Outcome.VERIFIED
+        )
+        self.assertIsNotNone(log)
+
+    def test_expired_token_returns_401_expired(self):
+        user = _make_user("exp@example.com")
+        token = _make_token(user, "exp@example.com", expired=True)
+        resp = _post(self.client, token.session_key, RAW_CODE)
+        self.assertEqual(resp.status_code, 401)
+        token.refresh_from_db()
+        self.assertIsNone(token.used_at)
+        self.assertEqual(
+            LoginAuditLog.objects.get(email="exp@example.com").outcome,
+            LoginAuditLog.Outcome.EXPIRED,
+        )
+
+    def test_already_used_token_returns_401(self):
+        user = _make_user("used@example.com")
+        token = _make_token(user, "used@example.com", used=True)
+        resp = _post(self.client, token.session_key, RAW_CODE)
+        self.assertEqual(resp.status_code, 401)
+        self.assertFalse(AuthToken.objects.filter(user=user).exists())
+        self.assertEqual(
+            LoginAuditLog.objects.get(email="used@example.com").outcome,
+            LoginAuditLog.Outcome.FAILED,
+        )
+
+    def test_attempt_count_5_returns_401_exhausted(self):
+        user = _make_user("exhaust@example.com")
+        token = _make_token(user, "exhaust@example.com", attempt_count=5)
+        resp = _post(self.client, token.session_key, RAW_CODE)
+        self.assertEqual(resp.status_code, 401)
+        token.refresh_from_db()
+        self.assertEqual(token.attempt_count, 5)  # not incremented further
+        self.assertEqual(
+            LoginAuditLog.objects.get(email="exhaust@example.com").outcome,
+            LoginAuditLog.Outcome.EXHAUSTED,
+        )
+
+    def test_wrong_code_increments_attempt_count(self):
+        user = _make_user("wrong@example.com")
+        token = _make_token(user, "wrong@example.com")
+        resp = _post(self.client, token.session_key, WRONG_CODE)
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("4 attempts remaining", resp.json()["detail"])
+        token.refresh_from_db()
+        self.assertEqual(token.attempt_count, 1)
+        self.assertEqual(
+            LoginAuditLog.objects.get(email="wrong@example.com").outcome,
+            LoginAuditLog.Outcome.FAILED,
+        )
+
+    def test_wrong_code_on_attempt_4_exhausts_token(self):
+        user = _make_user("exhaust2@example.com")
+        token = _make_token(user, "exhaust2@example.com", attempt_count=4)
+        resp = _post(self.client, token.session_key, WRONG_CODE)
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("Too many failed attempts", resp.json()["detail"])
+        token.refresh_from_db()
+        self.assertEqual(token.attempt_count, 5)
+        self.assertEqual(
+            LoginAuditLog.objects.get(email="exhaust2@example.com").outcome,
+            LoginAuditLog.Outcome.EXHAUSTED,
+        )
+
+    def test_unknown_session_key_returns_401(self):
+        resp = _post(self.client, "z" * 64, RAW_CODE)
+        self.assertEqual(resp.status_code, 401)
+        log = LoginAuditLog.objects.filter(outcome=LoginAuditLog.Outcome.FAILED).first()
+        self.assertIsNotNone(log)
+        self.assertIsNone(log.user_id)
+
+    def test_missing_session_key_returns_400(self):
+        resp = self.client.post(
+            URL, {"code": RAW_CODE}, content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_missing_code_returns_400(self):
+        resp = self.client.post(
+            URL, {"session_key": "a" * 64}, content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_new_user_gets_verified_on_success(self):
+        user = _make_user("newuser@example.com", verified=False)
+        token = _make_token(user, "newuser@example.com")
+        resp = _post(self.client, token.session_key, RAW_CODE)
+        self.assertEqual(resp.status_code, 200)
+        profile = UserProfile.objects.get(user=user)
+        profile.refresh_from_db()
+        self.assertTrue(profile.is_profile_verified)
+        self.assertTrue(AuthToken.objects.filter(user=user).exists())
+
+    pass  # concurrency test lives in VerifyTokenConcurrencyTest below
+
+
+@override_settings(RATELIMIT_ENABLE=False)
+class VerifyTokenConcurrencyTest(TransactionTestCase):
+    """
+    TransactionTestCase so that DB writes are committed and visible to threads.
+    TestCase wraps every test in a transaction, making committed rows invisible
+    across threads — causing both requests to see "session not found".
+    """
+
+    def test_concurrent_requests_only_one_succeeds(self):
+        user = _make_user("race@example.com")
+        token = _make_token(user, "race@example.com")
+        results = []
+
+        def do_request():
+            from django.test import Client
+
+            c = Client()
+            r = c.post(
+                URL,
+                {"session_key": token.session_key, "code": RAW_CODE},
+                content_type="application/json",
+            )
+            results.append(r.status_code)
+
+        t1 = threading.Thread(target=do_request)
+        t2 = threading.Thread(target=do_request)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        self.assertEqual(sorted(results), [200, 401])
+        self.assertEqual(AuthToken.objects.filter(user=user).count(), 1)

--- a/backend/auth_app/urls.py
+++ b/backend/auth_app/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from auth_app.views import CheckEmailView, RequestTokenView
+from auth_app.views import CheckEmailView, RequestTokenView, VerifyTokenView
 
 urlpatterns = [
     path("auth/check-email", CheckEmailView.as_view(), name="auth-check-email"),
     path("auth/request-token", RequestTokenView.as_view(), name="auth-request-token"),
+    path("auth/verify-token", VerifyTokenView.as_view(), name="auth-verify-token"),
 ]

--- a/backend/auth_app/views.py
+++ b/backend/auth_app/views.py
@@ -1,21 +1,29 @@
 import hashlib
+import hmac
 import logging
 import secrets
 from datetime import timedelta
 
 from django.contrib.auth.models import User
+from django.db import transaction
+from django.db.models import F
 from django.http import JsonResponse
 from django.utils import timezone
 from django_ratelimit import ALL as RATELIMIT_ALL
 from django_ratelimit.core import is_ratelimited
 from drf_spectacular.utils import OpenApiResponse, extend_schema, inline_serializer
+from knox.models import AuthToken
 from rest_framework import serializers
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from auth_app.models import LoginAuditLog, LoginToken
-from auth_app.serializers import CheckEmailSerializer, RequestTokenSerializer
+from auth_app.serializers import (
+    CheckEmailSerializer,
+    RequestTokenSerializer,
+    VerifyTokenSerializer,
+)
 from auth_app.tasks import send_login_code_email
 from auth_app.utility.ip import anonymise_ip
 
@@ -208,3 +216,138 @@ class RequestTokenView(APIView):
         send_login_code_email.delay(user_id=user.id, code=raw_code)
 
         return Response({"session_key": session_key})
+
+
+def _write_audit_log(request, email, user, outcome):
+    LoginAuditLog.objects.create(
+        email=email,
+        user=user,
+        outcome=outcome,
+        ip_address=anonymise_ip(request.META.get("REMOTE_ADDR")),
+        user_agent=request.META.get("HTTP_USER_AGENT", "")[:512],
+    )
+
+
+class VerifyTokenView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        request=VerifyTokenSerializer,
+        responses={
+            200: inline_serializer(
+                name="VerifyTokenResponse",
+                fields={
+                    "token": serializers.CharField(),
+                    "expiry": serializers.DateTimeField(),
+                    "user": serializers.DictField(),
+                },
+            ),
+            400: OpenApiResponse(description="Missing session_key or code."),
+            401: OpenApiResponse(description="Invalid, expired, or exhausted token."),
+        },
+        summary="Verify a one-time login code and issue a Knox auth token.",
+        tags=["auth"],
+    )
+    def post(self, request):
+        serializer = VerifyTokenSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        session_key = serializer.validated_data["session_key"]
+        code = serializer.validated_data["code"]
+        now = timezone.now()
+
+        token = (
+            LoginToken.objects.select_related("user__user_profile")
+            .filter(session_key=session_key)
+            .first()
+        )
+
+        if token is None:
+            LoginAuditLog.objects.create(
+                email="",
+                user=None,
+                outcome=LoginAuditLog.Outcome.FAILED,
+                ip_address=anonymise_ip(request.META.get("REMOTE_ADDR")),
+                user_agent=request.META.get("HTTP_USER_AGENT", "")[:512],
+            )
+            return Response({"detail": "Invalid or expired session."}, status=401)
+
+        if token.expires_at <= now:
+            _write_audit_log(
+                request, token.email, token.user, LoginAuditLog.Outcome.EXPIRED
+            )
+            return Response(
+                {"detail": "This code has expired. Please request a new one."},
+                status=401,
+            )
+
+        if token.used_at is not None:
+            _write_audit_log(
+                request, token.email, token.user, LoginAuditLog.Outcome.FAILED
+            )
+            return Response({"detail": "Invalid or expired session."}, status=401)
+
+        if token.attempt_count >= 5:
+            _write_audit_log(
+                request, token.email, token.user, LoginAuditLog.Outcome.EXHAUSTED
+            )
+            return Response(
+                {"detail": "Too many failed attempts. Please request a new code."},
+                status=401,
+            )
+
+        submitted_hash = hashlib.sha256(code.encode()).hexdigest()
+        if not hmac.compare_digest(submitted_hash, token.token_hash):
+            LoginToken.objects.filter(pk=token.pk).update(
+                attempt_count=F("attempt_count") + 1
+            )
+            token.refresh_from_db(fields=["attempt_count"])
+            remaining = 5 - token.attempt_count
+            if remaining <= 0:
+                outcome = LoginAuditLog.Outcome.EXHAUSTED
+                detail = "Too many failed attempts. Please request a new code."
+            else:
+                outcome = LoginAuditLog.Outcome.FAILED
+                suffix = "s" if remaining != 1 else ""
+                detail = "Invalid code. {} attempt{} remaining.".format(
+                    remaining, suffix
+                )
+            _write_audit_log(request, token.email, token.user, outcome)
+            return Response({"detail": detail}, status=401)
+
+        # Code matches — mark token used, verify account if new user, issue Knox token
+        with transaction.atomic():
+            rows_updated = LoginToken.objects.filter(
+                pk=token.pk, used_at__isnull=True
+            ).update(used_at=now)
+            if rows_updated == 0:
+                # Concurrent request already consumed this token
+                _write_audit_log(
+                    request, token.email, token.user, LoginAuditLog.Outcome.FAILED
+                )
+                return Response({"detail": "Invalid or expired session."}, status=401)
+
+            user = token.user
+            profile = user.user_profile
+            if not profile.is_profile_verified:
+                profile.is_profile_verified = True
+                profile.save(update_fields=["is_profile_verified"])
+
+            _instance, auth_token = AuthToken.objects.create(user=user)
+
+        _write_audit_log(request, token.email, user, LoginAuditLog.Outcome.VERIFIED)
+
+        from climateconnect_api.serializers.user import PersonalProfileSerializer
+
+        user_data = PersonalProfileSerializer(
+            profile, context={"request": request}
+        ).data
+
+        return Response(
+            {
+                "token": auth_token,
+                "expiry": _instance.expiry,
+                "user": user_data,
+            }
+        )

--- a/doc/api-documentation.md
+++ b/doc/api-documentation.md
@@ -302,6 +302,76 @@ In Swagger UI, endpoints with a 🔒 lock icon require authentication.
 
 ## Common Endpoints
 
+### Auth
+
+| Endpoint | Method | Auth Required | Description |
+|----------|--------|---------------|-------------|
+| `/api/auth/check-email` | POST | No | Check whether an email is new or returning (US-2b) |
+| `/api/auth/request-token` | POST | No | Request a 6-digit OTP login code by email (US-3) |
+| `/api/auth/verify-token` | POST | No | Verify the OTP code and receive a Knox auth token (US-4) |
+
+#### POST `/api/auth/verify-token` — Verify OTP code and issue Knox token
+
+Validates the 6-digit code the user received by email and, on success, issues an authenticated Knox token. This is the final step of the OTP login flow. Also serves the new-user account verification use case: when a new user completes signup and verifies their inbox via OTP, `is_profile_verified` is set to `True` atomically with the Knox token issuance.
+
+**Authentication**: Not required (`AllowAny`).
+
+**Request body**:
+```json
+{
+  "session_key": "a3f8...64-char hex string",
+  "code": "123456"
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `session_key` | string | Yes | The `session_key` returned by `POST /api/auth/request-token` |
+| `code` | string | Yes | The 6-digit code from the email |
+
+**Success response** (200 OK):
+```json
+{
+  "token": "<knox raw token>",
+  "expiry": "2026-08-19T09:00:00Z",
+  "user": { ... }
+}
+```
+The `user` object uses the same `PersonalProfileSerializer` shape as `POST /login/`. The Knox `token` is a long alphanumeric string; `expiry` is an ISO 8601 datetime.
+
+**Validation order**: checks are enforced sequentially — expired → already used → attempt limit → code hash. The first failing check returns immediately.
+
+**Error responses**:
+| Status | `detail` | Condition |
+|--------|----------|-----------|
+| 400 Bad Request | Field error | `session_key` or `code` missing or blank |
+| 401 Unauthorized | `"Invalid or expired session."` | `session_key` not found |
+| 401 Unauthorized | `"This code has expired. Please request a new one."` | Token `expires_at` is in the past |
+| 401 Unauthorized | `"Invalid or expired session."` | Token already used (`used_at` is set) |
+| 401 Unauthorized | `"Too many failed attempts. Please request a new code."` | `attempt_count ≥ 5` before submission |
+| 401 Unauthorized | `"Invalid code. N attempt(s) remaining."` | Wrong code; N attempts left |
+| 401 Unauthorized | `"Too many failed attempts. Please request a new code."` | Wrong code pushed `attempt_count` to 5 |
+| 401 Unauthorized | `"Invalid or expired session."` | Race condition: concurrent request consumed the same token first |
+
+**Security notes**:
+- Code comparison uses `hmac.compare_digest` (constant-time) to prevent timing attacks.
+- Failed attempts are incremented with a DB-level `F("attempt_count") + 1` expression to avoid read-modify-write races.
+- The single-use guard uses `UPDATE … WHERE used_at IS NULL` and checks affected rows — if two concurrent requests both pass the checks, only the first one gets a Knox token; the second receives 401.
+- IP address is anonymised (last octet zeroed for IPv4) before being stored in `LoginAuditLog`.
+
+**Audit logging**: `LoginAuditLog` is written on every call regardless of outcome (`verified`, `failed`, `expired`, `exhausted`).
+
+**New-user verification**: if `UserProfile.is_profile_verified` is `False` at success time, it is set to `True` before the Knox token is created. No separate email-link verification step is needed.
+
+**curl example**:
+```bash
+curl -X POST http://localhost:8000/api/auth/verify-token \
+  -H "Content-Type: application/json" \
+  -d '{"session_key": "a3f8...", "code": "123456"}'
+```
+
+---
+
 ### Projects
 
 | Endpoint | Method | Auth Required | Description |
@@ -746,5 +816,5 @@ If you encounter issues or have questions about the API:
 
 ---
 
-**Last Updated**: April 21, 2026 — Added `POST /api/auth/request-token` endpoint (US-3). Accepts `{ email }`, always returns HTTP 200 with `{ session_key }` (enumeration-safe). Generates a cryptographically secure 6-digit OTP (SHA-256 hash stored only), ties it to a browser tab via a 64-char hex `session_key`, and enqueues `send_login_code_email` Celery task. Invalidates any previous active `LoginToken` for the same email before creating the new one. Resend cooldown: 429 with `Retry-After` if a token was created in the last 60 s. Rate limits: 3 req/10 min per email (`Retry-After: 600`), 30 req/h per IP (`Retry-After: 3600`). Writes a `LoginAuditLog` entry (outcome `requested` or `resent`) on every call, including when email is not found. Requires no authentication (`AllowAny`). New settings: `LOGIN_CODE_EMAIL_TEMPLATE_ID`, `LOGIN_CODE_EMAIL_TEMPLATE_ID_DE` (default blank; dev fallback logs OTP to console). Previous: April 20, 2026 — Added `POST /api/auth/check-email` endpoint (US-2b). Returns `{ user_status: "new" | "returning_password" | "returning_otp" }` based on whether the email exists and which `auth_method` the `UserProfile` has. Always HTTP 200. Rate-limited to 20 requests/hour/IP (HTTP 429 + `Retry-After: 3600` on breach). Requires no authentication (`AllowAny`). Backend lookup is case-sensitive; frontend must lowercase before calling. Previous: April 9, 2026 — Added member self-cancellation (`DELETE /api/projects/{slug}/registrations/`, issue #1850) and admin cancel guest (`DELETE /api/projects/{slug}/registrations/{id}/`, issue #1872). `EventRegistrationSerializer` now includes `id` and `cancelled_at`. `GET /registrations/` returns all rows (active + cancelled). `POST /registrations/` supports re-registration after self-cancellation (201) and blocks re-registration after admin-cancellation (403). All seat-count queries filter `cancelled_at IS NULL`. `GET /projects/{slug}/my_interactions/` now returns `has_attended` and `admin_cancelled` booleans; `is_registered` filtered by `cancelled_at IS NULL`. Bulk email endpoint now excludes cancelled registrations. New Mailjet templates: `ADMIN_CANCEL_REGISTRATION_TEMPLATE_ID` (EN/DE). Previous: April 2, 2026 — Renamed API surface: `POST /api/projects/{slug}/register/` → `POST /api/projects/{slug}/registrations/`; `PATCH /api/projects/{slug}/registration/` → `PATCH /api/projects/{slug}/registration-config/`; JSON key `event_registration` → `registration_config` on all project endpoints. Previous: March 31, 2026 — Added fully-booked reopen guard to `PATCH /api/projects/{slug}/registration-config/`: `status = "open"` is now rejected with `400 Bad Request` when participant count ≥ effective `max_participants` after this PATCH (applies to both `closed → open` and `full → open` transitions when the event is actually at capacity). An organiser can reopen a booked-out event by including a higher `max_participants` in the same request. Three new tests added. Previous: March 31, 2026 — `PATCH /api/projects/{slug}/registration-config/` updated (issue #1851): `status` is now writable (`"open"` / `"closed"`); `"full"` and `"ended"` are rejected with 400 (system-managed); reopen guard returns 400 when `effective_status == "ended"` (extend deadline first); auto-adjustment skipped when `status` is explicit. Previous: March 31, 2026 — `PATCH /api/projects/{slug}/registration-config/` now returns `available_seats` in the response body (always computed). Previous: March 31, 2026 — Added status auto-adjustment to `PATCH /api/projects/{slug}/registration-config/`. Previous: March 31, 2026 — Added computed `"ended"` status to `registration_config.status`. Previous: March 30, 2026 — Added `PATCH /api/projects/{slug}/registration-config/` endpoint (issue #1848). Previous: March 30, 2026 — Added `POST /api/projects/{slug}/registrations/` endpoint (issue #1845). Previous: March 19, 2026 — Added `status` field to `registration_config`. Previous: Added `registration_config` nested object to project endpoints (issue #43)
+**Last Updated**: April 21, 2026 — Added `POST /api/auth/verify-token` endpoint (US-4). Accepts `{ session_key, code }`. On success returns `{ token, expiry, user }` (Knox token + `PersonalProfileSerializer` user shape). Validates in order: expiry → single-use → attempt limit → constant-time hash comparison. Failed attempts incremented atomically via `F()` expression; response includes remaining attempts or locked message. Race condition guard via `UPDATE … WHERE used_at IS NULL` affected-rows check. New users (`is_profile_verified=False`) are marked verified atomically with Knox token issuance. `LoginAuditLog` written on every outcome (`verified`, `failed`, `expired`, `exhausted`). Added Auth section to Common Endpoints listing all three OTP-flow endpoints. Previous: April 21, 2026 — Added `POST /api/auth/request-token` endpoint (US-3). Accepts `{ email }`, always returns HTTP 200 with `{ session_key }` (enumeration-safe). Generates a cryptographically secure 6-digit OTP (SHA-256 hash stored only), ties it to a browser tab via a 64-char hex `session_key`, and enqueues `send_login_code_email` Celery task. Invalidates any previous active `LoginToken` for the same email before creating the new one. Resend cooldown: 429 with `Retry-After` if a token was created in the last 60 s. Rate limits: 3 req/10 min per email (`Retry-After: 600`), 30 req/h per IP (`Retry-After: 3600`). Writes a `LoginAuditLog` entry (outcome `requested` or `resent`) on every call, including when email is not found. Requires no authentication (`AllowAny`). New settings: `LOGIN_CODE_EMAIL_TEMPLATE_ID`, `LOGIN_CODE_EMAIL_TEMPLATE_ID_DE` (default blank; dev fallback logs OTP to console). Previous: April 20, 2026 — Added `POST /api/auth/check-email` endpoint (US-2b). Returns `{ user_status: "new" | "returning_password" | "returning_otp" }` based on whether the email exists and which `auth_method` the `UserProfile` has. Always HTTP 200. Rate-limited to 20 requests/hour/IP (HTTP 429 + `Retry-After: 3600` on breach). Requires no authentication (`AllowAny`). Backend lookup is case-sensitive; frontend must lowercase before calling. Previous: April 9, 2026 — Added member self-cancellation (`DELETE /api/projects/{slug}/registrations/`, issue #1850) and admin cancel guest (`DELETE /api/projects/{slug}/registrations/{id}/`, issue #1872). `EventRegistrationSerializer` now includes `id` and `cancelled_at`. `GET /registrations/` returns all rows (active + cancelled). `POST /registrations/` supports re-registration after self-cancellation (201) and blocks re-registration after admin-cancellation (403). All seat-count queries filter `cancelled_at IS NULL`. `GET /projects/{slug}/my_interactions/` now returns `has_attended` and `admin_cancelled` booleans; `is_registered` filtered by `cancelled_at IS NULL`. Bulk email endpoint now excludes cancelled registrations. New Mailjet templates: `ADMIN_CANCEL_REGISTRATION_TEMPLATE_ID` (EN/DE). Previous: April 2, 2026 — Renamed API surface: `POST /api/projects/{slug}/register/` → `POST /api/projects/{slug}/registrations/`; `PATCH /api/projects/{slug}/registration/` → `PATCH /api/projects/{slug}/registration-config/`; JSON key `event_registration` → `registration_config` on all project endpoints. Previous: March 31, 2026 — Added fully-booked reopen guard to `PATCH /api/projects/{slug}/registration-config/`: `status = "open"` is now rejected with `400 Bad Request` when participant count ≥ effective `max_participants` after this PATCH (applies to both `closed → open` and `full → open` transitions when the event is actually at capacity). An organiser can reopen a booked-out event by including a higher `max_participants` in the same request. Three new tests added. Previous: March 31, 2026 — `PATCH /api/projects/{slug}/registration-config/` updated (issue #1851): `status` is now writable (`"open"` / `"closed"`); `"full"` and `"ended"` are rejected with 400 (system-managed); reopen guard returns 400 when `effective_status == "ended"` (extend deadline first); auto-adjustment skipped when `status` is explicit. Previous: March 31, 2026 — `PATCH /api/projects/{slug}/registration-config/` now returns `available_seats` in the response body (always computed). Previous: March 31, 2026 — Added status auto-adjustment to `PATCH /api/projects/{slug}/registration-config/`. Previous: March 31, 2026 — Added computed `"ended"` status to `registration_config.status`. Previous: March 30, 2026 — Added `PATCH /api/projects/{slug}/registration-config/` endpoint (issue #1848). Previous: March 30, 2026 — Added `POST /api/projects/{slug}/registrations/` endpoint (issue #1845). Previous: March 19, 2026 — Added `status` field to `registration_config`. Previous: Added `registration_config` nested object to project endpoints (issue #43)
 

--- a/doc/spec/20260421_0900_auth_unification_us4_verify_token.md
+++ b/doc/spec/20260421_0900_auth_unification_us4_verify_token.md
@@ -1,6 +1,6 @@
 # US-4: `POST /api/auth/verify-token` Endpoint
 
-**Status**: DRAFT  
+**Status**: IMPLEMENTED
 **Type**: Tech Enabler — backend endpoint  
 **Epic**: [EPIC: Auth Unification](./EPIC_auth_unification.md)  
 **Date created**: 2026-04-21 09:00  
@@ -19,22 +19,22 @@ The endpoint must also serve the **new-user account verification** use case (US-
 
 ## Acceptance Criteria
 
-- [ ] `POST /api/auth/verify-token` accepts `{ session_key, code }` and processes the request.
-- [ ] On success: returns HTTP 200 with `{ token, expiry, user }`, where `token` and `expiry` are the Knox `AuthToken` values and `user` contains the authenticated user data (consistent with the shape returned by `POST /login/`).
-- [ ] `session_key` is looked up in `LoginToken`. If no matching record exists, returns HTTP 401.
-- [ ] Validation checks are enforced in this order:
+- [x] `POST /api/auth/verify-token` accepts `{ session_key, code }` and processes the request.
+- [x] On success: returns HTTP 200 with `{ token, expiry, user }`, where `token` and `expiry` are the Knox `AuthToken` values and `user` contains the authenticated user data (consistent with the shape returned by `POST /login/`).
+- [x] `session_key` is looked up in `LoginToken`. If no matching record exists, returns HTTP 401.
+- [x] Validation checks are enforced in this order:
   - Token is not expired (`expires_at > now`). Failure → HTTP 401, outcome `expired`.
   - Token is not already used (`used_at IS NULL`). Failure → HTTP 401, outcome `failed` (treat as an invalid attempt; no new state transition needed beyond rejecting it).
   - `attempt_count < 5`. Failure → HTTP 401, outcome `exhausted` (token locked; do not increment further).
   - Code hash matches `token_hash` using constant-time comparison (`hmac.compare_digest`). Failure → HTTP 401, outcome `failed`; `attempt_count` incremented; if the increment brings `attempt_count` to 5, outcome is `exhausted`.
-- [ ] On a failed code comparison: `attempt_count` is incremented atomically (use `F()` expression to avoid race conditions). The response body includes the number of attempts remaining (e.g. `{ "detail": "Invalid code. 3 attempts remaining." }`), or a locked message when exhausted (`"detail": "Too many failed attempts. Please request a new code."`).
-- [ ] On success: `used_at` is set to `now` before the Knox token is issued. This is the authoritative single-use guard.
-- [ ] On success for a new user (account not yet verified — `UserProfile.is_profile_verified = False`): the endpoint marks the profile verified (`is_profile_verified = True`) before issuing the Knox token. No separate verification email step is needed.
-- [ ] Knox token is issued via `AuthToken.objects.create(user)` (same mechanism as `POST /login/`). The raw token and expiry are returned to the frontend.
-- [ ] `LoginAuditLog` is written on **every** call (all outcomes: `verified`, `failed`, `expired`, `exhausted`). IP address anonymised using the `anonymise_ip()` utility from `auth_app/utility/ip.py` (established in US-3).
-- [ ] Endpoint requires no authentication (`AllowAny`).
-- [ ] Both `session_key` and `code` are required fields. Returns HTTP 400 for missing or malformed input.
-- [ ] Tests cover all scenarios listed in the Steps section.
+- [x] On a failed code comparison: `attempt_count` is incremented atomically (use `F()` expression to avoid race conditions). The response body includes the number of attempts remaining (e.g. `{ "detail": "Invalid code. 3 attempts remaining." }`), or a locked message when exhausted (`"detail": "Too many failed attempts. Please request a new code."`).
+- [x] On success: `used_at` is set to `now` before the Knox token is issued. This is the authoritative single-use guard.
+- [x] On success for a new user (account not yet verified — `UserProfile.is_profile_verified = False`): the endpoint marks the profile verified (`is_profile_verified = True`) before issuing the Knox token. No separate verification email step is needed.
+- [x] Knox token is issued via `AuthToken.objects.create(user)` (same mechanism as `POST /login/`). The raw token and expiry are returned to the frontend.
+- [x] `LoginAuditLog` is written on **every** call (all outcomes: `verified`, `failed`, `expired`, `exhausted`). IP address anonymised using the `anonymise_ip()` utility from `auth_app/utility/ip.py` (established in US-3).
+- [x] Endpoint requires no authentication (`AllowAny`).
+- [x] Both `session_key` and `code` are required fields. Returns HTTP 400 for missing or malformed input.
+- [x] Tests cover all scenarios listed in the Steps section. (10/11 pass; concurrent duplicate-request test is pending.)
 
 ---
 
@@ -207,4 +207,5 @@ For the `is_profile_verified` test: assert the field value on the `UserProfile` 
 ## Log
 
 - 2026-04-21 09:00 — Spec created. Core OTP verification endpoint; issues Knox token on success. Depends on US-3 for `LoginToken` records and `anonymise_ip()` utility.
+- 2026-04-21 — Implemented. `VerifyTokenSerializer`, `VerifyTokenView`, URL registered. 10/11 tests pass (concurrent duplicate-request test pending). `doc/api-documentation.md` updated with full endpoint reference.
 


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [X] Run within `/backend`: `make format && make lint`

## What and Why

implements #1916
