### PR TITLE
Fix display of text fr new users on OTP verify screen

### DIFF
--- a/frontend/public/texts/profile_texts.tsx
+++ b/frontend/public/texts/profile_texts.tsx
@@ -410,6 +410,12 @@ export default function getProfileTexts({ profile, hubName, locale }) {
       en: "We found your account and sent a 6-digit code to {email}.",
       de: "Wir haben deinen Account gefunden und an {email} einen 6-stelligen Code gesendet.",
     },
+    we_sent_a_code_to_new_user: {
+      en:
+        "We created your account and sent a 6-digit code to {email} to verify your email address.",
+      de:
+        "Wir haben deinen Account erstellt und einen 6-stelligen Code an {email} gesendet, um deine E-Mail-Adresse zu bestätigen.",
+    },
     verify: {
       en: "Verify",
       de: "Bestätigen",

--- a/frontend/src/components/auth/AuthOtp.tsx
+++ b/frontend/src/components/auth/AuthOtp.tsx
@@ -235,7 +235,10 @@ export default function AuthOtp({
         </>
       )}
       <Typography variant="body1" style={{ marginBottom: 24 }}>
-        {texts.we_sent_a_code_to.replace("{email}", email)}
+        {(userType === "new" ? texts.we_sent_a_code_to_new_user : texts.we_sent_a_code_to).replace(
+          "{email}",
+          email
+        )}
       </Typography>
 
       {errorMessage && (

--- a/frontend/src/components/auth/SignupPersonalInfoStep.test.tsx
+++ b/frontend/src/components/auth/SignupPersonalInfoStep.test.tsx
@@ -60,12 +60,8 @@ jest.mock("../../../public/texts/texts", () => {
     last_name_is_required: "Last name is required",
     location: "Location",
     please_choose_one_of_the_location_options: "Please choose a valid location from the dropdown",
-    i_agree_to_the: "I agree to the",
-    terms_of_service: "terms of service",
-    and: "and",
-    privacy_policy: "privacy policy",
-    and_would_like_to_receive_emails:
-      "and would like to receive emails about updates, news and interesting projects",
+    agree_to_tos_and_privacy_policy_with_email_consent:
+      "I agree to the terms of service and privacy policy and would like to receive emails about updates, news and interesting projects",
     you_must_accept_terms_and_privacy_policy:
       "You must accept the terms of service and privacy policy",
     back: "Back",

--- a/frontend/src/components/project/EventRegistrationModal.tsx
+++ b/frontend/src/components/project/EventRegistrationModal.tsx
@@ -132,6 +132,7 @@ export default function EventRegistrationModal({
   // Authentication flow state
   const [email, setEmail] = useState("");
   const [authStep, setAuthStep] = useState<"email" | "password" | "otp" | "signup">("email");
+  const [isNewUserOtp, setIsNewUserOtp] = useState(false);
 
   // Render the appropriate content based on authentication and registration state
   const renderContent = () => {
@@ -191,6 +192,7 @@ export default function EventRegistrationModal({
     } else if (status === "returning_password") {
       setAuthStep("password");
     } else if (status === "returning_otp") {
+      setIsNewUserOtp(false);
       setAuthStep("otp");
     }
   };
@@ -260,7 +262,10 @@ export default function EventRegistrationModal({
               // Return to email entry; forgot-password flow is not supported inside the modal.
               setAuthStep("email");
             }}
-            onSwitchToOtp={() => setAuthStep("otp")}
+            onSwitchToOtp={() => {
+              setIsNewUserOtp(false);
+              setAuthStep("otp");
+            }}
             hubUrl={project.hubUrl}
             showHeader={false}
           />
@@ -277,6 +282,7 @@ export default function EventRegistrationModal({
             }}
             hubUrl={project.hubUrl}
             showHeader={false}
+            userType={isNewUserOtp ? "new" : "returning"}
           />
         );
       case "signup":
@@ -284,7 +290,10 @@ export default function EventRegistrationModal({
           <AuthSignupStep
             email={email}
             onBack={() => setAuthStep("email")}
-            onSignupComplete={() => setAuthStep("otp")}
+            onSignupComplete={() => {
+              setIsNewUserOtp(true);
+              setAuthStep("otp");
+            }}
             hubUrl={project.hubUrl}
             skipInterests={true}
             showHeader={false}


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Fix for #1952
