### PR TITLE
Implement OTP based login

### DIFF
--- a/backend/auth_app/views.py
+++ b/backend/auth_app/views.py
@@ -141,9 +141,17 @@ class RequestTokenView(APIView):
         email = serializer.validated_data["email"]
         now = timezone.now()
 
-        # Resend cooldown: check the most recent token for this email
+        # Resend cooldown: check the most recent active (non-exhausted, non-used, non-expired) token.
+        # Exhausted tokens (attempt_count >= 5) should not block the user from requesting a new code.
         recent_token = (
-            LoginToken.objects.filter(email=email).order_by("-created_at").first()
+            LoginToken.objects.filter(
+                email=email,
+                used_at__isnull=True,
+                expires_at__gt=now,
+                attempt_count__lt=5,
+            )
+            .order_by("-created_at")
+            .first()
         )
         if recent_token is not None:
             seconds_since = (now - recent_token.created_at).total_seconds()

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -146,9 +146,15 @@ export default function Login({
     setCurrentStep("email_entry");
   };
 
+  const handleAuthSuccess = () => {
+    const storedRedirect = window.sessionStorage.getItem("auth_redirect_url");
+    router.push(storedRedirect || getLocalePrefix(locale || "en") + "/");
+  };
+
   const commonProps = {
     email,
     onBack: handleBack,
+    onSuccess: handleAuthSuccess,
     hubUrl: hubSlug || undefined,
   };
 

--- a/frontend/public/texts/profile_texts.tsx
+++ b/frontend/public/texts/profile_texts.tsx
@@ -396,5 +396,45 @@ export default function getProfileTexts({ profile, hubName, locale }) {
       en: "Areas of interest",
       de: "Interessensgebiete",
     },
+    enter_your_code: {
+      en: "Enter your code",
+      de: "Code eingeben",
+    },
+    we_sent_a_code_to: {
+      en: "We sent a 6-digit code to",
+      de: "Wir haben einen 6-stelligen Code gesendet an",
+    },
+    verify: {
+      en: "Verify",
+      de: "Bestätigen",
+    },
+    resend_code: {
+      en: "Resend code",
+      de: "Code erneut senden",
+    },
+    back: {
+      en: "Back",
+      de: "Zurück",
+    },
+    this_code_has_expired_please_request_a_new_one: {
+      en: "This code has expired. Please request a new one.",
+      de: "Dieser Code ist abgelaufen. Bitte fordere einen neuen an.",
+    },
+    too_many_attempts_please_request_a_new_code: {
+      en: "Too many attempts. Please request a new code.",
+      de: "Zu viele Versuche. Bitte fordere einen neuen Code an.",
+    },
+    incorrect_code_please_try_again: {
+      en: "Incorrect code. Please try again.",
+      de: "Falscher Code. Bitte versuche es erneut.",
+    },
+    please_wait_before_requesting_a_new_code: {
+      en: "Please wait before requesting a new code.",
+      de: "Bitte warte, bevor du einen neuen Code anforderst.",
+    },
+    connection_error_please_try_again: {
+      en: "Connection error. Please try again.",
+      de: "Verbindungsfehler. Bitte versuche es erneut.",
+    },
   };
 }

