### PR TITLE
Edit custom event registration fields

### DIFF
--- a/backend/organization/serializers/event_registration.py
+++ b/backend/organization/serializers/event_registration.py
@@ -757,20 +757,136 @@ class EditEventRegistrationConfigSerializer(EventRegistrationConfigBaseSerialize
                 raise serializers.ValidationError(
                     {"fields": "Field order values must be unique within the event."}
                 )
-            # Verify that all provided field IDs actually belong to this config.
+            # Verify submitted field IDs belong to this config; also enforce
+            # answer-lock: immutable text properties cannot change once registrants
+            # have submitted answers referencing that field or option.
             submitted_ids = [f["id"] for f in fields_data if f.get("id") is not None]
             if submitted_ids and self.instance:
-                existing_ids = set(
-                    self.instance.fields.filter(id__in=submitted_ids).values_list(
-                        "id", flat=True
-                    )
-                )
-                unknown = set(submitted_ids) - existing_ids
+                existing_fields = {
+                    f.id: f
+                    for f in self.instance.fields.filter(
+                        id__in=submitted_ids
+                    ).prefetch_related("options")
+                }
+                unknown = set(submitted_ids) - set(existing_fields.keys())
                 if unknown:
                     raise serializers.ValidationError(
                         {
                             "fields": f"Field IDs not found on this event: {sorted(unknown)}"
                         }
                     )
+
+                for i, field_data in enumerate(fields_data):
+                    field_id = field_data.get("id")
+                    if field_id is None:
+                        continue
+                    existing_field = existing_fields.get(field_id)
+                    if existing_field is None:
+                        continue
+
+                    has_field_answers = RegistrationFieldAnswer.objects.filter(
+                        field=existing_field
+                    ).exists()
+
+                    if has_field_answers:
+                        field_type = (
+                            field_data.get("field_type") or existing_field.field_type
+                        )
+                        settings = field_data.get("settings")
+
+                        if (
+                            field_type == RegistrationFieldType.CHECKBOX
+                            and settings is not None
+                        ):
+                            submitted_desc = settings.get("description")
+                            stored_desc = (existing_field.settings or {}).get(
+                                "description", ""
+                            )
+                            if (
+                                submitted_desc is not None
+                                and submitted_desc != stored_desc
+                            ):
+                                raise serializers.ValidationError(
+                                    {
+                                        "fields": {
+                                            i: {
+                                                "settings": {
+                                                    "description": (
+                                                        "Cannot change description after "
+                                                        "registrants have answered this field."
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+                                )
+
+                        elif (
+                            field_type == RegistrationFieldType.OPTION_SELECT
+                            and settings is not None
+                        ):
+                            submitted_title = settings.get("title")
+                            stored_title = (existing_field.settings or {}).get(
+                                "title", ""
+                            )
+                            if (
+                                submitted_title is not None
+                                and submitted_title != stored_title
+                            ):
+                                raise serializers.ValidationError(
+                                    {
+                                        "fields": {
+                                            i: {
+                                                "settings": {
+                                                    "title": (
+                                                        "Cannot change question title after "
+                                                        "registrants have answered this field."
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+                                )
+
+                    # Per-option answer-lock: option title is immutable once any
+                    # registrant has selected that option.
+                    options_data = field_data.get("options")
+                    if options_data is not None:
+                        existing_options = {
+                            o.id: o for o in existing_field.options.all()
+                        }
+                        for j, opt_data in enumerate(options_data):
+                            opt_id = opt_data.get("id")
+                            if opt_id is None:
+                                continue
+                            existing_opt = existing_options.get(opt_id)
+                            if existing_opt is None:
+                                continue
+                            has_opt_answers = RegistrationFieldAnswer.objects.filter(
+                                value_option=existing_opt
+                            ).exists()
+                            if has_opt_answers:
+                                submitted_opt_title = opt_data.get("title")
+                                if (
+                                    submitted_opt_title is not None
+                                    and submitted_opt_title != existing_opt.title
+                                ):
+                                    raise serializers.ValidationError(
+                                        {
+                                            "fields": {
+                                                i: {
+                                                    "options": {
+                                                        j: {
+                                                            "title": (
+                                                                "Cannot change option title "
+                                                                "after registrants have "
+                                                                "selected it."
+                                                            )
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    )
 
         return attrs

--- a/backend/organization/serializers/registration_field.py
+++ b/backend/organization/serializers/registration_field.py
@@ -2,6 +2,7 @@ from django.db import transaction
 from rest_framework import serializers
 
 from climateconnect_api.utility.html import sanitize_html
+from organization.models.event_registration import RegistrationFieldAnswer
 from organization.models.registration_field import (
     RegistrationField,
     RegistrationFieldOption,
@@ -56,17 +57,26 @@ class RegistrationFieldOptionSerializer(serializers.ModelSerializer):
     id is optional on write:
       - Absent → create new option.
       - Present → identify an existing option for update.
+
+    has_answers (read-only): True if any RegistrationFieldAnswer row references
+    this option as value_option. The frontend uses this to lock the title field.
     """
 
     id = serializers.IntegerField(required=False, allow_null=True)
+    has_answers = serializers.SerializerMethodField()
 
     class Meta:
         model = RegistrationFieldOption
-        fields = ["id", "title", "order"]
+        fields = ["id", "title", "order", "has_answers"]
         extra_kwargs = {
             "title": {"max_length": 200},
             "order": {"min_value": 0},
         }
+
+    def get_has_answers(self, obj):
+        if not obj.pk:
+            return False
+        return RegistrationFieldAnswer.objects.filter(value_option=obj).exists()
 
 
 # ---------------------------------------------------------------------------
@@ -91,6 +101,10 @@ class RegistrationFieldSerializer(serializers.ModelSerializer):
     options is optional on write. When absent, existing options are left
     untouched (only relevant for updates). When present (even as []), the
     full option set for the field is synced.
+
+    has_answers (read-only): True if any RegistrationFieldAnswer row references
+    this field. The frontend uses this to lock text inputs (checkbox description,
+    option select title) that cannot be changed once answers exist.
     """
 
     id = serializers.IntegerField(required=False, allow_null=True)
@@ -99,14 +113,28 @@ class RegistrationFieldSerializer(serializers.ModelSerializer):
     )
     settings = serializers.JSONField(required=False)
     options = RegistrationFieldOptionSerializer(many=True, required=False)
+    has_answers = serializers.SerializerMethodField()
 
     class Meta:
         model = RegistrationField
-        fields = ["id", "field_type", "order", "is_required", "settings", "options"]
+        fields = [
+            "id",
+            "field_type",
+            "order",
+            "is_required",
+            "settings",
+            "options",
+            "has_answers",
+        ]
         extra_kwargs = {
             "order": {"min_value": 0},
             "is_required": {"required": False, "default": False},
         }
+
+    def get_has_answers(self, obj):
+        if not obj.pk:
+            return False
+        return RegistrationFieldAnswer.objects.filter(field=obj).exists()
 
     def validate(self, attrs):
         field_id = attrs.get("id")

--- a/backend/organization/serializers/registration_field.py
+++ b/backend/organization/serializers/registration_field.py
@@ -240,9 +240,7 @@ def sync_fields(registration_config, fields_data):
                     RegistrationFieldOption.objects.create(field=field, **opt_data)
 
     # Delete fields absent from the submitted array.
-    # Guard: RegistrationFieldAnswer does not exist yet in Phase 4a, so all
-    # deletions are safe. The follow-up registrant task will add answer-based
-    # protection before Phase 4a ships.
+    # RegistrationFieldAnswer rows are removed automatically via DB CASCADE.
     to_delete = [fid for fid in existing if fid not in incoming_ids]
     if to_delete:
         RegistrationField.objects.filter(id__in=to_delete).delete()

--- a/backend/organization/tests/test_event_registration_custom_fields.py
+++ b/backend/organization/tests/test_event_registration_custom_fields.py
@@ -31,7 +31,9 @@ from climateconnect_api.models import Language, Role
 from location.models import Location
 from organization.models import Project, ProjectMember, ProjectStatus
 from organization.models.event_registration import (
+    EventRegistration,
     EventRegistrationConfig,
+    RegistrationFieldAnswer,
     RegistrationStatus,
 )
 from organization.models.registration_field import (
@@ -730,3 +732,281 @@ class TestEditRegistrationConfigFields(_CustomFieldsBase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertTrue(RegistrationField.objects.filter(id=field.id).exists())
         self.assertEqual(self.er.fields.count(), 1)
+
+
+# ---------------------------------------------------------------------------
+# PATCH — answer-cascade and draft-vs-publish validation
+# ---------------------------------------------------------------------------
+
+
+class TestEditFieldsDeleteWithAnswers(_CustomFieldsBase):
+    """
+    Tests 7 and 7b — deleting a field / option that already has registrant
+    answers must succeed; the DB CASCADE removes dependent answers automatically.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.registrant = User.objects.create_user(
+            username="registrant_cf", password="testpassword"
+        )
+        self.registration = EventRegistration.objects.create(
+            user=self.registrant,
+            registration_config=self.er,
+        )
+
+    def _create_field(self, field_type="checkbox", order=0, settings=None, options=None):
+        if settings is None:
+            settings = (
+                {"description": "<p>Test</p>"} if field_type == "checkbox" else {}
+            )
+        field = RegistrationField.objects.create(
+            registration_config=self.er,
+            field_type=field_type,
+            order=order,
+            is_required=False,
+            settings=settings,
+        )
+        if options:
+            for opt in options:
+                RegistrationFieldOption.objects.create(field=field, **opt)
+        return field
+
+    @tag("custom_fields", "registration_config")
+    def test_delete_field_with_answers_cascades_and_returns_200(self):
+        """Test 7 — deleting a field that has registrant answers succeeds; answers cascade-deleted."""
+        field = self._create_field(order=0)
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_boolean=True,
+        )
+
+        self.client.login(username="organiser_cf", password="testpassword")
+        response = self.client.patch(
+            self.patch_url,
+            {"fields": []},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.assertFalse(RegistrationField.objects.filter(id=field.id).exists())
+        self.assertFalse(
+            RegistrationFieldAnswer.objects.filter(registration=self.registration).exists()
+        )
+
+    @tag("custom_fields", "registration_config")
+    def test_delete_option_with_answers_cascades_and_returns_200(self):
+        """Test 7b — deleting an option that has answers succeeds; answers cascade-deleted."""
+        field = self._create_field(
+            field_type="option_select",
+            order=0,
+            options=[{"title": "Option A", "order": 0}, {"title": "Option B", "order": 1}],
+        )
+        option_a = field.options.get(title="Option A")
+        option_b = field.options.get(title="Option B")
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option_a,
+        )
+
+        self.client.login(username="organiser_cf", password="testpassword")
+        # Keep the field, keep option_b, drop option_a
+        response = self.client.patch(
+            self.patch_url,
+            {
+                "fields": [
+                    {
+                        "id": field.id,
+                        "order": 0,
+                        "options": [{"id": option_b.id, "title": "Option B", "order": 0}],
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.assertFalse(RegistrationFieldOption.objects.filter(id=option_a.id).exists())
+        self.assertFalse(
+            RegistrationFieldAnswer.objects.filter(
+                registration=self.registration, value_option=option_a
+            ).exists()
+        )
+        self.assertTrue(RegistrationFieldOption.objects.filter(id=option_b.id).exists())
+
+
+class TestEditFieldsDraftVsPublish(_CustomFieldsBase):
+    """
+    Tests 3, 4, 10, 11, 12, 13 for the PATCH path.
+
+    Tests 3 and 10 use the published project from _CustomFieldsBase (is_draft=False).
+    Tests 4 and 11 use a separate draft project created here.
+    Tests 12 and 13 verify server-side sanitization on PATCH.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Draft project + config for is_draft=True tests
+        self.draft_event = Project.objects.create(
+            name="Draft Custom Fields Event",
+            url_slug="draft-custom-fields-event",
+            is_active=True,
+            is_draft=True,
+            status=self.project_status,
+            language=self.default_language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=10),
+            end_date=timezone.now() + timedelta(days=60),
+        )
+        self.draft_er = EventRegistrationConfig.objects.create(
+            project=self.draft_event,
+            status=RegistrationStatus.OPEN,
+        )
+        ProjectMember.objects.create(
+            user=self.organiser, project=self.draft_event, role=self.admin_role
+        )
+        self.draft_patch_url = reverse(
+            "organization:edit-registration-config",
+            kwargs={"url_slug": self.draft_event.url_slug},
+        )
+
+    # ── Test 3: option_select 0 options on publish → 400 ────────────────────
+
+    @tag("custom_fields", "registration_config")
+    def test_option_select_no_options_on_publish_rejected_via_patch(self):
+        """Test 3 (PATCH) — option_select with 0 options rejected on published project."""
+        self.client.login(username="organiser_cf", password="testpassword")
+        response = self.client.patch(
+            self.patch_url,
+            {
+                "fields": [
+                    {
+                        "field_type": "option_select",
+                        "order": 0,
+                        "settings": {},
+                        "options": [],
+                    }
+                ]
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # ── Test 4: option_select 0 options on draft → accepted ─────────────────
+
+    @tag("custom_fields", "registration_config")
+    def test_option_select_no_options_on_draft_accepted_via_patch(self):
+        """Test 4 (PATCH) — option_select with 0 options accepted on draft project."""
+        self.client.login(username="organiser_cf", password="testpassword")
+        response = self.client.patch(
+            self.draft_patch_url,
+            {
+                "fields": [
+                    {
+                        "field_type": "option_select",
+                        "order": 0,
+                        "settings": {},
+                        "options": [],
+                    }
+                ]
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
+    # ── Test 10: checkbox empty description on publish → 400 ─────────────────
+
+    @tag("custom_fields", "registration_config")
+    def test_checkbox_empty_description_on_publish_rejected_via_patch(self):
+        """Test 10 (PATCH) — empty checkbox description rejected on published project."""
+        self.client.login(username="organiser_cf", password="testpassword")
+        response = self.client.patch(
+            self.patch_url,
+            {
+                "fields": [
+                    {
+                        "field_type": "checkbox",
+                        "order": 0,
+                        "settings": {"description": ""},
+                    }
+                ]
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # ── Test 11: checkbox empty description on draft → accepted ──────────────
+
+    @tag("custom_fields", "registration_config")
+    def test_checkbox_empty_description_on_draft_accepted_via_patch(self):
+        """Test 11 (PATCH) — empty checkbox description accepted on draft project."""
+        self.client.login(username="organiser_cf", password="testpassword")
+        response = self.client.patch(
+            self.draft_patch_url,
+            {
+                "fields": [
+                    {
+                        "field_type": "checkbox",
+                        "order": 0,
+                        "settings": {"description": ""},
+                    }
+                ]
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
+    # ── Test 12: unknown settings key stripped via PATCH ──────────────────────
+
+    @tag("custom_fields", "registration_config")
+    def test_checkbox_unknown_settings_key_stripped_via_patch(self):
+        """Test 12 (PATCH) — unknown key in settings is stripped on PATCH."""
+        self.client.login(username="organiser_cf", password="testpassword")
+        response = self.client.patch(
+            self.draft_patch_url,
+            {
+                "fields": [
+                    {
+                        "field_type": "checkbox",
+                        "order": 0,
+                        "settings": {
+                            "description": "<p>Valid</p>",
+                            "rogue": "should-be-stripped",
+                        },
+                    }
+                ]
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        field = RegistrationField.objects.get(registration_config=self.draft_er)
+        self.assertNotIn("rogue", field.settings)
+        self.assertIn("description", field.settings)
+
+    # ── Test 13: HTML sanitization via PATCH ─────────────────────────────────
+
+    @tag("custom_fields", "registration_config")
+    def test_checkbox_xss_stripped_via_patch(self):
+        """Test 13 (PATCH) — disallowed HTML tags stripped on PATCH."""
+        self.client.login(username="organiser_cf", password="testpassword")
+        response = self.client.patch(
+            self.draft_patch_url,
+            {
+                "fields": [
+                    {
+                        "field_type": "checkbox",
+                        "order": 0,
+                        "settings": {
+                            "description": "<p>Safe</p><script>alert(1)</script>"
+                        },
+                    }
+                ]
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        field = RegistrationField.objects.get(registration_config=self.draft_er)
+        self.assertNotIn("script", field.settings["description"])
+        self.assertIn("<p>Safe</p>", field.settings["description"])

--- a/backend/organization/tests/test_event_registration_custom_fields.py
+++ b/backend/organization/tests/test_event_registration_custom_fields.py
@@ -755,7 +755,9 @@ class TestEditFieldsDeleteWithAnswers(_CustomFieldsBase):
             registration_config=self.er,
         )
 
-    def _create_field(self, field_type="checkbox", order=0, settings=None, options=None):
+    def _create_field(
+        self, field_type="checkbox", order=0, settings=None, options=None
+    ):
         if settings is None:
             settings = (
                 {"description": "<p>Test</p>"} if field_type == "checkbox" else {}
@@ -792,7 +794,9 @@ class TestEditFieldsDeleteWithAnswers(_CustomFieldsBase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertFalse(RegistrationField.objects.filter(id=field.id).exists())
         self.assertFalse(
-            RegistrationFieldAnswer.objects.filter(registration=self.registration).exists()
+            RegistrationFieldAnswer.objects.filter(
+                registration=self.registration
+            ).exists()
         )
 
     @tag("custom_fields", "registration_config")
@@ -801,7 +805,10 @@ class TestEditFieldsDeleteWithAnswers(_CustomFieldsBase):
         field = self._create_field(
             field_type="option_select",
             order=0,
-            options=[{"title": "Option A", "order": 0}, {"title": "Option B", "order": 1}],
+            options=[
+                {"title": "Option A", "order": 0},
+                {"title": "Option B", "order": 1},
+            ],
         )
         option_a = field.options.get(title="Option A")
         option_b = field.options.get(title="Option B")
@@ -820,7 +827,9 @@ class TestEditFieldsDeleteWithAnswers(_CustomFieldsBase):
                     {
                         "id": field.id,
                         "order": 0,
-                        "options": [{"id": option_b.id, "title": "Option B", "order": 0}],
+                        "options": [
+                            {"id": option_b.id, "title": "Option B", "order": 0}
+                        ],
                     }
                 ]
             },
@@ -828,7 +837,9 @@ class TestEditFieldsDeleteWithAnswers(_CustomFieldsBase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        self.assertFalse(RegistrationFieldOption.objects.filter(id=option_a.id).exists())
+        self.assertFalse(
+            RegistrationFieldOption.objects.filter(id=option_a.id).exists()
+        )
         self.assertFalse(
             RegistrationFieldAnswer.objects.filter(
                 registration=self.registration, value_option=option_a
@@ -1010,3 +1021,240 @@ class TestEditFieldsDraftVsPublish(_CustomFieldsBase):
         field = RegistrationField.objects.get(registration_config=self.draft_er)
         self.assertNotIn("script", field.settings["description"])
         self.assertIn("<p>Safe</p>", field.settings["description"])
+
+
+# ---------------------------------------------------------------------------
+# PATCH — has_answers flag and answer-lock validation
+# ---------------------------------------------------------------------------
+
+
+class TestAnswerLock(_CustomFieldsBase):
+    """
+    Tests 14-19 — answer-aware read-only restrictions and has_answers flag.
+
+    When a field or option has existing registrant answers:
+      - GET response includes has_answers=true
+      - Changing immutable text properties (checkbox description, option_select
+        title, option title) is rejected with 400
+      - Non-text changes (is_required, order) are still allowed
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.registrant = User.objects.create_user(
+            username="registrant_lock", password="testpassword"
+        )
+        self.registration = EventRegistration.objects.create(
+            user=self.registrant,
+            registration_config=self.er,
+        )
+
+    def _create_checkbox_field(self, description="<p>Agree</p>", order=0):
+        return RegistrationField.objects.create(
+            registration_config=self.er,
+            field_type="checkbox",
+            order=order,
+            is_required=False,
+            settings={"description": description},
+        )
+
+    def _create_option_select_field(self, title="Meal?", order=0, options=None):
+        field = RegistrationField.objects.create(
+            registration_config=self.er,
+            field_type="option_select",
+            order=order,
+            is_required=False,
+            settings={"title": title},
+        )
+        if options:
+            for opt in options:
+                RegistrationFieldOption.objects.create(field=field, **opt)
+        return field
+
+    # ── Test 14: has_answers=true in GET response ────────────────────────────
+
+    @tag("custom_fields", "registration_config")
+    def test_has_answers_true_in_get_response(self):
+        """Test 14 — has_answers=true on fields/options that have answers."""
+        field = self._create_checkbox_field()
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_boolean=True,
+        )
+
+        option_field = self._create_option_select_field(
+            order=1, options=[{"title": "A", "order": 0}, {"title": "B", "order": 1}]
+        )
+        option_a = option_field.options.get(title="A")
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=option_field,
+            value_option=option_a,
+        )
+
+        self.client.login(username="organiser_cf", password="testpassword")
+        # GET via PATCH with no fields key — response includes fields
+        response = self.client.patch(self.patch_url, {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        returned_fields = {f["id"]: f for f in response.data["fields"]}
+
+        # Checkbox field: has_answers=true
+        self.assertTrue(returned_fields[field.id]["has_answers"])
+
+        # option_select field: has_answers=true; option A locked, option B not
+        self.assertTrue(returned_fields[option_field.id]["has_answers"])
+        opt_map = {o["id"]: o for o in returned_fields[option_field.id]["options"]}
+        self.assertTrue(opt_map[option_a.id]["has_answers"])
+        option_b = option_field.options.get(title="B")
+        self.assertFalse(opt_map[option_b.id]["has_answers"])
+
+    # ── Test 15: checkbox description change rejected ────────────────────────
+
+    @tag("custom_fields", "registration_config")
+    def test_checkbox_description_change_rejected_when_has_answers(self):
+        """Test 15 — changing checkbox description rejected when field has answers."""
+        field = self._create_checkbox_field(description="<p>Original</p>")
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_boolean=True,
+        )
+
+        self.client.login(username="organiser_cf", password="testpassword")
+        response = self.client.patch(
+            self.patch_url,
+            {
+                "fields": [
+                    {
+                        "id": field.id,
+                        "order": 0,
+                        "settings": {"description": "<p>Changed</p>"},
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("fields", response.data)
+
+    # ── Test 16: option_select title change rejected ─────────────────────────
+
+    @tag("custom_fields", "registration_config")
+    def test_option_select_title_change_rejected_when_has_answers(self):
+        """Test 16 — changing option_select question title rejected when field has answers."""
+        field = self._create_option_select_field(
+            title="Original?", options=[{"title": "Yes", "order": 0}]
+        )
+        option = field.options.first()
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option,
+        )
+
+        self.client.login(username="organiser_cf", password="testpassword")
+        response = self.client.patch(
+            self.patch_url,
+            {
+                "fields": [
+                    {
+                        "id": field.id,
+                        "order": 0,
+                        "settings": {"title": "Changed?"},
+                        "options": [{"id": option.id, "title": "Yes", "order": 0}],
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("fields", response.data)
+
+    # ── Test 17: answered option title change rejected ───────────────────────
+
+    @tag("custom_fields", "registration_config")
+    def test_answered_option_title_change_rejected(self):
+        """Test 17 — changing title of a selected option rejected when has answers."""
+        field = self._create_option_select_field(
+            title="Meal?", options=[{"title": "Vegan", "order": 0}]
+        )
+        option = field.options.first()
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option,
+        )
+
+        self.client.login(username="organiser_cf", password="testpassword")
+        response = self.client.patch(
+            self.patch_url,
+            {
+                "fields": [
+                    {
+                        "id": field.id,
+                        "order": 0,
+                        "settings": {"title": "Meal?"},
+                        "options": [
+                            {"id": option.id, "title": "Plant-based", "order": 0}
+                        ],
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("fields", response.data)
+
+    # ── Test 18: is_required and order changes allowed with has_answers ───────
+
+    @tag("custom_fields", "registration_config")
+    def test_is_required_and_order_changes_allowed_when_has_answers(self):
+        """Test 18 — is_required and order can change even when field has answers."""
+        field = self._create_checkbox_field(description="<p>Agree</p>")
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_boolean=True,
+        )
+
+        self.client.login(username="organiser_cf", password="testpassword")
+        response = self.client.patch(
+            self.patch_url,
+            {
+                "fields": [
+                    {
+                        "id": field.id,
+                        "order": 0,
+                        "is_required": True,
+                        # description unchanged — not sending settings at all
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        field.refresh_from_db()
+        self.assertTrue(field.is_required)
+
+    # ── Test 19: has_answers=false when no answers ───────────────────────────
+
+    @tag("custom_fields", "registration_config")
+    def test_has_answers_false_when_no_answers(self):
+        """Test 19 — has_answers=false for fields and options without any answers."""
+        field = self._create_option_select_field(options=[{"title": "Yes", "order": 0}])
+        option = field.options.first()
+
+        self.client.login(username="organiser_cf", password="testpassword")
+        response = self.client.patch(self.patch_url, {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        returned_field = next(f for f in response.data["fields"] if f["id"] == field.id)
+        self.assertFalse(returned_field["has_answers"])
+        opt_data = next(o for o in returned_field["options"] if o["id"] == option.id)
+        self.assertFalse(opt_data["has_answers"])

--- a/backend/organization/views/event_registration_views.py
+++ b/backend/organization/views/event_registration_views.py
@@ -485,9 +485,10 @@ class EditRegistrationConfigView(APIView):
             )
 
         # ── 4. Validate and save ─────────────────────────────────────────────
-        # is_draft is read from the request body so the client can save partial
-        # field data without triggering publish-time validation.
-        is_draft = request.data.get("is_draft", False) in (True, "true", "True", "1", 1)
+        # Derive is_draft from the project's stored state, not the request body.
+        # Draft events skip publish-time field validation (e.g. empty checkbox
+        # description) without requiring the frontend to pass extra state.
+        is_draft = project.is_draft
         serializer = EditEventRegistrationConfigSerializer(
             rc,
             data=request.data,

--- a/doc/spec/20260512_0725_edit_event_registration_custom_fields.md
+++ b/doc/spec/20260512_0725_edit_event_registration_custom_fields.md
@@ -1,9 +1,9 @@
 # Organiser Edits Event Registration Custom Fields (Phase 4a — Edit)
 
-**Status**: READY FOR IMPLEMENTATION
+**Status**: IN PROGRESS — SPEC GAP IDENTIFIED (see Log 2026-05-19 #2)
 **Type**: Feature
 **Date and time created**: 2026-05-12 07:25
-**Date and time updated**: 2026-05-19 07:30
+**Date and time updated**: 2026-05-19
 **GitHub Issue**: [#1961](https://github.com/climateconnect/climateconnect/issues/1961)
 **Epic**: [`EPIC_event_registration.md`](./EPIC_event_registration.md)
 **Related Specs**:
@@ -31,6 +31,12 @@ This task extends the organiser-side custom fields infrastructure to the **edit*
   - Fields can be **reordered** via up/down controls.
 - Changes are saved through the existing edit endpoints, gated behind the same feature toggle (`REGISTRATION_CUSTOM_FIELDS`).
 - Deleting a field or option that already has registrant answers must be handled safely: the backend cascades the deletion, and the frontend warns the organiser with a confirmation dialog.
+- **Answer-aware edit restrictions** — once a field has at least one registrant answer, certain text properties become immutable (to preserve answer integrity):
+  - **Checkbox**: `settings.description` is read-only; cannot be changed via the editor or accepted by the backend.
+  - **Option select**: `settings.title` (the question label) is read-only.
+  - **Option select — existing options**: individual option `title` values are read-only. Options may still be reordered or deleted (with confirmation), and new options may be added.
+  - These restrictions apply **only when answers exist**. If no registrant has yet answered a field/option, all text properties remain freely editable.
+  - The `is_required` flag remains freely editable regardless of answers (see note in Non-Functional Requirements).
 
 **Explicitly Out of Scope (this task):**
 - **Registrant-side flow** — rendering custom fields on the public registration form and capturing answers — delivered in [#1960](https://github.com/climateconnect/climateconnect/issues/1960).
@@ -45,12 +51,18 @@ This task extends the organiser-side custom fields infrastructure to the **edit*
 - **Validation on publish**: when `is_draft=false`, all required field settings must be validated. Draft events skip full validation — consistent with the draft-mode contract established in [#1820](https://github.com/climateconnect/climateconnect/issues/1820).
 - **No breaking changes** to existing API contracts.
 - **Toggle gate**: all new frontend UI must be gated behind `REGISTRATION_CUSTOM_FIELDS`. This toggle is separate from `EVENT_REGISTRATION` (dev ✅, staging ✅, production ❌). All four Phase 4a tasks (create, edit, organiser view, registrant-side follow-up) must be validated on staging together before the toggle is flipped.
-- **Delete guard**: deletion of fields and options is **allowed** even when registrant answers exist because the `RegistrationFieldAnswer` model already uses `CASCADE` on both `field` and `value_option` foreign keys. The backend simply performs the deletion and the database cascade removes dependent answers automatically. The frontend must show a **confirmation dialog** before deleting a field or an option that was previously saved (has an `id`).
+- **Delete guard**: deletion of fields and options is **allowed** even when registrant answers exist because the `RegistrationFieldAnswer` model already uses `CASCADE` on both `field` and `value_option` foreign keys. The backend simply performs the deletion and the database cascade removes dependent answers automatically. The frontend must show a **confirmation dialog** before deleting a field or option that has `has_answers: true`.
+- **Edit guard (text properties)**: when `has_answers: true` on a field or option, the backend must reject modifications to protected text properties and the frontend must show them as read-only. See the `has_answers` surface in the API section.
 - **Required flag**: a field can be changed from **required → not required** and from **not required → required** at any time, regardless of existing registrations or answers. The organiser accepts responsibility for any incomplete data; the backend does not block this change.
 
 ### AI Agent Insights and Additions
 
-- **Backend already partially implemented**: `EditEventRegistrationConfigSerializer` and `EditRegistrationConfigView` already support reading and writing nested `fields` (the create task wired them in). What remains is adding the **answer-aware guard logic** inside `EditEventRegistrationConfigSerializer.validate()` and updating `sync_fields()` / `_sync_options()` to remove their Phase-4a-only placeholder comments.
+- **Backend `has_answers` flag required**: `RegistrationFieldSerializer` must expose a read-only `has_answers: bool` on each field (True if any `RegistrationFieldAnswer` row references that field). `RegistrationFieldOptionSerializer` must expose `has_answers: bool` on each option (True if any `RegistrationFieldAnswer` row references that option's `value_option`). These flags are included in `GET /api/projects/{slug}/` and in the `EditEventRegistrationConfigSerializer` PATCH response.
+- **Backend write guard for text properties**: `sync_fields()` / `_sync_options()` (or a pre-save validation step in `EditEventRegistrationConfigSerializer.validate()`) must enforce that when a field or option has existing answers, the protected text properties are not changed. Specifically:
+  - Checkbox field with answers: reject if the submitted `settings.description` differs from the stored value.
+  - Option select field with answers: reject if the submitted `settings.title` differs from the stored value.
+  - Option with answers: reject if the submitted `title` differs from the stored value.
+  Return `400 Bad Request` with a field-level error message. (Changing `is_required` and `order` is always permitted.)
 - **Frontend — single edit surface**: the custom field builder is added to the **dedicated registration settings modal** (`EditEventRegistrationModal.tsx`), not the full project edit page. The full project edit page (`/editProject/[projectUrl].tsx`) is reserved for core project settings (name, description, dates, team members, collaborators). Registration settings — including custom fields — are managed separately via the modal that `PATCH`es `/api/projects/{slug}/registration-config/`.
 - **Modal state management**: `EditEventRegistrationModal` uses local form state (useState for each field) and constructs a flat payload object for the PATCH. To support nested `fields`, the modal must:
   - Load existing `fields` from `eventRegistration.fields` (already returned by `GET /api/projects/{slug}/`) into local state.
@@ -58,8 +70,8 @@ This task extends the organiser-side custom fields infrastructure to the **edit*
   - Include the full `fields` array in the PATCH payload.
   - Handle backend validation errors mapped to individual field items (e.g. `fields[0].settings.description`).
 - **Error handling**: DRF nested serializer errors return keys like `fields[0][settings][description]`. The modal's error parser must flatten these into a usable structure for the UI. The existing modal already handles flat field-level errors (`max_participants`, `registration_end_date`, `status`, `general`); it should be extended to parse nested `fields` errors and pass them down to the field builder components.
-- **Component reuse**: the same sub-components created for the create flow (`RegistrationFieldList`, `RegistrationFieldEditor`, `CheckboxFieldEditor`, `OptionSelectFieldEditor`) should be reused. They already accept a controlled `fields` array and an `onChange` callback, so they can be dropped into `EditEventRegistrationModal.tsx` without modification.
-- **Confirmation dialog strategy**: the frontend does not need a `has_answers` flag from the API. Any field or option that has an `id` (i.e., it was previously persisted) might have answers. The simplest reliable guard is to show a confirmation dialog whenever the user attempts to delete a persisted field or option. The dialog copy should warn that existing registrant data will be lost.
+- **Component reuse with read-only support**: the sub-components (`RegistrationFieldList`, `RegistrationFieldEditor`, `CheckboxFieldEditor`, `OptionSelectFieldEditor`) need minor extension to accept a `readOnly` signal for answer-locked text properties. `CheckboxFieldEditor` must disable its description input when `has_answers=true`. `OptionSelectFieldEditor` must disable the title input when the field `has_answers=true` and disable individual option title inputs when the option `has_answers=true`.
+- **Confirmation dialog strategy** (revised): show a confirmation dialog when the user attempts to delete a field or option where `has_answers=true`. For fields/options without answers (`has_answers=false`), delete immediately without confirmation, even if the item is persisted (has an `id`).
 - **No new migrations**: `RegistrationField`, `RegistrationFieldOption`, and `RegistrationFieldAnswer` tables all exist from prior tasks.
 
 ---
@@ -120,9 +132,37 @@ Sync rules (applied atomically in one transaction by `sync_fields()`):
 - Item **without `id`** → create as new field
 - Existing field **absent from the array** → delete (with `CASCADE` on `RegistrationFieldAnswer` via DB FK)
 
-**Read — fields in project detail** (already handled by create task):
+**Read — fields in project detail** (already handled by create task; this task adds `has_answers`):
 
 `GET /api/projects/{slug}/` → `event_registration_config.fields` array returned, ordered by `order`.
+
+Each field object now includes:
+
+```json
+{
+  "id": 1,
+  "field_type": "checkbox",
+  "order": 0,
+  "is_required": true,
+  "settings": { "description": "<p>I agree to the terms.</p>" },
+  "has_answers": true,
+  "options": []
+}
+```
+
+Each option object (for option_select fields) now includes:
+
+```json
+{
+  "id": 10,
+  "title": "Vegetarian",
+  "order": 0,
+  "has_answers": false
+}
+```
+
+`has_answers: true` on a **field** means at least one `RegistrationFieldAnswer` row references that field.
+`has_answers: true` on an **option** means at least one `RegistrationFieldAnswer` row has `value_option` pointing to that option.
 
 **Validation (publish, `is_draft=false`)**:
 - Checkbox: `settings.description` must be non-empty and non-whitespace HTML.
@@ -131,37 +171,43 @@ Sync rules (applied atomically in one transaction by `sync_fields()`):
 
 **Validation (draft)**: all publish validations are skipped.
 
+**Answer-lock validation** (applies regardless of draft state, on any PATCH that touches an existing field/option):
+- Checkbox field with `has_answers=true`: reject if submitted `settings.description` differs from the stored value.
+- Option select field with `has_answers=true`: reject if submitted `settings.title` differs from the stored value.
+- Option with `has_answers=true`: reject if submitted `title` differs from the stored value.
+
 **Error responses**:
 
 | Status | Condition |
 |--------|-----------|
-| `400` | 6th field; option select with 0 options on publish; missing required settings; nested field validation error |
+| `400` | 6th field; option select with 0 options on publish; missing required settings; nested field validation error; attempt to change a locked text property on a field or option that has answers |
 | `401` | Unauthenticated |
 | `403` | Not organiser or team admin |
 | `404` | Project not found or no registration config |
 
 ### Backend
 
-- **`organization/serializers/event_registration.py`** — remove the placeholder comment in `sync_fields()` that says "RegistrationFieldAnswer does not exist yet" — no code change needed there because the DB `CASCADE` already handles answer deletion. No other backend changes are required; `is_required` may be toggled freely at any time.
-- **`organization/serializers/registration_field.py`** — optionally clean up the `_sync_options()` and `sync_fields()` docstrings to remove Phase-4a-only placeholders. No functional change needed because `CASCADE` on the `RegistrationFieldAnswer` FKs is already configured in the model.
-- **`organization/views/event_registration_views.py`** — change `EditRegistrationConfigView.patch()` to derive `is_draft` from `project.is_draft` instead of reading it from the request body. The backend already knows the project's draft state, so the frontend does not need to send `is_draft` explicitly. This ensures draft events skip publish-time field validation (e.g. empty checkbox description) without requiring the modal to pass extra state.
+- **`organization/serializers/event_registration.py`** — ✅ done (placeholder comment removed).
+- **`organization/serializers/registration_field.py`** — needs the following changes (not yet implemented):
+  - `RegistrationFieldSerializer`: add read-only `has_answers` `SerializerMethodField` — `True` if `RegistrationFieldAnswer.objects.filter(field=instance).exists()`.
+  - `RegistrationFieldOptionSerializer`: add read-only `has_answers` `SerializerMethodField` — `True` if `RegistrationFieldAnswer.objects.filter(value_option=instance).exists()`.
+  - `_sync_options()`: before updating an option that has answers, check if `title` changed; raise `ValidationError` if so.
+  - `sync_fields()`: before updating a field that has answers, check if the locked text property changed (`description` for checkbox, `title` in settings for option_select); raise `ValidationError` if so.
+- **`organization/views/event_registration_views.py`** — ✅ done (`is_draft` now derived from `project.is_draft`).
 - **No new view file and no new URL patterns**.
 
 ### Frontend
 
-- **`src/components/project/EditEventRegistrationModal.tsx`** — extend the modal with:
-  - Local state for `fields` (loaded from `eventRegistration.fields` on open).
-  - Render `RegistrationFieldList` (toggle-gated behind `isEnabled("REGISTRATION_CUSTOM_FIELDS")`) below the existing max_participants / end_date / status / notify_admins fields.
-  - Include `fields` in the PATCH payload sent to `/api/projects/{slug}/registration-config/`.
-  - Parse nested `fields` errors from the backend response and pass them to the field builder components.
-  - Show a **confirmation dialog** when the user attempts to delete a field or option that has an `id` (i.e., was previously saved). The dialog warns that existing registrant answers will be permanently deleted.
-- **Reused components** (all created in the create task; this task wires them into the edit modal):
-  - `RegistrationFieldList.tsx`
-  - `RegistrationFieldEditor.tsx`
-  - `CheckboxFieldEditor.tsx`
-  - `OptionSelectFieldEditor.tsx`
-- **Text keys** — add any edit-specific labels (e.g. "Edit custom fields", "No custom fields yet", delete confirmation copy) in `public/texts/project_texts.tsx` (EN + DE).
-- **Toggle check** — `isEnabled("REGISTRATION_CUSTOM_FIELDS")` wraps the entire field builder section in the modal.
+- **`src/components/shareProject/CheckboxFieldEditor.tsx`** — add optional `disabled?: boolean` prop; disable the TipTap editor when `true`.
+- **`src/components/shareProject/OptionSelectFieldEditor.tsx`** — add optional `titleDisabled?: boolean` prop (disables the title TextField when the field has answers). Option rows: disable the title TextField for options where `option.has_answers === true`. *(`onRequestDeleteOption` prop already added in the partial implementation.)*
+- **`src/components/shareProject/RegistrationFieldEditor.tsx`** — pass `disabled`/`titleDisabled` down to the appropriate sub-editor based on `field.has_answers`.
+- **`src/components/shareProject/RegistrationFieldList.tsx`** — pass `has_answers`-based read-only signals through `RegistrationFieldEditor`. *(`onRequestDeleteField`/`onRequestDeleteOption` props already added in the partial implementation.)*
+- **`src/components/project/EditEventRegistrationModal.tsx`** — ✅ partially done (fields state, RegistrationFieldList, confirmation dialogs, PATCH payload). Still needed:
+  - Change confirmation dialog trigger: show only when `field.has_answers === true` (not for all persisted fields).
+  - Pass `has_answers` through to sub-editors so locked text fields render as read-only.
+- **`src/types.ts`** — add `has_answers?: boolean` to `RegistrationField` and `RegistrationFieldOption` types.
+- **`public/texts/project_texts.tsx`** — ✅ done (delete confirmation copy added in EN + DE).
+- **Toggle check** — `isEnabled("REGISTRATION_CUSTOM_FIELDS")` wraps the entire field builder section in the modal. ✅ done.
 
 ### Data / Migrations
 
@@ -173,19 +219,24 @@ None.
 
 ### Backend
 
-| File | Change |
-|------|--------|
-| `organization/serializers/event_registration.py` | Clean up placeholder comments about answer storage (no functional change) |
-| `organization/serializers/registration_field.py` | Clean up docstring placeholders that say "RegistrationFieldAnswer does not exist yet" (no functional change) |
-| `organization/views/event_registration_views.py` | Derive `is_draft` from `project.is_draft` instead of `request.data.get("is_draft")` |
-| `organization/tests/test_event_registration.py` | Add tests for field edit/sync and error responses |
+| File | Change | Status |
+|------|--------|--------|
+| `organization/serializers/event_registration.py` | Clean up placeholder comments about answer storage (no functional change) | ✅ done |
+| `organization/serializers/registration_field.py` | (1) Add `has_answers` SerializerMethodField to `RegistrationFieldSerializer` and `RegistrationFieldOptionSerializer`; (2) enforce answer-lock in `sync_fields()` / `_sync_options()` | ⬜ not yet implemented |
+| `organization/views/event_registration_views.py` | Derive `is_draft` from `project.is_draft` instead of `request.data.get("is_draft")` | ✅ done |
+| `organization/tests/test_event_registration_custom_fields.py` | Add tests for field edit/sync, cascade deletes, and answer-lock violations | ✅ partially done — answer-lock tests still needed |
 
 ### Frontend
 
-| File | Change |
-|------|--------|
-| `src/components/project/EditEventRegistrationModal.tsx` | Add toggle-gated field builder section; manage `fields` local state; include `fields` in PATCH payload; parse nested field errors; add confirmation dialog for delete |
-| `public/texts/project_texts.tsx` | Add new text keys (EN + DE) for edit-specific labels and delete confirmation copy |
+| File | Change | Status |
+|------|--------|--------|
+| `src/types.ts` | Add `has_answers?: boolean` to `RegistrationField` and `RegistrationFieldOption` | ⬜ not yet implemented |
+| `src/components/shareProject/CheckboxFieldEditor.tsx` | Add `disabled?: boolean` prop; disable editor when true | ⬜ not yet implemented |
+| `src/components/shareProject/OptionSelectFieldEditor.tsx` | Add `titleDisabled?: boolean` prop; disable option title inputs for `has_answers` options | ⬜ not yet implemented (`onRequestDeleteOption` ✅ done) |
+| `src/components/shareProject/RegistrationFieldEditor.tsx` | Pass `disabled`/`titleDisabled` to sub-editors based on `field.has_answers` | ⬜ not yet implemented (`onRequestDeleteOption` pass-through ✅ done) |
+| `src/components/shareProject/RegistrationFieldList.tsx` | Pass has_answers-based read-only signals through | ⬜ not yet implemented (`onRequestDeleteField`/`onRequestDeleteOption` ✅ done) |
+| `src/components/project/EditEventRegistrationModal.tsx` | Add toggle-gated field builder section; manage `fields` local state; include `fields` in PATCH payload; parse nested field errors; confirmation dialogs; pass `has_answers` to sub-editors | ✅ partially done — `has_answers`-based read-only and corrected delete-confirmation trigger not yet implemented |
+| `public/texts/project_texts.tsx` | Add new text keys (EN + DE) for edit-specific labels and delete confirmation copy | ✅ done |
 
 ---
 
@@ -209,21 +260,31 @@ None.
 | 11 | Checkbox `settings.description` empty on draft save | Accepted |
 | 12 | Unknown key in `settings` (e.g. `{"rogue": "x"}`) | Stripped; only allowed keys persisted |
 | 13 | HTML sanitization — disallowed tags in description | Script tag stripped; safe HTML stored |
+| 14 | PATCH attempts to change checkbox description when field has answers | `400 Bad Request` |
+| 15 | PATCH attempts to change option select title when field has answers | `400 Bad Request` |
+| 16 | PATCH attempts to change option title when option has answers | `400 Bad Request` |
+| 17 | PATCH changes `is_required` on a field that has answers | `200 OK`; flag updated |
+| 18 | PATCH changes `order` on a field that has answers | `200 OK`; order updated |
+| 19 | GET field with answers — `has_answers` flag on field and option | `has_answers: true` returned for field; `has_answers: true` returned for answered option, `false` for unanswered option |
 
 ### Frontend
 
 | # | Scenario | Expected |
 |---|----------|---------|
 | 1 | Organiser opens "Edit registration settings" modal — no custom fields yet | Field builder UI shows empty state with "Add field" button |
-| 2 | Modal opens with existing checkbox field | Pre-loaded description and required toggle shown |
-| 3 | Modal opens with existing option select field | Pre-loaded title and options shown |
-| 4 | Add a 6th field in the modal | "Add field" button disabled or shows error (max 5 reached) |
-| 5 | Reorder fields in the modal | Order reflected in preview and saved correctly |
-| 6 | Save modal with invalid field (e.g. empty checkbox description on publish) | Inline error shown on the field; modal stays open |
-| 7 | Feature toggle disabled | Field builder UI not rendered in modal |
-| 8 | Delete a previously saved field | Confirmation dialog shown; on confirm, field removed from UI and PATCH sent without it |
-| 9 | Delete a previously saved option within an option-select field | Confirmation dialog shown; on confirm, option removed from UI |
-| 11 | Reorder then delete a field | Order indices recalculated correctly before PATCH |
+| 2 | Modal opens with existing checkbox field (no answers) | Pre-loaded description and required toggle shown; description editor is editable |
+| 3 | Modal opens with existing checkbox field (`has_answers=true`) | Description editor is disabled/read-only |
+| 4 | Modal opens with existing option select field (no answers) | Title and option titles are editable |
+| 5 | Modal opens with existing option select field (`has_answers=true` on field) | Title input is disabled; options with `has_answers=true` have their title disabled |
+| 6 | Add a 6th field in the modal | "Add field" button disabled or shows error (max 5 reached) |
+| 7 | Reorder fields in the modal | Order reflected in preview and saved correctly |
+| 8 | Save modal with invalid field (e.g. empty checkbox description on publish) | Inline error shown on the field; modal stays open |
+| 9 | Feature toggle disabled | Field builder UI not rendered in modal |
+| 10 | Delete a field with `has_answers=true` | Confirmation dialog shown; on confirm, field removed from UI and PATCH sent without it |
+| 11 | Delete a field with `has_answers=false` (or new unsaved field) | Field removed immediately with no confirmation dialog |
+| 12 | Delete an option with `has_answers=true` | Confirmation dialog shown; on confirm, option removed |
+| 13 | Delete an option with `has_answers=false` | Option removed immediately with no confirmation dialog |
+| 14 | Reorder then delete a field | Order indices recalculated correctly before PATCH |
 
 ---
 
@@ -243,9 +304,9 @@ None.
 - [ ] **Option select**: has a title and at least one option; each option has a title and an order value.
 - [ ] Attempting to add a 6th field is rejected server-side with `400 Bad Request`.
 - [ ] An option select with zero options is rejected server-side on publish (`is_draft=false`); accepted on draft save.
-- [ ] Deleting a field or option cascades to delete related registrant answers automatically via the existing DB `CASCADE` constraint. The frontend shows a confirmation dialog before deleting a previously saved field or option.
+- [ ] Deleting a field or option cascades to delete related registrant answers automatically via the existing DB `CASCADE` constraint. The frontend shows a confirmation dialog before deleting a field or option where `has_answers=true`.
 - [ ] The `is_required` flag on a field may be toggled freely at any time (required ↔ not required), regardless of existing registrations or answers.
-- [ ] The custom field definitions are returned as part of the event API response, in configured order, with enough data for the registrant-side task to render the form.
+- [ ] The custom field definitions are returned as part of the event API response, in configured order, with `has_answers` flags on fields and options so the UI can enforce read-only constraints.
 - [ ] All new frontend UI is gated behind the `REGISTRATION_CUSTOM_FIELDS` feature toggle.
 - [ ] No breaking changes to existing API contracts.
 - [ ] All tests pass.
@@ -257,3 +318,4 @@ None.
 
 - 2026-05-12 07:25 — Task created from GitHub issue [#1961](https://github.com/climateconnect/climateconnect/issues/1961). DRAFT spec written assuming #1960 was not yet merged.
 - 2026-05-19 07:30 — Spec updated to READY FOR IMPLEMENTATION. #1960 (answer storage) is now merged. Backend serializer and view already support nested `fields` on PATCH (create task wired them in). Remaining work: (1) wire existing field-builder components into `EditEventRegistrationModal.tsx`, (2) add frontend confirmation dialogs for delete, (3) add tests. No backend guard logic needed; `is_required` may be toggled freely.
+- 2026-05-19 (this session) — Partial implementation completed: backend comment cleanup ✅, `is_draft` derivation fix ✅, confirmation dialogs ✅, `RegistrationFieldList`/`RegistrationFieldEditor`/`OptionSelectFieldEditor` delete-intercept props ✅, text keys ✅, `EditEventRegistrationModal` field builder section ✅. **Spec gap identified** by comparing #1961 issue text vs. spec: the issue requires answer-aware read-only restrictions on text properties (checkbox description, option select title, option titles) when answers exist. This was missing from the spec and not implemented. See updated Core Requirements, API, Backend, and Frontend sections above. Remaining work: (1) `has_answers` flag on `RegistrationFieldSerializer` and `RegistrationFieldOptionSerializer`; (2) answer-lock enforcement in `sync_fields()`/`_sync_options()`; (3) `has_answers` type additions and read-only UI in frontend field editor components; (4) update delete-confirmation trigger to `has_answers` rather than "has id"; (5) additional backend and frontend tests (test cases 14–19).

--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -1370,6 +1370,26 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       en: "Maximum of 5 fields reached",
       de: "Maximal 5 Felder erreicht",
     },
+    confirm_delete_field_title: {
+      en: "Delete field?",
+      de: "Feld löschen?",
+    },
+    confirm_delete_field_body: {
+      en:
+        "This will permanently delete the field and any answers already submitted by registrants. This cannot be undone.",
+      de:
+        "Dieses Feld und alle bereits eingereichten Antworten der Teilnehmenden werden unwiderruflich gelöscht.",
+    },
+    confirm_delete_option_title: {
+      en: "Delete option?",
+      de: "Option löschen?",
+    },
+    confirm_delete_option_body: {
+      en:
+        "This will permanently delete the option and any answers already submitted for it. This cannot be undone.",
+      de:
+        "Diese Option und alle bereits eingereichten Antworten dafür werden unwiderruflich gelöscht.",
+    },
     your_project_has_been_saved_as_a_draft: {
       en: "Your project has been saved as a draft!",
       de: "Dein Projekt wurde als Entwurf gespeichert!",

--- a/frontend/src/components/project/EditEventRegistrationModal.test.tsx
+++ b/frontend/src/components/project/EditEventRegistrationModal.test.tsx
@@ -15,6 +15,34 @@ jest.mock("universal-cookie", () => {
   return jest.fn(() => ({ get: jest.fn(() => "test-token") }));
 });
 
+// Feature toggles — default to all disabled; individual tests opt-in.
+const mockIsEnabled = jest.fn(() => false);
+jest.mock("../featureToggle", () => ({
+  useFeatureToggles: () => ({ isEnabled: mockIsEnabled }),
+}));
+
+// Stub RegistrationFieldList to avoid rendering the full component tree.
+// Exposes a delete-field button per field so modal-level dialog tests work.
+jest.mock("../shareProject/RegistrationFieldList", () => ({
+  __esModule: true,
+  default: ({ fields, onFieldsChange, onRequestDeleteField }: any) => (
+    <div data-testid="registration-field-list">
+      {fields.map((f: any, i: number) => (
+        <button
+          key={f._clientKey ?? f.id ?? i}
+          onClick={() =>
+            f.has_answers && onRequestDeleteField
+              ? onRequestDeleteField(i, f)
+              : onFieldsChange(fields.filter((_: any, j: number) => j !== i))
+          }
+        >
+          delete field {i}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
 const mockApiRequest = jest.fn();
 jest.mock("../../../public/lib/apiOperations", () => ({
   ...jest.requireActual("../../../public/lib/apiOperations"),
@@ -379,6 +407,118 @@ describe("EditEventRegistrationModal", () => {
       await waitFor(() => {
         expect(screen.getByText(/must be a positive integer/i)).toBeInTheDocument();
       });
+    });
+  });
+
+  // ── Custom fields section ─────────────────────────────────────────────────
+
+  describe("custom fields section", () => {
+    beforeEach(() => {
+      mockIsEnabled.mockImplementation((flag: string) => flag === "REGISTRATION_CUSTOM_FIELDS");
+    });
+
+    it("renders the RegistrationFieldList when the feature toggle is enabled", () => {
+      renderModal({
+        eventRegistration: makeRegistration({ fields: [] }),
+      });
+      expect(screen.getByTestId("registration-field-list")).toBeInTheDocument();
+    });
+
+    it("does not render the RegistrationFieldList when the feature toggle is disabled", () => {
+      mockIsEnabled.mockReturnValue(false);
+      renderModal({ eventRegistration: makeRegistration({ fields: [] }) });
+      expect(screen.queryByTestId("registration-field-list")).not.toBeInTheDocument();
+    });
+
+    it("includes fields in the PATCH payload when the feature toggle is enabled", async () => {
+      const fields = [
+        {
+          id: 1,
+          field_type: "checkbox" as const,
+          order: 0,
+          is_required: false,
+          settings: { description: "<p>OK</p>" },
+          has_answers: false,
+        },
+      ];
+      renderModal({ eventRegistration: makeRegistration({ fields }) });
+      fireEvent.click(screen.getByRole("button", { name: /save/i }));
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
+      const { payload } = mockApiRequest.mock.calls[0][0];
+      expect(payload.fields).toEqual(fields);
+    });
+  });
+
+  // ── Delete field confirmation dialog ──────────────────────────────────────
+
+  describe("delete field confirmation dialog", () => {
+    beforeEach(() => {
+      mockIsEnabled.mockImplementation((flag: string) => flag === "REGISTRATION_CUSTOM_FIELDS");
+    });
+
+    it("opens the confirmation dialog when deleting a field with has_answers=true", () => {
+      const fields = [
+        {
+          id: 1,
+          field_type: "checkbox" as const,
+          order: 0,
+          is_required: false,
+          settings: {},
+          has_answers: true,
+          _clientKey: "k1",
+        },
+      ];
+      renderModal({ eventRegistration: makeRegistration({ fields }) });
+      fireEvent.click(screen.getByRole("button", { name: /delete field 0/i }));
+      expect(screen.getByRole("dialog", { name: /delete field/i })).toBeInTheDocument();
+    });
+
+    it("removes the field from state when the confirmation dialog is confirmed", async () => {
+      const fields = [
+        {
+          id: 1,
+          field_type: "checkbox" as const,
+          order: 0,
+          is_required: false,
+          settings: {},
+          has_answers: true,
+          _clientKey: "k1",
+        },
+      ];
+      renderModal({ eventRegistration: makeRegistration({ fields }) });
+      fireEvent.click(screen.getByRole("button", { name: /delete field 0/i }));
+      fireEvent.click(screen.getByRole("button", { name: /^delete field$/i }));
+      // Wait for the confirmation dialog to close and main dialog to become accessible again
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument()
+      );
+      fireEvent.click(screen.getByRole("button", { name: /save/i }));
+      await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
+      const { payload } = mockApiRequest.mock.calls[0][0];
+      expect(payload.fields).toHaveLength(0);
+    });
+
+    it("keeps the field when the confirmation dialog is cancelled", async () => {
+      const fields = [
+        {
+          id: 1,
+          field_type: "checkbox" as const,
+          order: 0,
+          is_required: false,
+          settings: {},
+          has_answers: true,
+          _clientKey: "k1",
+        },
+      ];
+      renderModal({ eventRegistration: makeRegistration({ fields }) });
+      fireEvent.click(screen.getByRole("button", { name: /delete field 0/i }));
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      // Wait for the main dialog to be accessible again, confirming the confirmation dialog closed
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: /delete field 0/i })).toBeInTheDocument()
+      );
+      // Field is still present in the list
+      expect(screen.getByTestId("registration-field-list")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/project/EditEventRegistrationModal.tsx
+++ b/frontend/src/components/project/EditEventRegistrationModal.tsx
@@ -11,10 +11,12 @@ import {
   DialogTitle,
   Divider,
   FormControlLabel,
+  IconButton,
   Switch,
   TextField,
   Typography,
 } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
 import makeStyles from "@mui/styles/makeStyles";
 import dayjs, { Dayjs } from "dayjs";
 import Cookies from "universal-cookie";
@@ -30,7 +32,6 @@ import {
 import UserContext from "../context/UserContext";
 import { useFeatureToggles } from "../featureToggle";
 import DatePicker from "../general/DatePicker";
-import GenericDialog from "../dialogs/GenericDialog";
 import RegistrationFieldList from "../shareProject/RegistrationFieldList";
 
 const useStyles = makeStyles((theme) => ({
@@ -46,19 +47,10 @@ const useStyles = makeStyles((theme) => ({
       width: "100%",
     },
   },
-  actionRow: {
-    display: "flex",
-    justifyContent: "flex-end",
-    gap: theme.spacing(1),
-    marginTop: theme.spacing(3),
-  },
   errorText: {
     color: theme.palette.error.main,
     fontSize: "0.75rem",
     marginTop: theme.spacing(0.5),
-  },
-  generalError: {
-    marginTop: theme.spacing(1),
   },
   statusHint: {
     marginTop: theme.spacing(0.5),
@@ -342,156 +334,170 @@ export default function EditEventRegistrationModal({
 
   return (
     <>
-      <GenericDialog
+      <Dialog
         open={open}
         onClose={onClose}
-        title={texts.edit_registration_settings}
+        scroll="paper"
         maxWidth="sm"
+        fullWidth
+        aria-labelledby="edit-registration-dialog-title"
       >
-        <Box className={classes.fieldsRow}>
-          <Box className={classes.field}>
-            <TextField
-              fullWidth
-              variant="outlined"
-              type="number"
-              label={texts.max_participants}
-              value={maxParticipants}
-              onChange={(e) => setMaxParticipants(e.target.value)}
-              inputProps={{ min: 1 }}
-              error={!!errors.max_participants}
-              helperText={errors.max_participants}
-              required
-              aria-label={texts.max_participants}
-            />
-          </Box>
-          <Box className={classes.field}>
-            <DatePicker
-              label={texts.registration_end_date}
-              enableTime
-              date={registrationEndDate}
-              handleChange={(val: Dayjs) => setRegistrationEndDate(val)}
-              minDate={dayjs()}
-              maxDate={project.end_date ? dayjs(project.end_date) : undefined}
-              error={errors.registration_end_date as any}
-              required
-            />
-          </Box>
+        <DialogTitle
+          id="edit-registration-dialog-title"
+          sx={{ display: "flex", alignItems: "center", gap: 1 }}
+        >
+          <IconButton aria-label="close" onClick={onClose} size="small" sx={{ color: "grey.500" }}>
+            <CloseIcon />
+          </IconButton>
+          {texts.edit_registration_settings}
+        </DialogTitle>
 
-          {/* Status field */}
-          <Box className={classes.field}>
-            {isStatusEnded ? (
-              // "ended" is system-managed — show read-only chip, no select
-              <Box>
-                <Typography
-                  variant="caption"
-                  sx={{
-                    textTransform: "uppercase",
-                    letterSpacing: "0.08em",
-                    color: "text.secondary",
-                  }}
-                >
-                  {texts.registration_status}
-                </Typography>
-                <Box sx={{ mt: 0.5 }}>
-                  <Chip
-                    size="small"
-                    label={texts.registration_status_ended}
-                    color="error"
-                    sx={{ fontWeight: 600 }}
-                  />
-                </Box>
-              </Box>
-            ) : (
-              // "open", "closed", or "full" — show a Switch
-              <Box>
-                {isStatusFull && (
-                  // Extra chip to communicate the current effective status
-                  <Box sx={{ mb: 1 }}>
+        <DialogContent dividers>
+          <Box className={classes.fieldsRow}>
+            <Box className={classes.field}>
+              <TextField
+                fullWidth
+                variant="outlined"
+                type="number"
+                label={texts.max_participants}
+                value={maxParticipants}
+                onChange={(e) => setMaxParticipants(e.target.value)}
+                inputProps={{ min: 1 }}
+                error={!!errors.max_participants}
+                helperText={errors.max_participants}
+                required
+                aria-label={texts.max_participants}
+              />
+            </Box>
+            <Box className={classes.field}>
+              <DatePicker
+                label={texts.registration_end_date}
+                enableTime
+                date={registrationEndDate}
+                handleChange={(val: Dayjs) => setRegistrationEndDate(val)}
+                minDate={dayjs()}
+                maxDate={project.end_date ? dayjs(project.end_date) : undefined}
+                error={errors.registration_end_date as any}
+                required
+              />
+            </Box>
+
+            {/* Status field */}
+            <Box className={classes.field}>
+              {isStatusEnded ? (
+                // "ended" is system-managed — show read-only chip, no select
+                <Box>
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                      color: "text.secondary",
+                    }}
+                  >
+                    {texts.registration_status}
+                  </Typography>
+                  <Box sx={{ mt: 0.5 }}>
                     <Chip
                       size="small"
-                      label={texts.registration_status_full}
-                      color="warning"
+                      label={texts.registration_status_ended}
+                      color="error"
                       sx={{ fontWeight: 600 }}
                     />
                   </Box>
-                )}
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={selectedStatus === "open"}
-                      onChange={(e) => {
-                        // Capacity guard: block turning ON when full and seats not freed
-                        if (e.target.checked && !canSelectOpen) return;
-                        setSelectedStatus(e.target.checked ? "open" : "closed");
-                      }}
-                      color="primary"
-                      aria-label={texts.registration_status}
-                    />
-                  }
-                  label={
-                    selectedStatus === "open"
-                      ? texts.registration_is_open
-                      : texts.registration_is_closed
-                  }
+                </Box>
+              ) : (
+                // "open", "closed", or "full" — show a Switch
+                <Box>
+                  {isStatusFull && (
+                    // Extra chip to communicate the current effective status
+                    <Box sx={{ mb: 1 }}>
+                      <Chip
+                        size="small"
+                        label={texts.registration_status_full}
+                        color="warning"
+                        sx={{ fontWeight: 600 }}
+                      />
+                    </Box>
+                  )}
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={selectedStatus === "open"}
+                        onChange={(e) => {
+                          // Capacity guard: block turning ON when full and seats not freed
+                          if (e.target.checked && !canSelectOpen) return;
+                          setSelectedStatus(e.target.checked ? "open" : "closed");
+                        }}
+                        color="primary"
+                        aria-label={texts.registration_status}
+                      />
+                    }
+                    label={
+                      selectedStatus === "open"
+                        ? texts.registration_is_open
+                        : texts.registration_is_closed
+                    }
+                  />
+                  {errors.status && (
+                    <Typography className={classes.errorText} role="alert">
+                      {errors.status}
+                    </Typography>
+                  )}
+                  {isStatusFull && !canSelectOpen && (
+                    <Typography className={classes.statusHint} role="note">
+                      {texts.registration_fully_booked_increase_max_participants}
+                    </Typography>
+                  )}
+                </Box>
+              )}
+            </Box>
+          </Box>
+
+          {/* Notify admins toggle */}
+          <Box sx={{ width: "100%", mt: 2 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={notifyAdmins}
+                  onChange={(e) => setNotifyAdmins(e.target.checked)}
+                  color="primary"
+                  aria-label={texts.notify_admins_on_registration}
                 />
-                {errors.status && (
-                  <Typography className={classes.errorText} role="alert">
-                    {errors.status}
-                  </Typography>
-                )}
-                {isStatusFull && !canSelectOpen && (
-                  <Typography className={classes.statusHint} role="note">
-                    {texts.registration_fully_booked_increase_max_participants}
-                  </Typography>
-                )}
-              </Box>
-            )}
-          </Box>
-        </Box>
-
-        {/* Notify admins toggle */}
-        <Box sx={{ width: "100%", mt: 2 }}>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={notifyAdmins}
-                onChange={(e) => setNotifyAdmins(e.target.checked)}
-                color="primary"
-                aria-label={texts.notify_admins_on_registration}
-              />
-            }
-            label={texts.notify_admins_on_registration}
-          />
-        </Box>
-
-        {/* Custom fields section (toggle-gated) */}
-        {isCustomFieldsEnabled && (
-          <Box className={classes.customFieldsSection}>
-            <Divider sx={{ mb: 2 }} />
-            <Typography variant="subtitle1" sx={{ mb: 1.5, fontWeight: 600 }}>
-              {texts.registration_custom_fields}
-            </Typography>
-            <RegistrationFieldList
-              fields={fields}
-              onFieldsChange={setFields}
-              onRequestDeleteField={handleRequestDeleteField}
-              onRequestDeleteOption={handleRequestDeleteOption}
+              }
+              label={texts.notify_admins_on_registration}
             />
-            {errors.fields && (
-              <Typography className={classes.customFieldsError} role="alert">
-                {errors.fields}
-              </Typography>
-            )}
           </Box>
-        )}
 
-        {errors.general && (
-          <Typography className={`${classes.errorText} ${classes.generalError}`} role="alert">
-            {errors.general}
-          </Typography>
-        )}
+          {/* Custom fields section (toggle-gated) */}
+          {isCustomFieldsEnabled && (
+            <Box className={classes.customFieldsSection}>
+              <Divider sx={{ mb: 2 }} />
+              <Typography variant="subtitle1" sx={{ mb: 1.5, fontWeight: 600 }}>
+                {texts.registration_custom_fields}
+              </Typography>
+              <RegistrationFieldList
+                fields={fields}
+                onFieldsChange={setFields}
+                onRequestDeleteField={handleRequestDeleteField}
+                onRequestDeleteOption={handleRequestDeleteOption}
+              />
+              {errors.fields && (
+                <Typography className={classes.customFieldsError} role="alert">
+                  {errors.fields}
+                </Typography>
+              )}
+            </Box>
+          )}
 
-        <Box className={classes.actionRow}>
+          {errors.general && (
+            <Typography className={classes.errorText} sx={{ mt: 1 }} role="alert">
+              {errors.general}
+            </Typography>
+          )}
+        </DialogContent>
+
+        <DialogActions>
           <Button variant="outlined" onClick={onClose} disabled={saving} aria-label={texts.cancel}>
             {texts.cancel}
           </Button>
@@ -505,8 +511,8 @@ export default function EditEventRegistrationModal({
           >
             {saving ? texts.save + "…" : texts.save}
           </Button>
-        </Box>
-      </GenericDialog>
+        </DialogActions>
+      </Dialog>
 
       {/* Delete field confirmation dialog */}
       <Dialog

--- a/frontend/src/components/project/EditEventRegistrationModal.tsx
+++ b/frontend/src/components/project/EditEventRegistrationModal.tsx
@@ -4,6 +4,12 @@ import {
   Button,
   Chip,
   CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Divider,
   FormControlLabel,
   Switch,
   TextField,
@@ -15,10 +21,17 @@ import Cookies from "universal-cookie";
 
 import { apiRequest } from "../../../public/lib/apiOperations";
 import getTexts from "../../../public/texts/texts";
-import { EventRegistrationData, Project } from "../../types";
+import {
+  EventRegistrationData,
+  Project,
+  RegistrationField,
+  RegistrationFieldOption,
+} from "../../types";
 import UserContext from "../context/UserContext";
+import { useFeatureToggles } from "../featureToggle";
 import DatePicker from "../general/DatePicker";
 import GenericDialog from "../dialogs/GenericDialog";
+import RegistrationFieldList from "../shareProject/RegistrationFieldList";
 
 const useStyles = makeStyles((theme) => ({
   fieldsRow: {
@@ -52,6 +65,15 @@ const useStyles = makeStyles((theme) => ({
     fontSize: "0.75rem",
     color: theme.palette.warning.dark,
   },
+  customFieldsSection: {
+    width: "100%",
+    marginTop: theme.spacing(3),
+  },
+  customFieldsError: {
+    color: theme.palette.error.main,
+    fontSize: "0.75rem",
+    marginTop: theme.spacing(0.5),
+  },
 }));
 
 type FormErrors = {
@@ -59,6 +81,7 @@ type FormErrors = {
   registration_end_date?: string;
   status?: string;
   general?: string;
+  fields?: string;
 };
 
 type Props = {
@@ -88,13 +111,29 @@ export default function EditEventRegistrationModal({
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "project", locale });
   const token = new Cookies().get("auth_token");
+  const { isEnabled } = useFeatureToggles();
+  const isCustomFieldsEnabled = isEnabled("REGISTRATION_CUSTOM_FIELDS");
 
   const [maxParticipants, setMaxParticipants] = useState<string>("");
   const [registrationEndDate, setRegistrationEndDate] = useState<Dayjs | null>(null);
   const [selectedStatus, setSelectedStatus] = useState<"open" | "closed">("open");
   const [notifyAdmins, setNotifyAdmins] = useState<boolean>(true);
+  const [fields, setFields] = useState<RegistrationField[]>([]);
   const [errors, setErrors] = useState<FormErrors>({});
   const [saving, setSaving] = useState(false);
+
+  // Confirmation dialog for deleting a persisted field
+  const [confirmDeleteField, setConfirmDeleteField] = useState<{
+    open: boolean;
+    index: number | null;
+  }>({ open: false, index: null });
+
+  // Confirmation dialog for deleting a persisted option within a field
+  const [confirmDeleteOption, setConfirmDeleteOption] = useState<{
+    open: boolean;
+    fieldIndex: number | null;
+    optionIndex: number | null;
+  }>({ open: false, fieldIndex: null, optionIndex: null });
 
   // Sync form state when modal opens / eventRegistration values change
   useEffect(() => {
@@ -109,6 +148,7 @@ export default function EditEventRegistrationModal({
       );
       setSelectedStatus(initSelectedStatus(eventRegistration.status));
       setNotifyAdmins(eventRegistration.notify_admins);
+      setFields(eventRegistration.fields ?? []);
       setErrors({});
     }
   }, [open, eventRegistration]);
@@ -161,6 +201,56 @@ export default function EditEventRegistrationModal({
     return Object.keys(newErrors).length === 0;
   };
 
+  // ── Delete field confirmation handlers ──────────────────────────────────
+
+  const handleRequestDeleteField = (index: number, _field: RegistrationField) => {
+    setConfirmDeleteField({ open: true, index });
+  };
+
+  const handleConfirmDeleteField = () => {
+    const index = confirmDeleteField.index;
+    if (index !== null) {
+      setFields((prev) => prev.filter((_, i) => i !== index).map((f, i) => ({ ...f, order: i })));
+    }
+    setConfirmDeleteField({ open: false, index: null });
+  };
+
+  const handleCancelDeleteField = () => {
+    setConfirmDeleteField({ open: false, index: null });
+  };
+
+  // ── Delete option confirmation handlers ──────────────────────────────────
+
+  const handleRequestDeleteOption = (
+    fieldIndex: number,
+    optionIndex: number,
+    _option: RegistrationFieldOption
+  ) => {
+    setConfirmDeleteOption({ open: true, fieldIndex, optionIndex });
+  };
+
+  const handleConfirmDeleteOption = () => {
+    const { fieldIndex, optionIndex } = confirmDeleteOption;
+    if (fieldIndex !== null && optionIndex !== null) {
+      setFields((prev) =>
+        prev.map((f, fi) => {
+          if (fi !== fieldIndex) return f;
+          const updatedOptions = (f.options ?? [])
+            .filter((_, oi) => oi !== optionIndex)
+            .map((o, i) => ({ ...o, order: i }));
+          return { ...f, options: updatedOptions };
+        })
+      );
+    }
+    setConfirmDeleteOption({ open: false, fieldIndex: null, optionIndex: null });
+  };
+
+  const handleCancelDeleteOption = () => {
+    setConfirmDeleteOption({ open: false, fieldIndex: null, optionIndex: null });
+  };
+
+  // ── Save handler ──────────────────────────────────────────────────────────
+
   const handleSave = async () => {
     if (!validate()) return;
 
@@ -181,6 +271,10 @@ export default function EditEventRegistrationModal({
       payload.status = selectedStatus;
     }
     payload.notify_admins = notifyAdmins;
+
+    if (isCustomFieldsEnabled) {
+      payload.fields = fields;
+    }
 
     try {
       const resp = await apiRequest({
@@ -209,6 +303,31 @@ export default function EditEventRegistrationModal({
         if (data.status) {
           apiErrors.status = Array.isArray(data.status) ? data.status[0] : data.status;
         }
+        if (data.fields) {
+          // Flatten nested field errors into a single displayable string
+          const fieldsErr = data.fields;
+          if (typeof fieldsErr === "string") {
+            apiErrors.fields = fieldsErr;
+          } else if (Array.isArray(fieldsErr)) {
+            // Extract the first non-empty error message from the nested structure
+            const firstMsg = fieldsErr
+              .flatMap((fe: any) => {
+                if (typeof fe === "string") return [fe];
+                if (fe && typeof fe === "object") {
+                  return Object.values(fe).flatMap((v: any) =>
+                    Array.isArray(v)
+                      ? v.map(String)
+                      : typeof v === "object" && v !== null
+                      ? Object.values(v).map(String)
+                      : [String(v)]
+                  );
+                }
+                return [];
+              })
+              .find(Boolean);
+            if (firstMsg) apiErrors.fields = firstMsg;
+          }
+        }
         if (data.detail || data.non_field_errors) {
           apiErrors.general = data.detail ?? data.non_field_errors?.[0];
         }
@@ -222,149 +341,212 @@ export default function EditEventRegistrationModal({
   };
 
   return (
-    <GenericDialog
-      open={open}
-      onClose={onClose}
-      title={texts.edit_registration_settings}
-      maxWidth="sm"
-    >
-      <Box className={classes.fieldsRow}>
-        <Box className={classes.field}>
-          <TextField
-            fullWidth
-            variant="outlined"
-            type="number"
-            label={texts.max_participants}
-            value={maxParticipants}
-            onChange={(e) => setMaxParticipants(e.target.value)}
-            inputProps={{ min: 1 }}
-            error={!!errors.max_participants}
-            helperText={errors.max_participants}
-            required
-            aria-label={texts.max_participants}
-          />
-        </Box>
-        <Box className={classes.field}>
-          <DatePicker
-            label={texts.registration_end_date}
-            enableTime
-            date={registrationEndDate}
-            handleChange={(val: Dayjs) => setRegistrationEndDate(val)}
-            minDate={dayjs()}
-            maxDate={project.end_date ? dayjs(project.end_date) : undefined}
-            error={errors.registration_end_date as any}
-            required
-          />
-        </Box>
+    <>
+      <GenericDialog
+        open={open}
+        onClose={onClose}
+        title={texts.edit_registration_settings}
+        maxWidth="sm"
+      >
+        <Box className={classes.fieldsRow}>
+          <Box className={classes.field}>
+            <TextField
+              fullWidth
+              variant="outlined"
+              type="number"
+              label={texts.max_participants}
+              value={maxParticipants}
+              onChange={(e) => setMaxParticipants(e.target.value)}
+              inputProps={{ min: 1 }}
+              error={!!errors.max_participants}
+              helperText={errors.max_participants}
+              required
+              aria-label={texts.max_participants}
+            />
+          </Box>
+          <Box className={classes.field}>
+            <DatePicker
+              label={texts.registration_end_date}
+              enableTime
+              date={registrationEndDate}
+              handleChange={(val: Dayjs) => setRegistrationEndDate(val)}
+              minDate={dayjs()}
+              maxDate={project.end_date ? dayjs(project.end_date) : undefined}
+              error={errors.registration_end_date as any}
+              required
+            />
+          </Box>
 
-        {/* Status field */}
-        <Box className={classes.field}>
-          {isStatusEnded ? (
-            // "ended" is system-managed — show read-only chip, no select
-            <Box>
-              <Typography
-                variant="caption"
-                sx={{
-                  textTransform: "uppercase",
-                  letterSpacing: "0.08em",
-                  color: "text.secondary",
-                }}
-              >
-                {texts.registration_status}
-              </Typography>
-              <Box sx={{ mt: 0.5 }}>
-                <Chip
-                  size="small"
-                  label={texts.registration_status_ended}
-                  color="error"
-                  sx={{ fontWeight: 600 }}
-                />
-              </Box>
-            </Box>
-          ) : (
-            // "open", "closed", or "full" — show a Switch
-            <Box>
-              {isStatusFull && (
-                // Extra chip to communicate the current effective status
-                <Box sx={{ mb: 1 }}>
+          {/* Status field */}
+          <Box className={classes.field}>
+            {isStatusEnded ? (
+              // "ended" is system-managed — show read-only chip, no select
+              <Box>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    textTransform: "uppercase",
+                    letterSpacing: "0.08em",
+                    color: "text.secondary",
+                  }}
+                >
+                  {texts.registration_status}
+                </Typography>
+                <Box sx={{ mt: 0.5 }}>
                   <Chip
                     size="small"
-                    label={texts.registration_status_full}
-                    color="warning"
+                    label={texts.registration_status_ended}
+                    color="error"
                     sx={{ fontWeight: 600 }}
                   />
                 </Box>
-              )}
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={selectedStatus === "open"}
-                    onChange={(e) => {
-                      // Capacity guard: block turning ON when full and seats not freed
-                      if (e.target.checked && !canSelectOpen) return;
-                      setSelectedStatus(e.target.checked ? "open" : "closed");
-                    }}
-                    color="primary"
-                    aria-label={texts.registration_status}
-                  />
-                }
-                label={
-                  selectedStatus === "open"
-                    ? texts.registration_is_open
-                    : texts.registration_is_closed
-                }
-              />
-              {errors.status && (
-                <Typography className={classes.errorText} role="alert">
-                  {errors.status}
-                </Typography>
-              )}
-              {isStatusFull && !canSelectOpen && (
-                <Typography className={classes.statusHint} role="note">
-                  {texts.registration_fully_booked_increase_max_participants}
-                </Typography>
-              )}
-            </Box>
-          )}
+              </Box>
+            ) : (
+              // "open", "closed", or "full" — show a Switch
+              <Box>
+                {isStatusFull && (
+                  // Extra chip to communicate the current effective status
+                  <Box sx={{ mb: 1 }}>
+                    <Chip
+                      size="small"
+                      label={texts.registration_status_full}
+                      color="warning"
+                      sx={{ fontWeight: 600 }}
+                    />
+                  </Box>
+                )}
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={selectedStatus === "open"}
+                      onChange={(e) => {
+                        // Capacity guard: block turning ON when full and seats not freed
+                        if (e.target.checked && !canSelectOpen) return;
+                        setSelectedStatus(e.target.checked ? "open" : "closed");
+                      }}
+                      color="primary"
+                      aria-label={texts.registration_status}
+                    />
+                  }
+                  label={
+                    selectedStatus === "open"
+                      ? texts.registration_is_open
+                      : texts.registration_is_closed
+                  }
+                />
+                {errors.status && (
+                  <Typography className={classes.errorText} role="alert">
+                    {errors.status}
+                  </Typography>
+                )}
+                {isStatusFull && !canSelectOpen && (
+                  <Typography className={classes.statusHint} role="note">
+                    {texts.registration_fully_booked_increase_max_participants}
+                  </Typography>
+                )}
+              </Box>
+            )}
+          </Box>
         </Box>
-      </Box>
 
-      {/* Notify admins toggle */}
-      <Box sx={{ width: "100%", mt: 2 }}>
-        <FormControlLabel
-          control={
-            <Switch
-              checked={notifyAdmins}
-              onChange={(e) => setNotifyAdmins(e.target.checked)}
-              color="primary"
-              aria-label={texts.notify_admins_on_registration}
+        {/* Notify admins toggle */}
+        <Box sx={{ width: "100%", mt: 2 }}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={notifyAdmins}
+                onChange={(e) => setNotifyAdmins(e.target.checked)}
+                color="primary"
+                aria-label={texts.notify_admins_on_registration}
+              />
+            }
+            label={texts.notify_admins_on_registration}
+          />
+        </Box>
+
+        {/* Custom fields section (toggle-gated) */}
+        {isCustomFieldsEnabled && (
+          <Box className={classes.customFieldsSection}>
+            <Divider sx={{ mb: 2 }} />
+            <Typography variant="subtitle1" sx={{ mb: 1.5, fontWeight: 600 }}>
+              {texts.registration_custom_fields}
+            </Typography>
+            <RegistrationFieldList
+              fields={fields}
+              onFieldsChange={setFields}
+              onRequestDeleteField={handleRequestDeleteField}
+              onRequestDeleteOption={handleRequestDeleteOption}
             />
-          }
-          label={texts.notify_admins_on_registration}
-        />
-      </Box>
+            {errors.fields && (
+              <Typography className={classes.customFieldsError} role="alert">
+                {errors.fields}
+              </Typography>
+            )}
+          </Box>
+        )}
 
-      {errors.general && (
-        <Typography className={`${classes.errorText} ${classes.generalError}`} role="alert">
-          {errors.general}
-        </Typography>
-      )}
+        {errors.general && (
+          <Typography className={`${classes.errorText} ${classes.generalError}`} role="alert">
+            {errors.general}
+          </Typography>
+        )}
 
-      <Box className={classes.actionRow}>
-        <Button variant="outlined" onClick={onClose} disabled={saving} aria-label={texts.cancel}>
-          {texts.cancel}
-        </Button>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleSave}
-          disabled={saving}
-          startIcon={saving ? <CircularProgress size={16} color="inherit" /> : undefined}
-          aria-label={texts.save}
-        >
-          {saving ? texts.save + "…" : texts.save}
-        </Button>
-      </Box>
-    </GenericDialog>
+        <Box className={classes.actionRow}>
+          <Button variant="outlined" onClick={onClose} disabled={saving} aria-label={texts.cancel}>
+            {texts.cancel}
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleSave}
+            disabled={saving}
+            startIcon={saving ? <CircularProgress size={16} color="inherit" /> : undefined}
+            aria-label={texts.save}
+          >
+            {saving ? texts.save + "…" : texts.save}
+          </Button>
+        </Box>
+      </GenericDialog>
+
+      {/* Delete field confirmation dialog */}
+      <Dialog
+        open={confirmDeleteField.open}
+        onClose={handleCancelDeleteField}
+        aria-labelledby="confirm-delete-field-title"
+      >
+        <DialogTitle id="confirm-delete-field-title">
+          {texts.confirm_delete_field_title}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>{texts.confirm_delete_field_body}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancelDeleteField}>{texts.cancel}</Button>
+          <Button onClick={handleConfirmDeleteField} color="error" variant="contained">
+            {texts.delete_field}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete option confirmation dialog */}
+      <Dialog
+        open={confirmDeleteOption.open}
+        onClose={handleCancelDeleteOption}
+        aria-labelledby="confirm-delete-option-title"
+      >
+        <DialogTitle id="confirm-delete-option-title">
+          {texts.confirm_delete_option_title}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>{texts.confirm_delete_option_body}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancelDeleteOption}>{texts.cancel}</Button>
+          <Button onClick={handleConfirmDeleteOption} color="error" variant="contained">
+            {texts.delete_option}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 }

--- a/frontend/src/components/shareProject/CheckboxFieldEditor.tsx
+++ b/frontend/src/components/shareProject/CheckboxFieldEditor.tsx
@@ -54,9 +54,10 @@ const useStyles = makeStyles((theme) => ({
 type Props = {
   description: string;
   onChange: (_html: string) => void;
+  disabled?: boolean;
 };
 
-export default function CheckboxFieldEditor({ description, onChange }: Props) {
+export default function CheckboxFieldEditor({ description, onChange, disabled }: Props) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "project", locale });
@@ -85,6 +86,7 @@ export default function CheckboxFieldEditor({ description, onChange }: Props) {
         immediatelyRender={false}
         extensions={EXTENSIONS}
         content={description || ""}
+        editable={!disabled}
         onCreate={({ editor }) => {
           setCharCount(editor.storage.characterCount.characters());
         }}
@@ -93,14 +95,26 @@ export default function CheckboxFieldEditor({ description, onChange }: Props) {
           onChange(html === "<p></p>" ? "" : html);
           setCharCount(editor.storage.characterCount.characters());
         }}
-        renderControls={() => (
-          <MenuControlsContainer>
-            <MenuButtonBold />
-            <MenuButtonEditLink />
-          </MenuControlsContainer>
-        )}
+        renderControls={
+          disabled
+            ? () => null
+            : () => (
+                <MenuControlsContainer>
+                  <MenuButtonBold />
+                  <MenuButtonEditLink />
+                </MenuControlsContainer>
+              )
+        }
         RichTextFieldProps={{
-          footer: (
+          disabled: disabled,
+          sx: disabled
+            ? {
+                "& .MuiTiptap-RichTextContent-readonly p": {
+                  color: "text.disabled",
+                },
+              }
+            : undefined,
+          footer: disabled ? undefined : (
             <Box className={classes.charCount}>
               <Typography
                 variant="caption"

--- a/frontend/src/components/shareProject/OptionSelectFieldEditor.test.tsx
+++ b/frontend/src/components/shareProject/OptionSelectFieldEditor.test.tsx
@@ -23,11 +23,19 @@ function renderEditor({
   title = "",
   options = [] as RegistrationFieldOption[],
   onChange = jest.fn(),
+  onRequestDeleteOption = undefined as jest.Mock | undefined,
+  titleDisabled = false,
 } = {}) {
   return render(
     <ThemeProvider theme={theme}>
       <UserContext.Provider value={defaultContext as any}>
-        <OptionSelectFieldEditor title={title} options={options} onChange={onChange} />
+        <OptionSelectFieldEditor
+          title={title}
+          options={options}
+          onChange={onChange}
+          onRequestDeleteOption={onRequestDeleteOption}
+          titleDisabled={titleDisabled}
+        />
       </UserContext.Provider>
     </ThemeProvider>
   );
@@ -160,6 +168,64 @@ describe("OptionSelectFieldEditor", () => {
       expect(options).toHaveLength(2);
       expect(options[0]).toMatchObject({ title: "A", order: 0 });
       expect(options[1]).toMatchObject({ title: "C", order: 1 });
+    });
+  });
+
+  // ── Answer-lock: titleDisabled ────────────────────────────────────────────
+
+  describe("titleDisabled prop", () => {
+    it("disables the title input when titleDisabled is true", () => {
+      renderEditor({ title: "Meal?", titleDisabled: true });
+      expect(screen.getByRole("textbox", { name: /title/i })).toBeDisabled();
+    });
+
+    it("leaves the title input enabled when titleDisabled is false", () => {
+      renderEditor({ title: "Meal?", titleDisabled: false });
+      expect(screen.getByRole("textbox", { name: /title/i })).not.toBeDisabled();
+    });
+  });
+
+  // ── Answer-lock: per-option disabled ──────────────────────────────────────
+
+  describe("option title disabled when has_answers", () => {
+    it("disables the option title input when option has_answers is true", () => {
+      renderEditor({ options: [{ id: 1, title: "Vegan", order: 0, has_answers: true }] });
+      expect(screen.getByDisplayValue("Vegan")).toBeDisabled();
+    });
+
+    it("leaves the option title input enabled when option has_answers is false", () => {
+      renderEditor({ options: [{ id: 1, title: "Vegan", order: 0, has_answers: false }] });
+      expect(screen.getByDisplayValue("Vegan")).not.toBeDisabled();
+    });
+  });
+
+  // ── Answer-lock: delete confirmation ─────────────────────────────────────
+
+  describe("delete confirmation for options with answers", () => {
+    it("calls onRequestDeleteOption instead of immediate delete when option has_answers is true", () => {
+      const onChange = jest.fn();
+      const onRequestDeleteOption = jest.fn();
+      renderEditor({
+        options: [{ id: 1, title: "Vegan", order: 0, has_answers: true }],
+        onChange,
+        onRequestDeleteOption,
+      });
+      fireEvent.click(screen.getByRole("button", { name: /delete option/i }));
+      expect(onRequestDeleteOption).toHaveBeenCalledWith(0, expect.objectContaining({ id: 1 }));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("deletes immediately when option has_answers is false even if option has an id", () => {
+      const onChange = jest.fn();
+      const onRequestDeleteOption = jest.fn();
+      renderEditor({
+        options: [{ id: 1, title: "Vegan", order: 0, has_answers: false }],
+        onChange,
+        onRequestDeleteOption,
+      });
+      fireEvent.click(screen.getByRole("button", { name: /delete option/i }));
+      expect(onRequestDeleteOption).not.toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/components/shareProject/OptionSelectFieldEditor.tsx
+++ b/frontend/src/components/shareProject/OptionSelectFieldEditor.tsx
@@ -34,8 +34,10 @@ type Props = {
   title: string;
   options: RegistrationFieldOption[];
   onChange: (_update: { title: string; options: RegistrationFieldOption[] }) => void;
-  /** Called instead of immediate deletion when the option has an id (was previously saved). */
+  /** Called instead of immediate deletion when the option has answers (confirms data loss). */
   onRequestDeleteOption?: (_index: number, _option: RegistrationFieldOption) => void;
+  /** When true, the question title field is read-only (field has registrant answers). */
+  titleDisabled?: boolean;
 };
 
 export default function OptionSelectFieldEditor({
@@ -43,6 +45,7 @@ export default function OptionSelectFieldEditor({
   options,
   onChange,
   onRequestDeleteOption,
+  titleDisabled,
 }: Props) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
@@ -64,7 +67,7 @@ export default function OptionSelectFieldEditor({
 
   const handleDeleteOption = (index: number) => {
     const option = options[index];
-    if (option.id != null && onRequestDeleteOption) {
+    if (option.has_answers && onRequestDeleteOption) {
       onRequestDeleteOption(index, option);
       return;
     }
@@ -99,6 +102,7 @@ export default function OptionSelectFieldEditor({
         onChange={handleTitleChange}
         variant="outlined"
         size="small"
+        disabled={titleDisabled}
         sx={{ mb: 1.5 }}
       />
       {options.map((option, index) => (
@@ -110,6 +114,7 @@ export default function OptionSelectFieldEditor({
             placeholder={texts.option_placeholder}
             variant="outlined"
             size="small"
+            disabled={option.has_answers === true}
           />
           <Tooltip title={texts.move_field_up}>
             <span>

--- a/frontend/src/components/shareProject/OptionSelectFieldEditor.tsx
+++ b/frontend/src/components/shareProject/OptionSelectFieldEditor.tsx
@@ -34,9 +34,16 @@ type Props = {
   title: string;
   options: RegistrationFieldOption[];
   onChange: (_update: { title: string; options: RegistrationFieldOption[] }) => void;
+  /** Called instead of immediate deletion when the option has an id (was previously saved). */
+  onRequestDeleteOption?: (_index: number, _option: RegistrationFieldOption) => void;
 };
 
-export default function OptionSelectFieldEditor({ title, options, onChange }: Props) {
+export default function OptionSelectFieldEditor({
+  title,
+  options,
+  onChange,
+  onRequestDeleteOption,
+}: Props) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "project", locale });
@@ -56,6 +63,11 @@ export default function OptionSelectFieldEditor({ title, options, onChange }: Pr
   };
 
   const handleDeleteOption = (index: number) => {
+    const option = options[index];
+    if (option.id != null && onRequestDeleteOption) {
+      onRequestDeleteOption(index, option);
+      return;
+    }
     const updated = options.filter((_, i) => i !== index).map((o, i) => ({ ...o, order: i }));
     onChange({ title, options: updated });
   };

--- a/frontend/src/components/shareProject/RegistrationFieldEditor.tsx
+++ b/frontend/src/components/shareProject/RegistrationFieldEditor.tsx
@@ -11,6 +11,7 @@ type Props = {
 };
 
 export default function RegistrationFieldEditor({ field, onChange, onRequestDeleteOption }: Props) {
+  const answersLocked = !!field.has_answers;
   return (
     <Box>
       {field.field_type === "checkbox" && (
@@ -19,6 +20,7 @@ export default function RegistrationFieldEditor({ field, onChange, onRequestDele
           onChange={(description) =>
             onChange({ ...field, settings: { ...field.settings, description } })
           }
+          disabled={answersLocked}
         />
       )}
       {field.field_type === "option_select" && (
@@ -29,6 +31,7 @@ export default function RegistrationFieldEditor({ field, onChange, onRequestDele
             onChange({ ...field, settings: { ...field.settings, title }, options })
           }
           onRequestDeleteOption={onRequestDeleteOption}
+          titleDisabled={answersLocked}
         />
       )}
     </Box>

--- a/frontend/src/components/shareProject/RegistrationFieldEditor.tsx
+++ b/frontend/src/components/shareProject/RegistrationFieldEditor.tsx
@@ -1,15 +1,16 @@
 import React from "react";
 import { Box } from "@mui/material";
-import { RegistrationField } from "../../types";
+import { RegistrationField, RegistrationFieldOption } from "../../types";
 import CheckboxFieldEditor from "./CheckboxFieldEditor";
 import OptionSelectFieldEditor from "./OptionSelectFieldEditor";
 
 type Props = {
   field: RegistrationField;
   onChange: (_updated: RegistrationField) => void;
+  onRequestDeleteOption?: (_index: number, _option: RegistrationFieldOption) => void;
 };
 
-export default function RegistrationFieldEditor({ field, onChange }: Props) {
+export default function RegistrationFieldEditor({ field, onChange, onRequestDeleteOption }: Props) {
   return (
     <Box>
       {field.field_type === "checkbox" && (
@@ -27,6 +28,7 @@ export default function RegistrationFieldEditor({ field, onChange }: Props) {
           onChange={({ title, options }) =>
             onChange({ ...field, settings: { ...field.settings, title }, options })
           }
+          onRequestDeleteOption={onRequestDeleteOption}
         />
       )}
     </Box>

--- a/frontend/src/components/shareProject/RegistrationFieldList.test.tsx
+++ b/frontend/src/components/shareProject/RegistrationFieldList.test.tsx
@@ -282,4 +282,49 @@ describe("RegistrationFieldList", () => {
       expect(result[0].is_required).toBe(false);
     });
   });
+
+  // ── Answer-lock: delete confirmation ─────────────────────────────────────
+
+  describe("delete confirmation for fields with answers", () => {
+    function renderWithDeleteCallback(fields: RegistrationField[]) {
+      const onFieldsChange = jest.fn();
+      const onRequestDeleteField = jest.fn();
+      render(
+        <ThemeProvider theme={theme}>
+          <UserContext.Provider value={defaultContext as any}>
+            <RegistrationFieldList
+              fields={fields}
+              onFieldsChange={onFieldsChange}
+              onRequestDeleteField={onRequestDeleteField}
+            />
+          </UserContext.Provider>
+        </ThemeProvider>
+      );
+      return { onFieldsChange, onRequestDeleteField };
+    }
+
+    it("calls onRequestDeleteField instead of immediate delete when has_answers is true", () => {
+      const field = makeField({ id: 1, has_answers: true });
+      const { onFieldsChange, onRequestDeleteField } = renderWithDeleteCallback([field]);
+      fireEvent.click(screen.getByRole("button", { name: /delete field/i }));
+      expect(onRequestDeleteField).toHaveBeenCalledWith(0, field);
+      expect(onFieldsChange).not.toHaveBeenCalled();
+    });
+
+    it("deletes immediately (no callback) when has_answers is false even if field has an id", () => {
+      const field = makeField({ id: 1, has_answers: false });
+      const { onFieldsChange, onRequestDeleteField } = renderWithDeleteCallback([field]);
+      fireEvent.click(screen.getByRole("button", { name: /delete field/i }));
+      expect(onRequestDeleteField).not.toHaveBeenCalled();
+      expect(onFieldsChange).toHaveBeenCalledWith([]);
+    });
+
+    it("deletes immediately when has_answers is undefined", () => {
+      const field = makeField({ id: 1 }); // has_answers not set
+      const { onFieldsChange, onRequestDeleteField } = renderWithDeleteCallback([field]);
+      fireEvent.click(screen.getByRole("button", { name: /delete field/i }));
+      expect(onRequestDeleteField).not.toHaveBeenCalled();
+      expect(onFieldsChange).toHaveBeenCalledWith([]);
+    });
+  });
 });

--- a/frontend/src/components/shareProject/RegistrationFieldList.tsx
+++ b/frontend/src/components/shareProject/RegistrationFieldList.tsx
@@ -19,7 +19,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import makeStyles from "@mui/styles/makeStyles";
 import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
-import { RegistrationField } from "../../types";
+import { RegistrationField, RegistrationFieldOption } from "../../types";
 import RegistrationFieldEditor from "./RegistrationFieldEditor";
 
 const MAX_FIELDS = 5;
@@ -51,9 +51,22 @@ const useStyles = makeStyles((theme) => ({
 type Props = {
   fields: RegistrationField[];
   onFieldsChange: (_updated: RegistrationField[]) => void;
+  /** Called instead of immediate deletion when the field has an id (was previously saved). */
+  onRequestDeleteField?: (_index: number, _field: RegistrationField) => void;
+  /** Called instead of immediate deletion when a persisted option within a field is deleted. */
+  onRequestDeleteOption?: (
+    _fieldIndex: number,
+    _optionIndex: number,
+    _option: RegistrationFieldOption
+  ) => void;
 };
 
-export default function RegistrationFieldList({ fields, onFieldsChange }: Props) {
+export default function RegistrationFieldList({
+  fields,
+  onFieldsChange,
+  onRequestDeleteField,
+  onRequestDeleteOption,
+}: Props) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "project", locale });
@@ -101,6 +114,11 @@ export default function RegistrationFieldList({ fields, onFieldsChange }: Props)
   };
 
   const handleDeleteField = (index: number) => {
+    const field = fields[index];
+    if (field.id != null && onRequestDeleteField) {
+      onRequestDeleteField(index, field);
+      return;
+    }
     const updated = fields.filter((_, i) => i !== index).map((f, i) => ({ ...f, order: i }));
     onFieldsChange(updated);
   };
@@ -158,6 +176,11 @@ export default function RegistrationFieldList({ fields, onFieldsChange }: Props)
           <RegistrationFieldEditor
             field={field}
             onChange={(updated) => handleFieldChange(index, updated)}
+            onRequestDeleteOption={
+              onRequestDeleteOption
+                ? (optionIndex, option) => onRequestDeleteOption(index, optionIndex, option)
+                : undefined
+            }
           />
           <Divider sx={{ mt: 1.5 }} />
           <Box className={classes.fieldFooter}>

--- a/frontend/src/components/shareProject/RegistrationFieldList.tsx
+++ b/frontend/src/components/shareProject/RegistrationFieldList.tsx
@@ -115,7 +115,7 @@ export default function RegistrationFieldList({
 
   const handleDeleteField = (index: number) => {
     const field = fields[index];
-    if (field.id != null && onRequestDeleteField) {
+    if (field.has_answers && onRequestDeleteField) {
       onRequestDeleteField(index, field);
       return;
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,6 +5,7 @@ export type RegistrationFieldOption = {
   id?: number | null;
   title: string;
   order: number;
+  has_answers?: boolean;
 };
 
 export type RegistrationField = {
@@ -17,6 +18,7 @@ export type RegistrationField = {
     title?: string;
   };
   options?: RegistrationFieldOption[];
+  has_answers?: boolean;
   /** Client-only stable key for React list rendering before the field is saved. */
   _clientKey?: string;
 };


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [X] Run within `/backend`: `make format && make lint`

## What and Why

Implements #1961 
