### PR TITLE
Improve signup step in event registration

### DIFF
--- a/backend/organization/utility/email.py
+++ b/backend/organization/utility/email.py
@@ -2,7 +2,7 @@ import logging
 import re
 from organization.utility.project import get_project_name
 from organization.utility.organization import get_organization_name
-
+from location.utility import get_translated_location_name
 
 from climateconnect_api.utility.email_setup import send_email
 from climateconnect_api.utility.translation import get_user_lang_code, get_user_lang_url
@@ -415,16 +415,23 @@ def get_organiser_name(project, lang_code: str) -> str:
     return ""
 
 
-def get_location_name(project) -> str:
+def get_location_name(project, lang_code=None) -> str:
     """
     Return a human-readable location string for an event.
 
-    Returns ``"Online"`` for online events, ``Location.name`` when a location
-    row exists, or an empty string when neither applies.
+    Returns ``"Online"`` for online events, the translated location name when
+    a location row exists and *lang_code* is provided, or ``Location.name`` as
+    a fallback.  Returns an empty string when neither applies.
+
+    Expects ``location.translate_location__language`` to be pre-fetched (via
+    ``prefetch_related("loc__translate_location__language")``) to avoid N+1
+    queries when *lang_code* is passed.
     """
     if project.is_online:
         return "Online"
     if project.loc:
+        if lang_code:
+            return get_translated_location_name(project.loc, lang_code)
         return project.loc.name
     return ""
 
@@ -578,6 +585,7 @@ def send_event_registration_confirmation_to_user(user, project):
             ``select_related("loc", "language")`` and
             ``prefetch_related(
                 "translation_project__language",
+                "loc__translate_location__language",
                 "project_parent__parent_organization__language",
                 "project_parent__parent_organization__translation_org__language",
                 "project_parent__parent_user__user_profile",
@@ -605,7 +613,7 @@ def send_event_registration_confirmation_to_user(user, project):
         ),
         "StartDate": start_date_str,
         "OrganiserName": get_organiser_name(project, lang_code),
-        "LocationName": get_location_name(project),
+        "LocationName": get_location_name(project, lang_code),
     }
 
     send_email(

--- a/frontend/public/texts/profile_texts.tsx
+++ b/frontend/public/texts/profile_texts.tsx
@@ -494,6 +494,12 @@ export default function getProfileTexts({ profile, hubName, locale }) {
       de:
         "Du hast noch keinen persönlichen Account. Verrate uns bitte, wie du heißt und wo do wohnst, um loszulegen. Du hast die Möglichkeit, eine Organisation zu erstellen/hinzuzufügen, sobald du dich angemeldet hast.",
     },
+    event_signup_step_1_headline: {
+      en:
+        "You don't have an account yet. Please enter tell us your name and where you live to register for this event.",
+      de:
+        "Du hast noch keinen persönlichen Account. Verrate uns bitte wie du heißt und in welcher Stadt du wohnst, um dich zur Veranstaltung anzumelden.",
+    },
     email_cannot_be_changed: {
       en: "This is the email you'll use to log in",
       de: "Dies ist die E-Mail-Adresse, mit der du dich einloggst",

--- a/frontend/src/components/auth/AuthSignupStep.tsx
+++ b/frontend/src/components/auth/AuthSignupStep.tsx
@@ -14,6 +14,7 @@ interface AuthSignupStepProps {
   hubUrl?: string;
   skipInterests?: boolean;
   showHeader?: boolean;
+  isEventSignup?: boolean;
 }
 
 type SignupStep = "personal_info" | "interests";
@@ -32,6 +33,7 @@ export default function AuthSignupStep({
   hubUrl,
   skipInterests = false,
   showHeader = true,
+  isEventSignup = false,
 }: AuthSignupStepProps) {
   const { locale, ReactGA } = useContext(UserContext);
   const texts = getTexts({ page: "profile", locale: locale, hubName: hubUrl });
@@ -135,6 +137,7 @@ export default function AuthSignupStep({
         hubUrl={hubUrl}
         isLoading={isCreatingAccount}
         showHeader={showHeader}
+        isEventSignup={isEventSignup}
       />
     );
   }

--- a/frontend/src/components/auth/SignupPersonalInfoStep.tsx
+++ b/frontend/src/components/auth/SignupPersonalInfoStep.tsx
@@ -30,6 +30,7 @@ interface SignupPersonalInfoStepProps {
   hubUrl?: string;
   isLoading?: boolean;
   showHeader?: boolean;
+  isEventSignup?: boolean;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -52,6 +53,7 @@ export default function SignupPersonalInfoStep({
   hubUrl,
   isLoading = false,
   showHeader = true,
+  isEventSignup = false,
 }: SignupPersonalInfoStepProps) {
   const { locale, ReactGA } = useContext(UserContext);
   const texts = getTexts({ page: "profile", locale: locale, hubName: hubUrl });
@@ -166,6 +168,10 @@ export default function SignupPersonalInfoStep({
     });
   };
 
+  const headlineText = isEventSignup
+    ? texts.event_signup_step_1_headline
+    : texts.signup_step_1_headline;
+
   return (
     <Box>
       {showHeader && (
@@ -180,7 +186,7 @@ export default function SignupPersonalInfoStep({
       )}
 
       <Typography variant="body1" sx={{ mb: 2 }}>
-        {texts.signup_step_1_headline}
+        {headlineText}
       </Typography>
 
       {/* Email field - read-only */}

--- a/frontend/src/components/project/EventRegistrationModal.tsx
+++ b/frontend/src/components/project/EventRegistrationModal.tsx
@@ -309,6 +309,7 @@ export default function EventRegistrationModal({
             hubUrl={project.hubUrl}
             skipInterests={true}
             showHeader={false}
+            isEventSignup={true}
           />
         );
       default:


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Two improvements for event management v1:
- localize place name in confirmation email
-  show a different text on signup step when using it in the event registration
