### PR TITLE
changed label to register now when user log out

### DIFF
--- a/frontend/src/components/project/ProjectPageRoot.tsx
+++ b/frontend/src/components/project/ProjectPageRoot.tsx
@@ -164,6 +164,13 @@ export default function ProjectPageRoot({
   const hasUserAttended = hasAttended ?? false;
   const isAdminCancelled = adminCancelled ?? false;
 
+  useEffect(() => {
+    // Clear registration state when auth context switches to logged out.
+    if (!user) {
+      setIsUserRegistered(false);
+    }
+  }, [user]);
+
   // Get registered event slugs from user profile for sidebar projects
   const registeredEventSlugs = useMemo(() => {
     return new Set(user?.registered_event_slugs || []);


### PR DESCRIPTION
## Description
This PR addresses issue [1954](https://github.com/climateconnect/climateconnect/issues/1954)
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
