### PR TITLE
Improve Custom Field Editor UI for Event Registration Configuration

### DIFF
--- a/doc/spec/20260520_1334_improve_custom_field_editor_ui.md
+++ b/doc/spec/20260520_1334_improve_custom_field_editor_ui.md
@@ -1,0 +1,128 @@
+# Improve Custom Field Editor UI for Event Registration Configuration
+
+**Status**: DRAFT
+**Type**: Feature (UI polish)
+**Date and time created**: 2026-05-20 13:34
+**GitHub Issue**: [#1998](https://github.com/climateconnect/climateconnect/issues/1998)
+**Epic**: [`EPIC_event_registration.md`](./EPIC_event_registration.md)
+**Related Specs**:
+- [`20260416_1000_event_registration_custom_fields.md`](./20260416_1000_event_registration_custom_fields.md)
+- [`20260519_1328_inventory_field_type_event_registration.md`](./20260519_1328_inventory_field_type_event_registration.md)
+
+---
+
+## Problem Statement
+
+The create and edit flows for event registration configuration have three minor UI gaps that reduce usability:
+
+1. **No visual icons for field types** — When an organiser adds a custom registration field, the "Add field" dropdown menu and the field header only show plain text labels ("Checkbox", "Single choice", "Inventory"). Adding icons would make the field types instantly recognisable and improve the visual polish of the editor.
+
+2. **Inventory field form is cramped in the modal** — The `EditEventRegistrationModal` uses `maxWidth="sm"` (600px). The inventory field editor has three columns per option row (title, available amount, max per guest) plus action buttons. At 600px width the layout is tight, especially on the `md` breakpoint where the Grid columns compress. Widening the modal on desktop would give the inventory form room to breathe.
+
+3. **No guidance that single-select and inventory fields limit guests to one option** — Organisers may not realise that for "Single choice" and "Inventory" field types, a guest can only pick one option. A short helper text in the footer of those field editors would set the right expectation. The German translation is "Gast kann nur eine Option wählen".
+
+All three changes are **UI only** — no backend, API, or data model changes are needed.
+
+**Core Requirements (User/Stakeholder Stated):**
+
+1. Show icons for each custom field type in the "Add field" select menu and on the field form component header.
+2. On desktop, make the edit registration modal wider so that the inventory field form fits better.
+3. Add a helper text to single-select and inventory field types indicating that a guest can only choose one option (German: "Gast kann nur eine Option wählen"), displayed in the footer area of the field form component.
+
+**Explicitly Out of Scope (this task):**
+
+- Any backend or API changes.
+- Changes to the registrant-side registration modal (`EventRegistrationModal.tsx`).
+- Changes to the checkbox field editor (no single-option limitation applies).
+- Changes to the `RegistrationFieldList` component beyond the icon additions.
+- Any changes to field validation logic or data contracts.
+
+### Non-Functional Requirements
+
+- **No breaking changes** to existing UI behaviour or data flow.
+- **Icons must be from `@mui/icons-material`** — use existing icon imports, no new icon library dependencies.
+- **Modal widening must be responsive** — only widen on `md` and up breakpoints; mobile/tablet should keep the current width.
+- **Helper text must be translatable** — add EN and DE text keys following the existing pattern in `project_texts.tsx`.
+- **Accessibility** — icons in the menu items should have appropriate `aria-label` or be decorative with `aria-hidden`.
+
+### AI Agent Insights and Additions
+
+- **Icon choices** — Suggested MUI icons that match the field semantics:
+  - **Checkbox** → `CheckBoxOutlineBlankIcon` or `CheckCircleOutlineIcon` (conveys a checkbox/toggle)
+  - **Single choice (option_select)** → `RadioButtonUncheckedIcon` or `RadioIcon` (conveys a radio/single-select)
+  - **Inventory** → `InventoryIcon` or `LocalOfferIcon` (conveys stock/items)
+  The implementing agent should pick the most visually consistent set.
+
+- **Where to add icons in `RegistrationFieldList.tsx`**:
+  - **Add field menu** (lines 230–237): Each `<MenuItem>` currently renders plain text. Wrap the text in a `<Box>` or `<ListItem>` with an icon prefix.
+  - **Field header** (lines 148–153): The `<Typography>` that shows the field type label should be preceded by an icon.
+
+- **Modal widening in `EditEventRegistrationModal.tsx`**:
+  - Line 344: `maxWidth="sm"` → change to `maxWidth="md"` (900px) or use a breakpoint-aware approach. The simplest change is `maxWidth="md"`, which is still reasonable for the form layout and gives the inventory grid more room.
+
+- **Helper text placement**:
+  - **`OptionSelectFieldEditor.tsx`**: Add a `<Typography>` with `variant="caption"` and `color="textSecondary"` after the options list (after line 153, before the "Add option" button or after it).
+  - **`InventoryFieldEditor.tsx`**: Same pattern — add after the options list (after line 237, before or after the "Add option" button).
+  - The text should be subtle (caption style) and only appear for these two field types.
+
+- **Text keys to add in `project_texts.tsx`**:
+  - `single_option_per_guest_notice` — EN: "Guests can only select one option", DE: "Gast kann nur eine Option wählen"
+
+---
+
+## Acceptance Criteria
+
+- [ ] The "Add field" dropdown menu in `RegistrationFieldList` shows an icon next to each field type label (Checkbox, Single choice, Inventory).
+- [ ] Each field's header in `RegistrationFieldList` shows an icon next to the field type label.
+- [ ] The `EditEventRegistrationModal` is wider on desktop (at least `md` breakpoint), giving the inventory field form more horizontal space.
+- [ ] The `OptionSelectFieldEditor` displays a helper text indicating that guests can only select one option.
+- [ ] The `InventoryFieldEditor` displays the same helper text indicating that guests can only select one option.
+- [ ] The helper text is translatable — both EN and DE text keys exist in `project_texts.tsx`.
+- [ ] The `CheckboxFieldEditor` does **not** show the single-option helper text.
+- [ ] All existing tests pass.
+- [ ] `yarn lint` and `yarn format` pass with no errors.
+
+---
+
+## Files to Change
+
+### Frontend
+
+| File | Change |
+|------|--------|
+| `src/components/shareProject/RegistrationFieldList.tsx` | Add icons to the "Add field" menu items (lines 231–237) and to the field header label (lines 148–153) |
+| `src/components/project/EditEventRegistrationModal.tsx` | Change `maxWidth="sm"` to `maxWidth="md"` on the Dialog (line 344) |
+| `src/components/shareProject/OptionSelectFieldEditor.tsx` | Add helper text after the options list (after line 153) |
+| `src/components/shareProject/InventoryFieldEditor.tsx` | Add helper text after the options list (after line 237) |
+| `public/texts/project_texts.tsx` | Add `single_option_per_guest_notice` text key with EN and DE translations |
+
+---
+
+## Test Cases
+
+### Frontend
+
+| # | Scenario | Expected |
+|---|----------|---------|
+| 1 | Open "Add field" menu in create/edit event registration | Each menu item shows an icon next to the field type label |
+| 2 | View a field card in the registration field list | Field header shows an icon next to the type label |
+| 3 | Open edit registration modal on desktop (≥900px viewport) | Modal is wider than before (md width), inventory form has more space |
+| 4 | View an option-select field editor | Helper text "Guests can only select one option" is visible |
+| 5 | View an inventory field editor | Helper text "Guests can only select one option" is visible |
+| 6 | View a checkbox field editor | No single-option helper text is shown |
+| 7 | Switch locale to German | Helper text displays "Gast kann nur eine Option wählen" |
+| 8 | Existing unit tests for RegistrationFieldList, OptionSelectFieldEditor, InventoryFieldEditor | All pass without modification |
+
+---
+
+## Dependency Notes
+
+- **No new dependencies** — icons come from the existing `@mui/icons-material` package.
+- **No backend changes** — this is purely a frontend UI polish task.
+- **No feature toggle changes** — the existing `REGISTRATION_CUSTOM_FIELDS` toggle already gates the entire custom field editor UI.
+
+---
+
+## Log
+
+- 2026-05-20 13:34 — Task created from GitHub issue [#1998](https://github.com/climateconnect/climateconnect/issues/1998). Three UI-only improvements for the event registration custom field editor: icons for field types, wider modal on desktop, and helper text for single-option field types.

--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -1334,6 +1334,10 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       en: "Inventory",
       de: "Inventar",
     },
+    single_option_per_guest_notice: {
+      en: "Guests can only select one option",
+      de: "Gast kann nur eine Option wählen",
+    },
     inventory_available_amount: {
       en: "Available amount",
       de: "Verfügbare Menge",

--- a/frontend/src/components/project/EditEventRegistrationModal.tsx
+++ b/frontend/src/components/project/EditEventRegistrationModal.tsx
@@ -341,7 +341,7 @@ export default function EditEventRegistrationModal({
         open={open}
         onClose={onClose}
         scroll="paper"
-        maxWidth="sm"
+        maxWidth="md"
         fullWidth
         aria-labelledby="edit-registration-dialog-title"
       >

--- a/frontend/src/components/shareProject/InventoryFieldEditor.tsx
+++ b/frontend/src/components/shareProject/InventoryFieldEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { Box, Grid, IconButton, TextField, Tooltip, Typography } from "@mui/material";
+import { Box, IconButton, TextField, Tooltip, Typography } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme) => ({
   optionRow: {
     display: "flex",
     alignItems: "center",
-    gap: theme.spacing(0.5),
+    gap: theme.spacing(1),
     marginBottom: theme.spacing(0.75),
     [theme.breakpoints.down("sm")]: {
       flexDirection: "column",
@@ -21,10 +21,22 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   optionTitleInput: {
-    flex: 2,
+    flex: "2 1 0",
+    minWidth: 0,
   },
   capacityInput: {
-    flex: 1,
+    flex: "1 1 0",
+    minWidth: 185,
+  },
+  actionButtons: {
+    display: "flex",
+    alignItems: "center",
+    gap: theme.spacing(0.25),
+    flexShrink: 0,
+    [theme.breakpoints.down("sm")]: {
+      justifyContent: "flex-end",
+      marginTop: theme.spacing(0.5),
+    },
   },
   addButton: {
     display: "flex",
@@ -34,15 +46,6 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.primary.main,
     marginTop: theme.spacing(0.5),
     fontSize: "0.875rem",
-  },
-  actionButtons: {
-    display: "flex",
-    alignItems: "center",
-    gap: theme.spacing(0.5),
-    [theme.breakpoints.down("sm")]: {
-      justifyContent: "flex-end",
-      marginTop: theme.spacing(0.5),
-    },
   },
 }));
 
@@ -156,83 +159,70 @@ export default function InventoryFieldEditor({
       />
       {options.map((option, index) => (
         <Box key={option.id ?? `inv_opt_${index}`} className={classes.optionRow}>
-          <Grid container spacing={1} alignItems="center">
-            <Grid item xs={12} sm={6} md={5}>
-              <TextField
-                fullWidth
-                className={classes.optionTitleInput}
-                value={option.title}
-                onChange={(e) => handleOptionChange(index, "title", e.target.value)}
-                placeholder={texts.option_placeholder}
-                variant="outlined"
+          <TextField
+            className={classes.optionTitleInput}
+            value={option.title}
+            onChange={(e) => handleOptionChange(index, "title", e.target.value)}
+            placeholder={texts.option_placeholder}
+            variant="outlined"
+            size="small"
+            disabled={option.has_answers === true}
+          />
+          <TextField
+            className={classes.capacityInput}
+            value={option.available_amount ?? ""}
+            onChange={(e) => handleOptionChange(index, "available_amount", e.target.value)}
+            label={texts.inventory_available_amount}
+            type="number"
+            variant="outlined"
+            size="small"
+            inputProps={{ min: 1 }}
+          />
+          <TextField
+            className={classes.capacityInput}
+            value={option.max_amount_per_guest ?? ""}
+            onChange={(e) => handleOptionChange(index, "max_amount_per_guest", e.target.value)}
+            label={texts.inventory_max_per_guest}
+            type="number"
+            variant="outlined"
+            size="small"
+            inputProps={{ min: 1 }}
+          />
+          <Box className={classes.actionButtons}>
+            <Tooltip title={texts.move_field_up}>
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={() => handleMoveOptionUp(index)}
+                  disabled={index === 0}
+                  aria-label={texts.move_field_up}
+                >
+                  <ArrowUpwardIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title={texts.move_field_down}>
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={() => handleMoveOptionDown(index)}
+                  disabled={index === options.length - 1}
+                  aria-label={texts.move_field_down}
+                >
+                  <ArrowDownwardIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title={texts.delete_option}>
+              <IconButton
                 size="small"
-                disabled={option.has_answers === true}
-              />
-            </Grid>
-            <Grid item xs={6} sm={3} md={3}>
-              <TextField
-                fullWidth
-                className={classes.capacityInput}
-                value={option.available_amount ?? ""}
-                onChange={(e) => handleOptionChange(index, "available_amount", e.target.value)}
-                label={texts.inventory_available_amount}
-                type="number"
-                variant="outlined"
-                size="small"
-                inputProps={{ min: 1 }}
-              />
-            </Grid>
-            <Grid item xs={6} sm={3} md={3}>
-              <TextField
-                fullWidth
-                className={classes.capacityInput}
-                value={option.max_amount_per_guest ?? ""}
-                onChange={(e) => handleOptionChange(index, "max_amount_per_guest", e.target.value)}
-                label={texts.inventory_max_per_guest}
-                type="number"
-                variant="outlined"
-                size="small"
-                inputProps={{ min: 1 }}
-              />
-            </Grid>
-            <Grid item xs={12} sm={12} md={1}>
-              <Box className={classes.actionButtons}>
-                <Tooltip title={texts.move_field_up}>
-                  <span>
-                    <IconButton
-                      size="small"
-                      onClick={() => handleMoveOptionUp(index)}
-                      disabled={index === 0}
-                      aria-label={texts.move_field_up}
-                    >
-                      <ArrowUpwardIcon fontSize="small" />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-                <Tooltip title={texts.move_field_down}>
-                  <span>
-                    <IconButton
-                      size="small"
-                      onClick={() => handleMoveOptionDown(index)}
-                      disabled={index === options.length - 1}
-                      aria-label={texts.move_field_down}
-                    >
-                      <ArrowDownwardIcon fontSize="small" />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-                <Tooltip title={texts.delete_option}>
-                  <IconButton
-                    size="small"
-                    onClick={() => handleDeleteOption(index)}
-                    aria-label={texts.delete_option}
-                  >
-                    <DeleteIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-              </Box>
-            </Grid>
-          </Grid>
+                onClick={() => handleDeleteOption(index)}
+                aria-label={texts.delete_option}
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
         </Box>
       ))}
       <Box className={classes.addButton} onClick={handleAddOption} role="button" tabIndex={0}>

--- a/frontend/src/components/shareProject/RegistrationFieldList.tsx
+++ b/frontend/src/components/shareProject/RegistrationFieldList.tsx
@@ -16,6 +16,9 @@ import AddIcon from "@mui/icons-material/Add";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import DeleteIcon from "@mui/icons-material/Delete";
+import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
+import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
+import InventoryIcon from "@mui/icons-material/Inventory";
 import makeStyles from "@mui/styles/makeStyles";
 import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
@@ -136,6 +139,18 @@ export default function RegistrationFieldList({
 
   const isAtMax = fields.length >= MAX_FIELDS;
 
+  const getFieldIcon = (fieldType: string) => {
+    switch (fieldType) {
+      case "checkbox":
+        return <CheckBoxOutlineBlankIcon fontSize="small" />;
+      case "inventory":
+        return <InventoryIcon fontSize="small" />;
+      case "option_select":
+      default:
+        return <RadioButtonUncheckedIcon fontSize="small" />;
+    }
+  };
+
   return (
     <Box>
       {fields.map((field, index) => (
@@ -145,13 +160,16 @@ export default function RegistrationFieldList({
           className={classes.fieldPaper}
         >
           <Box className={classes.fieldHeader}>
-            <Typography variant="subtitle2" color="textSecondary">
-              {field.field_type === "checkbox"
-                ? texts.field_type_checkbox
-                : field.field_type === "inventory"
-                ? texts.field_type_inventory
-                : texts.field_type_option_select}
-            </Typography>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+              {getFieldIcon(field.field_type)}
+              <Typography variant="subtitle2" color="textSecondary">
+                {field.field_type === "checkbox"
+                  ? texts.field_type_checkbox
+                  : field.field_type === "inventory"
+                  ? texts.field_type_inventory
+                  : texts.field_type_option_select}
+              </Typography>
+            </Box>
             <Box className={classes.controlsRow}>
               <Tooltip title={texts.move_field_up}>
                 <span>
@@ -204,15 +222,22 @@ export default function RegistrationFieldList({
               }
               label={texts.registration_field_required}
             />
-            <Tooltip title={texts.delete_field}>
-              <IconButton
-                size="small"
-                onClick={() => handleDeleteField(index)}
-                aria-label={texts.delete_field}
-              >
-                <DeleteIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              {(field.field_type === "option_select" || field.field_type === "inventory") && (
+                <Typography variant="caption" color="textSecondary">
+                  {texts.single_option_per_guest_notice}
+                </Typography>
+              )}
+              <Tooltip title={texts.delete_field}>
+                <IconButton
+                  size="small"
+                  onClick={() => handleDeleteField(index)}
+                  aria-label={texts.delete_field}
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </Box>
           </Box>
         </Paper>
       ))}
@@ -228,12 +253,23 @@ export default function RegistrationFieldList({
         {isAtMax ? texts.max_registration_fields_reached : texts.add_registration_field}
       </Button>
       <Menu anchorEl={addMenuAnchor} open={Boolean(addMenuAnchor)} onClose={handleCloseAddMenu}>
-        <MenuItem onClick={() => handleAddField("checkbox")}>{texts.field_type_checkbox}</MenuItem>
+        <MenuItem onClick={() => handleAddField("checkbox")}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            {getFieldIcon("checkbox")}
+            {texts.field_type_checkbox}
+          </Box>
+        </MenuItem>
         <MenuItem onClick={() => handleAddField("option_select")}>
-          {texts.field_type_option_select}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            {getFieldIcon("option_select")}
+            {texts.field_type_option_select}
+          </Box>
         </MenuItem>
         <MenuItem onClick={() => handleAddField("inventory")}>
-          {texts.field_type_inventory}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            {getFieldIcon("inventory")}
+            {texts.field_type_inventory}
+          </Box>
         </MenuItem>
       </Menu>
     </Box>


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Minor UI changes for #1998 
