### PR TITLE
Update ProjectRegistrationsContent.tsx

### DIFF
--- a/frontend/src/components/project/ProjectRegistrationsContent.tsx
+++ b/frontend/src/components/project/ProjectRegistrationsContent.tsx
@@ -103,6 +103,7 @@ type ToolbarProps = {
   emailGuestsLabel?: string;
   csvFileName: string;
   csvFields: string[];
+  printFields: string[];
 };
 
 function CustomColumnMenu(props: GridColumnMenuProps) {
@@ -117,6 +118,7 @@ function RegistrationsToolbar({
   emailGuestsLabel,
   csvFileName,
   csvFields,
+  printFields,
 }: ToolbarProps) {
   return (
     <GridToolbarContainer sx={{ display: "flex", alignItems: "center", gap: 1, p: 1 }}>
@@ -145,7 +147,7 @@ function RegistrationsToolbar({
       )}
       <GridToolbarExport
         csvOptions={{ fileName: csvFileName, fields: csvFields }}
-        printOptions={{ hideFooter: true, hideToolbar: true }}
+        printOptions={{ hideFooter: true, hideToolbar: true, fields: printFields }}
       />
     </GridToolbarContainer>
   );
@@ -596,6 +598,7 @@ export default function ProjectRegistrationsContent({
                     "cancelled_at",
                     "cancelled_at_iso",
                   ],
+                  printFields: ["user_first_name", "user_last_name"],
                 } as ToolbarProps,
                 footer: {
                   total: participants.length,


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Minor change to event registration based on feedback. Makes the printable fields configurable and excludes some fields that add no value in the print. 