--- a/frontend/src/components/auth/AuthOtp.test.tsx
+++ b/frontend/src/components/auth/AuthOtp.test.tsx
@@ -1,0 +1,362 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ThemeProvider } from "@mui/material/styles";
+import theme from "../../themes/theme";
+import UserContext from "../context/UserContext";
+import AuthOtp from "./AuthOtp";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockApiRequest = jest.fn();
+jest.mock("../../../public/lib/apiOperations", () => ({
+  ...jest.requireActual("../../../public/lib/apiOperations"),
+  apiRequest: (...args: any[]) => mockApiRequest(...args),
+}));
+
+jest.useFakeTimers();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockSignIn = jest.fn();
+
+function makeContextValue(locale: "en" | "de" = "en") {
+  return {
+    locale,
+    user: null,
+    locales: [] as any,
+    pathName: "/",
+    donationGoals: [],
+    hubUrl: "",
+    signIn: mockSignIn,
+  };
+}
+
+function renderAuthOtp({
+  email = "user@example.com",
+  onBack = jest.fn(),
+  onSuccess = jest.fn(),
+  hubUrl = undefined,
+  locale = "en" as "en" | "de",
+} = {}) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <UserContext.Provider value={makeContextValue(locale) as any}>
+        <AuthOtp email={email} onBack={onBack} onSuccess={onSuccess} hubUrl={hubUrl} />
+      </UserContext.Provider>
+    </ThemeProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, "error").mockImplementation(() => {});
+  window.sessionStorage.clear();
+  // Default: request-token succeeds
+  mockApiRequest.mockResolvedValue({ data: { session_key: "test-session-key" } });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllTimers();
+});
+
+describe("AuthOtp", () => {
+  describe("rendering", () => {
+    it("renders heading and subtitle", async () => {
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalled());
+      expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+      expect(screen.getByText(/user@example\.com/)).toBeInTheDocument();
+    });
+
+    it("renders the code input field", async () => {
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalled());
+      expect(screen.getByRole("textbox", { name: /6-digit code/i })).toBeInTheDocument();
+    });
+
+    it("renders verify, resend, and back buttons", async () => {
+      renderAuthOtp();
+      // Wait for request-token to complete and countdown to show
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /resend code \(60s\)/i })).toBeInTheDocument();
+      });
+      expect(screen.getByRole("button", { name: /verify/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /back/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("request-token on mount", () => {
+    it("calls request-token with the email on mount", async () => {
+      renderAuthOtp({ email: "test@example.com" });
+      await waitFor(() => {
+        expect(mockApiRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: "post",
+            url: "/api/auth/request-token",
+            payload: { email: "test@example.com" },
+          })
+        );
+      });
+    });
+
+    it("stores session_key in sessionStorage", async () => {
+      renderAuthOtp();
+      await waitFor(() => {
+        expect(sessionStorage.getItem("auth_session_key")).toBe("test-session-key");
+      });
+    });
+
+    it("starts resend countdown after token is requested", async () => {
+      renderAuthOtp();
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /resend code \(60s\)/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("code input", () => {
+    it("only accepts numeric characters", async () => {
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalled());
+      const input = screen.getByRole("textbox", { name: /6-digit code/i });
+      fireEvent.change(input, { target: { value: "abc123def" } });
+      expect(input).toHaveValue("123");
+    });
+
+    it("limits input to 6 characters", async () => {
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalled());
+      const input = screen.getByRole("textbox", { name: /6-digit code/i });
+      fireEvent.change(input, { target: { value: "1234567890" } });
+      expect(input).toHaveValue("123456");
+    });
+
+    it("verify button is disabled when code is fewer than 6 digits", async () => {
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalled());
+      const input = screen.getByRole("textbox", { name: /6-digit code/i });
+      fireEvent.change(input, { target: { value: "123" } });
+      expect(screen.getByRole("button", { name: /verify/i })).toBeDisabled();
+    });
+
+    it("verify button is enabled when 6 digits are entered", async () => {
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalled());
+      const input = screen.getByRole("textbox", { name: /6-digit code/i });
+      fireEvent.change(input, { target: { value: "123456" } });
+      expect(screen.getByRole("button", { name: /verify/i })).not.toBeDisabled();
+    });
+  });
+
+  describe("submit success", () => {
+    it("calls verify-token and then signIn on success", async () => {
+      mockApiRequest
+        .mockResolvedValueOnce({ data: { session_key: "test-session-key" } }) // request-token
+        .mockResolvedValueOnce({
+          data: { token: "auth-token", expiry: "2099-01-01", user: { id: 1 } },
+        }); // verify-token
+
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
+
+      const input = screen.getByRole("textbox", { name: /6-digit code/i });
+      fireEvent.change(input, { target: { value: "123456" } });
+      fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+      await waitFor(() => {
+        expect(mockApiRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: "post",
+            url: "/api/auth/verify-token",
+            payload: { session_key: "test-session-key", code: "123456" },
+          })
+        );
+        expect(mockSignIn).toHaveBeenCalledWith("auth-token", "2099-01-01");
+      });
+    });
+
+    it("calls onSuccess callback on success", async () => {
+      const onSuccess = jest.fn();
+      mockApiRequest
+        .mockResolvedValueOnce({ data: { session_key: "test-session-key" } })
+        .mockResolvedValueOnce({
+          data: { token: "auth-token", expiry: "2099-01-01", user: { id: 1 } },
+        });
+
+      renderAuthOtp({ onSuccess });
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
+
+      const input = screen.getByRole("textbox", { name: /6-digit code/i });
+      fireEvent.change(input, { target: { value: "123456" } });
+      fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith();
+      });
+    });
+  });
+
+  describe("submit failure", () => {
+    it("shows expired error and starts resend countdown", async () => {
+      mockApiRequest.mockResolvedValueOnce({ data: { session_key: "key" } }).mockRejectedValueOnce({
+        response: { data: { detail: "Code expired. Please request a new one." } },
+      });
+
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
+
+      // Advance past initial countdown
+      act(() => {
+        jest.advanceTimersByTime(60000);
+      });
+
+      const input = screen.getByRole("textbox", { name: /6-digit code/i });
+      fireEvent.change(input, { target: { value: "000000" } });
+      fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(/expired/i);
+      });
+    });
+
+    it("shows too many attempts error and starts resend countdown", async () => {
+      mockApiRequest.mockResolvedValueOnce({ data: { session_key: "key" } }).mockRejectedValueOnce({
+        response: { data: { detail: "Too many attempts. Please request a new code." } },
+      });
+
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
+      act(() => {
+        jest.advanceTimersByTime(60000);
+      });
+
+      const input = screen.getByRole("textbox", { name: /6-digit code/i });
+      fireEvent.change(input, { target: { value: "000000" } });
+      fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(/too many attempts/i);
+      });
+    });
+
+    it("shows invalid code error", async () => {
+      mockApiRequest
+        .mockResolvedValueOnce({ data: { session_key: "key" } })
+        .mockRejectedValueOnce({ response: { data: { detail: "Invalid code." } } });
+
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
+      act(() => {
+        jest.advanceTimersByTime(60000);
+      });
+
+      const input = screen.getByRole("textbox", { name: /6-digit code/i });
+      fireEvent.change(input, { target: { value: "000000" } });
+      fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(/incorrect code/i);
+      });
+    });
+
+    it("clears the code input after failure", async () => {
+      mockApiRequest
+        .mockResolvedValueOnce({ data: { session_key: "key" } })
+        .mockRejectedValueOnce({ response: { data: { detail: "Invalid code." } } });
+
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
+      act(() => {
+        jest.advanceTimersByTime(60000);
+      });
+
+      const input = screen.getByRole("textbox", { name: /6-digit code/i });
+      fireEvent.change(input, { target: { value: "000000" } });
+      fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+      await waitFor(() => {
+        expect(input).toHaveValue("");
+      });
+    });
+  });
+
+  describe("resend", () => {
+    it("resend button is disabled during countdown", async () => {
+      renderAuthOtp();
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /resend code \(60s\)/i })).toBeDisabled();
+      });
+    });
+
+    it("resend button becomes enabled after countdown expires", async () => {
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
+
+      act(() => {
+        jest.advanceTimersByTime(60000);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /^resend code$/i })).not.toBeDisabled();
+      });
+    });
+
+    it("clicking resend calls request-token again and clears input", async () => {
+      mockApiRequest
+        .mockResolvedValueOnce({ data: { session_key: "key1" } })
+        .mockResolvedValueOnce({ data: { session_key: "key2" } });
+
+      renderAuthOtp();
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
+
+      // Enter some code
+      const input = screen.getByRole("textbox", { name: /6-digit code/i });
+      fireEvent.change(input, { target: { value: "123456" } });
+
+      // Advance past countdown
+      act(() => {
+        jest.advanceTimersByTime(60000);
+      });
+
+      const resendBtn = await screen.findByRole("button", { name: /^resend code$/i });
+      fireEvent.click(resendBtn);
+
+      await waitFor(() => {
+        expect(mockApiRequest).toHaveBeenCalledTimes(2);
+        expect(sessionStorage.getItem("auth_session_key")).toBe("key2");
+        expect(input).toHaveValue("");
+      });
+    });
+  });
+
+  describe("back navigation", () => {
+    it("calls onBack when Back button is clicked", async () => {
+      const onBack = jest.fn();
+      renderAuthOtp({ onBack });
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalled());
+
+      fireEvent.click(screen.getByRole("button", { name: /back/i }));
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+
+    it("removes session_key from sessionStorage when Back is clicked", async () => {
+      renderAuthOtp();
+      await waitFor(() => {
+        expect(sessionStorage.getItem("auth_session_key")).toBe("test-session-key");
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /back/i }));
+      expect(sessionStorage.getItem("auth_session_key")).toBeNull();
+    });
+  });
+});

