### PR TITLE
Do not show register button on draft events

### DIFF
--- a/frontend/src/utils/eventRegistrationHelpers.test.ts
+++ b/frontend/src/utils/eventRegistrationHelpers.test.ts
@@ -44,6 +44,19 @@ describe("shouldShowRegisterButton", () => {
 
       expect(result).toBe(false);
     });
+
+    it("should return false when project is a draft", () => {
+      const project = {
+        is_draft: true,
+        registration_config: {
+          status: "open",
+        },
+      } as Project;
+
+      const result = shouldShowRegisterButton(true, project);
+
+      expect(result).toBe(false);
+    });
   });
 
   describe("when registration should be shown", () => {
@@ -262,6 +275,14 @@ describe("getRegistrationUIState", () => {
 
     it('returns hidden when status is "ended" and user is not registered', () => {
       expect(getRegistrationUIState(true, endedProject)).toBe("hidden");
+    });
+
+    it("returns hidden when project is a draft", () => {
+      const draftProject = {
+        is_draft: true,
+        registration_config: { status: "open" },
+      } as Project;
+      expect(getRegistrationUIState(true, draftProject, false, false, false)).toBe("hidden");
     });
   });
 

--- a/frontend/src/utils/eventRegistrationHelpers.ts
+++ b/frontend/src/utils/eventRegistrationHelpers.ts
@@ -12,6 +12,7 @@ export const shouldShowRegisterButton = (
 ): boolean => {
   return !!(
     isEventRegistrationEnabled &&
+    !project.is_draft &&
     project.registration_config &&
     project.registration_config.status !== "ended"
   );
@@ -84,6 +85,9 @@ export const getRegistrationUIState = (
   adminCancelled?: boolean
 ): RegistrationUIState => {
   if (!isEventRegistrationEnabled || !project.registration_config) return "hidden";
+
+  // Draft projects should never show a registration button
+  if (project.is_draft) return "hidden";
 
   // Priority 1 — always show attended label, even if status is ended
   if (hasAttended) return "attended";


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Small fix. Don't show event register button when the event is still in draft mode.