### PR TITLE
Fix Profile page causes API calls that get a server 500 error

### DIFF
--- a/frontend/pages/profiles/[profileUrl].tsx
+++ b/frontend/pages/profiles/[profileUrl].tsx
@@ -19,6 +19,20 @@ import { parseProjectStubs } from "../../public/lib/parsingOperations";
 export async function getServerSideProps(ctx) {
   const { auth_token } = NextCookies(ctx);
   const profileUrl = encodeURI(ctx.query.profileUrl);
+  // Prevent API calls with undefined slug
+  // see https://github.com/climateconnect/climateconnect/issues/1796
+  if (profileUrl === "undefined") {
+    return {
+      props: nullifyUndefinedValues({
+        profile: null,
+        organizations: null,
+        projects: null,
+        projectTypes: null,
+        hubUrl: ctx.query.hub,
+        hubThemeData: null,
+      }),
+    };
+  }
   const hubUrl = ctx.query.hub;
   const [profile, organizations, projects, projectTypes, hubThemeData] = await Promise.all([
     getProfileByUrlIfExists(profileUrl, auth_token, ctx.locale),

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -545,7 +545,7 @@ function NormalScreenLinks({
             </Fragment>
           );
       })}
-      {loggedInUser && (
+      {loggedInUser && loggedInUser.url_slug && (
         <LoggedInNormalScreen
           loggedInUser={loggedInUser}
           handleLogout={handleLogout}
@@ -839,6 +839,7 @@ function NarrowScreenLinks({
                 }
               })}
               {loggedInUser &&
+                loggedInUser.url_slug &&
                 getLoggedInLinks({ loggedInUser: loggedInUser, texts: texts, queryString }).map(
                   (link, index) => {
                     const Icon: any = link.iconForDrawer;


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Fix for #1796
