### PR TITLE
Extend user api to support new auth flows

### DIFF
--- a/backend/climateconnect_api/serializers/user.py
+++ b/backend/climateconnect_api/serializers/user.py
@@ -316,11 +316,14 @@ class DonorProfileSerializer(UserProfileStubSerializer):
 
 class UserAccountSettingsSerializer(serializers.ModelSerializer):
     email = serializers.SerializerMethodField()
+    has_password = serializers.SerializerMethodField()
 
     class Meta:
         model = UserProfile
         fields = (
             "email",
+            "auth_method",
+            "has_password",
             "send_newsletter",
             "url_slug",
             "email_on_private_chat_message",
@@ -339,6 +342,9 @@ class UserAccountSettingsSerializer(serializers.ModelSerializer):
 
     def get_email(self, obj):
         return obj.user.email
+
+    def get_has_password(self, obj):
+        return obj.user.has_usable_password()
 
 
 class UserProfileSitemapEntrySerializer(serializers.ModelSerializer):

--- a/backend/climateconnect_api/tests/test_registered_event_slugs.py
+++ b/backend/climateconnect_api/tests/test_registered_event_slugs.py
@@ -47,7 +47,7 @@ class PersonalProfileRegisteredEventSlugsTest(APITestCase):
         self.mock_cache = self.cache_patcher.start()
         self.mock_cache.keys.return_value = []
         self.mock_cache.delete_many.return_value = None
-        
+
         # Create test user and profile
         self.user = User.objects.create_user(
             username="testuser",

--- a/backend/climateconnect_api/tests/test_settings_views.py
+++ b/backend/climateconnect_api/tests/test_settings_views.py
@@ -1,0 +1,108 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+
+from climateconnect_api.models import UserProfile
+
+URL = reverse("user-account-settings-api")
+
+
+def _make_user(email, auth_method="password", password="testpass123"):
+    user = User.objects.create_user(username=email, email=email, password=password)
+    if password == "":
+        user.set_unusable_password()
+        user.save()
+    UserProfile.objects.create(user=user, auth_method=auth_method)
+    return user
+
+
+class UserAccountSettingsGetTest(TestCase):
+    def test_get_includes_auth_method_password(self):
+        user = _make_user("password@example.com", auth_method="password")
+        self.client.force_login(user)
+        response = self.client.get(URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["auth_method"], "password")
+
+    def test_get_includes_auth_method_otp(self):
+        user = _make_user("otp@example.com", auth_method="otp")
+        self.client.force_login(user)
+        response = self.client.get(URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["auth_method"], "otp")
+
+    def test_get_has_password_true_when_user_has_password(self):
+        user = _make_user("haspass@example.com", password="testpass123")
+        self.client.force_login(user)
+        response = self.client.get(URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.json()["has_password"])
+
+    def test_get_has_password_false_when_user_has_no_password(self):
+        user = _make_user("nopass@example.com", password="")
+        self.client.force_login(user)
+        response = self.client.get(URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.json()["has_password"])
+
+
+class UserAccountSettingsPostTest(TestCase):
+    def test_post_updates_auth_method_to_otp(self):
+        user = _make_user("update@example.com", auth_method="password")
+        self.client.force_login(user)
+        response = self.client.post(
+            URL, {"auth_method": "otp"}, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user.user_profile.refresh_from_db()
+        self.assertEqual(user.user_profile.auth_method, "otp")
+
+    def test_post_updates_auth_method_to_password_when_user_has_password(self):
+        user = _make_user("update@example.com", auth_method="otp")
+        self.client.force_login(user)
+        response = self.client.post(
+            URL, {"auth_method": "password"}, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user.user_profile.refresh_from_db()
+        self.assertEqual(user.user_profile.auth_method, "password")
+
+    def test_post_rejects_password_auth_method_when_no_password(self):
+        user = _make_user("nopass@example.com", auth_method="otp", password="")
+        self.client.force_login(user)
+        response = self.client.post(
+            URL, {"auth_method": "password"}, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("no password is set", response.json()["message"])
+        user.user_profile.refresh_from_db()
+        self.assertEqual(user.user_profile.auth_method, "otp")
+
+    def test_post_rejects_invalid_auth_method(self):
+        user = _make_user("invalid@example.com")
+        self.client.force_login(user)
+        response = self.client.post(
+            URL, {"auth_method": "magic"}, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("auth_method must be either", response.json()["message"])
+
+    def test_post_without_auth_method_leaves_it_unchanged(self):
+        user = _make_user("unchanged@example.com", auth_method="otp")
+        self.client.force_login(user)
+        response = self.client.post(URL, {}, content_type="application/json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user.user_profile.refresh_from_db()
+        self.assertEqual(user.user_profile.auth_method, "otp")
+
+    def test_post_ignores_has_password_in_payload(self):
+        user = _make_user("ignore@example.com")
+        self.client.force_login(user)
+        response = self.client.post(
+            URL, {"has_password": False}, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user.user_profile.refresh_from_db()
+        # has_password is computed, so it should still be True
+        self.assertTrue(user.has_usable_password())

--- a/backend/climateconnect_api/views/settings_views.py
+++ b/backend/climateconnect_api/views/settings_views.py
@@ -45,6 +45,29 @@ class UserAccountSettingsView(APIView):
                     "Incorrect password. Did you forget your password?"
                 )
 
+        if "auth_method" in request.data:
+            auth_method = request.data["auth_method"]
+            if auth_method not in [
+                UserProfile.AuthMethod.PASSWORD,
+                UserProfile.AuthMethod.OTP,
+            ]:
+                return Response(
+                    {"message": "auth_method must be either 'password' or 'otp'."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if (
+                auth_method == UserProfile.AuthMethod.PASSWORD
+                and not user.has_usable_password()
+            ):
+                return Response(
+                    {
+                        "message": "Cannot set auth_method to password because no password is set."
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            user.user_profile.auth_method = auth_method
+            user.user_profile.save()
+
         if "email" in request.data:
             new_verification_key = uuid.uuid4()
             user.user_profile.verification_key = new_verification_key

--- a/backend/location/tests/test_utility.py
+++ b/backend/location/tests/test_utility.py
@@ -314,7 +314,7 @@ class TestGetLocation(TestCase):
         self.assertEqual(global_location.osm_type, "R")
         self.assertEqual(global_location.osm_class, "global")
         self.assertEqual(global_location.osm_class_type, "global")
-        
+
     @override_settings(
         ENABLE_LEGACY_LOCATION_FORMAT="True", CELERY_TASK_ALWAYS_EAGER=True
     )
@@ -399,7 +399,6 @@ class TestGetLocationWithRange(TestCase):
         # The returned geometry must be the buffered multi_polygon, not a Point.
         # Note: .buffer() on a MultiPolygon may return a Polygon (when the buffer
         # collapses multiple rings into one), so we accept any area geometry here.
-        
 
         self.assertIsInstance(result["location"], GEOSGeometry)
         self.assertNotIsInstance(result["location"], Point)


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Implements #1927