--- a/frontend/src/components/auth/AuthOtp.tsx
+++ b/frontend/src/components/auth/AuthOtp.tsx
@@ -1,29 +1,211 @@
-import { useContext } from "react";
-import { Button, Typography } from "@mui/material";
+import React, { useContext, useEffect, useRef, useState } from "react";
+import { Alert, Box, Button, CircularProgress, TextField, Typography } from "@mui/material";
+import { apiRequest } from "../../../public/lib/apiOperations";
 import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
 
-interface AuthOtpPlaceholderProps {
+const SESSION_KEY = "auth_session_key";
+const RESEND_COOLDOWN_SECONDS = 60;
+
+interface AuthOtpProps {
   email: string;
   onBack: () => void;
+  onSuccess?: () => void;
   hubUrl?: string;
 }
 
-export default function AuthOtp({ email, onBack, hubUrl }: AuthOtpPlaceholderProps) {
-  const { locale } = useContext(UserContext);
-  const texts = getTexts({ page: "profile", locale: locale, hubName: hubUrl });
+export default function AuthOtp({ email, onBack, onSuccess, hubUrl }: AuthOtpProps) {
+  const { locale, signIn } = useContext(UserContext);
+  const texts = getTexts({ page: "profile", locale, hubName: hubUrl });
+
+  const [sessionKey, setSessionKey] = useState<string | null>(null);
+  const [code, setCode] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSendingCode, setIsSendingCode] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [resendCountdown, setResendCountdown] = useState<number | null>(null);
+
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startCountdown = () => {
+    if (countdownRef.current) clearInterval(countdownRef.current);
+    setResendCountdown(RESEND_COOLDOWN_SECONDS);
+    countdownRef.current = setInterval(() => {
+      setResendCountdown((prev) => {
+        if (prev !== null && prev > 1) return prev - 1;
+        clearInterval(countdownRef.current!);
+        countdownRef.current = null;
+        return null;
+      });
+    }, 1000);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (countdownRef.current) clearInterval(countdownRef.current);
+    };
+  }, []);
+
+  const requestToken = async () => {
+    setIsSendingCode(true);
+    try {
+      const response = await apiRequest({
+        method: "post",
+        url: "/api/auth/request-token",
+        payload: { email },
+        locale,
+      });
+      const key = response.data.session_key;
+      setSessionKey(key);
+      sessionStorage.setItem(SESSION_KEY, key);
+      startCountdown();
+    } catch (err: any) {
+      if (err.response?.status === 429) {
+        setErrorMessage(
+          texts.please_wait_before_requesting_a_new_code ||
+            "Please wait before requesting a new code."
+        );
+      } else {
+        setErrorMessage(
+          texts.connection_error_please_try_again || "Connection error. Please try again."
+        );
+      }
+    } finally {
+      setIsSendingCode(false);
+    }
+  };
+
+  // Request token on mount
+  useEffect(() => {
+    requestToken();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!sessionKey || code.length !== 6) return;
+
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await apiRequest({
+        method: "post",
+        url: "/api/auth/verify-token",
+        payload: { session_key: sessionKey, code },
+        locale,
+      });
+
+      const { token, expiry } = response.data;
+      await signIn(token, expiry);
+      if (onSuccess) onSuccess();
+    } catch (err: any) {
+      const detail: string = err.response?.data?.detail ?? "";
+      setCode("");
+
+      if (detail.toLowerCase().includes("expired")) {
+        setErrorMessage(
+          texts.this_code_has_expired_please_request_a_new_one ||
+            "This code has expired. Please request a new one."
+        );
+        startCountdown();
+      } else if (detail.toLowerCase().includes("too many")) {
+        setErrorMessage(
+          texts.too_many_attempts_please_request_a_new_code ||
+            "Too many attempts. Please request a new code."
+        );
+        startCountdown();
+      } else if (detail.toLowerCase().includes("invalid")) {
+        setErrorMessage(
+          texts.incorrect_code_please_try_again || "Incorrect code. Please try again."
+        );
+      } else if (err.response?.status === 429) {
+        setErrorMessage(
+          texts.please_wait_before_requesting_a_new_code ||
+            "Please wait before requesting a new code."
+        );
+      } else {
+        setErrorMessage(
+          texts.connection_error_please_try_again || "Connection error. Please try again."
+        );
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleResend = async () => {
+    setCode("");
+    setErrorMessage(null);
+    await requestToken();
+  };
+
+  const handleBack = () => {
+    sessionStorage.removeItem(SESSION_KEY);
+    onBack();
+  };
+
+  const isResendDisabled = resendCountdown !== null && resendCountdown > 0;
+  const resendLabel = isResendDisabled
+    ? `${texts.resend_code || "Resend code"} (${resendCountdown}s)`
+    : texts.resend_code || "Resend code";
 
   return (
-    <div>
-      <Typography variant="h1" style={{ fontWeight: "bold", marginBottom: 16 }}>
-        {texts.enter_code || "Enter your code"}
+    <Box component="form" onSubmit={handleSubmit} aria-busy={isLoading}>
+      <Typography variant="h1" style={{ fontWeight: "bold", marginBottom: 8 }}>
+        {texts.enter_your_code || "Enter your code"}
       </Typography>
       <Typography variant="body1" style={{ marginBottom: 24 }}>
-        {texts.otp_entry_coming_soon || "OTP code entry coming soon (US-6). Your email: " + email}
+        {texts.we_sent_a_code_to || "We sent a 6-digit code to"} {email}
       </Typography>
-      <Button variant="outlined" onClick={onBack}>
+
+      {errorMessage && (
+        <Alert severity="error" role="alert" style={{ marginBottom: 16 }}>
+          {errorMessage}
+        </Alert>
+      )}
+
+      <TextField
+        label={texts.enter_your_code || "Enter your code"}
+        value={code}
+        onChange={(e) => setCode(e.target.value.replace(/\D/g, "").slice(0, 6))}
+        inputProps={{
+          maxLength: 6,
+          inputMode: "numeric",
+          autoComplete: "one-time-code",
+          "aria-label": "6-digit code",
+        }}
+        fullWidth
+        disabled={isLoading || isSendingCode}
+        style={{ marginBottom: 16 }}
+        autoFocus
+      />
+
+      <Button
+        type="submit"
+        variant="contained"
+        color="primary"
+        fullWidth
+        disabled={isLoading || isSendingCode || code.length !== 6}
+        style={{ marginBottom: 12 }}
+      >
+        {isLoading ? <CircularProgress size={24} color="inherit" /> : texts.verify || "Verify"}
+      </Button>
+
+      <Button
+        variant="text"
+        fullWidth
+        onClick={handleResend}
+        disabled={isResendDisabled || isLoading || isSendingCode}
+        aria-disabled={isResendDisabled}
+        style={{ marginBottom: 8 }}
+      >
+        {isSendingCode ? <CircularProgress size={20} color="inherit" /> : resendLabel}
+      </Button>
+
+      <Button variant="outlined" fullWidth onClick={handleBack} disabled={isLoading}>
         {texts.back || "Back"}
       </Button>
-    </div>
+    </Box>
   );
 }

--- a/frontend/src/components/auth/AuthPasswordLogin.tsx
+++ b/frontend/src/components/auth/AuthPasswordLogin.tsx
@@ -6,12 +6,14 @@ import UserContext from "../context/UserContext";
 interface AuthPasswordLoginPlaceholderProps {
   email: string;
   onBack: () => void;
+  onSuccess?: () => void;
   hubUrl?: string;
 }
 
 export default function AuthPasswordLogin({
   email,
   onBack,
+  onSuccess: _onSuccess,
   hubUrl,
 }: AuthPasswordLoginPlaceholderProps) {
   const { locale } = useContext(UserContext);

--- a/frontend/src/components/auth/AuthSignupStep.tsx
+++ b/frontend/src/components/auth/AuthSignupStep.tsx
@@ -6,10 +6,16 @@ import UserContext from "../context/UserContext";
 interface AuthSignupStepPlaceholderProps {
   email: string;
   onBack: () => void;
+  onSuccess?: () => void;
   hubUrl?: string;
 }
 
-export default function AuthSignupStep({ email, onBack, hubUrl }: AuthSignupStepPlaceholderProps) {
+export default function AuthSignupStep({
+  email,
+  onBack,
+  onSuccess: _onSuccess,
+  hubUrl,
+}: AuthSignupStepPlaceholderProps) {
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "profile", locale: locale, hubName: hubUrl });
 


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Implements #1920
