### PR TITLE
Add custom fields to export

### DIFF
--- a/frontend/src/components/project/ProjectRegistrationsContent.tsx
+++ b/frontend/src/components/project/ProjectRegistrationsContent.tsx
@@ -40,6 +40,7 @@ import { apiRequest, getLocalePrefix } from "../../../public/lib/apiOperations";
 
 import getTexts from "../../../public/texts/texts";
 import { EventRegistrationData, Project, RegistrationFieldAnswer } from "../../types";
+import { resolveAnswerToStrings } from "../../utils/resolveRegistrationFieldAnswer";
 import UserContext from "../context/UserContext";
 import { useFeatureToggles } from "../featureToggle";
 import CancelGuestRegistrationModal, { RegistrationInfo } from "./CancelGuestRegistrationModal";
@@ -335,6 +336,39 @@ export default function ProjectRegistrationsContent({
   const statusConfig = STATUS_CONFIG[eventRegistration.status];
   const StatusIcon = statusConfig.icon;
 
+  // Custom field export columns — hidden from the grid, included in CSV/print
+  const customFields = isCustomFieldsEnabled
+    ? [...(eventRegistration.fields ?? [])].sort((a, b) => a.order - b.order)
+    : [];
+
+  const customFieldColumns: GridColDef[] = [];
+  const customFieldColumnNames: string[] = [];
+
+  for (const field of customFields) {
+    if (field.id == null) continue;
+
+    // Probe with undefined answer to determine column count (1 for most types, 2 for inventory)
+    const columnSpec = resolveAnswerToStrings(field, undefined, locale);
+    for (let i = 0; i < columnSpec.length; i++) {
+      const colName = `custom_field_${field.id}${columnSpec[i].columnSuffix}`;
+      customFieldColumnNames.push(colName);
+      customFieldColumns.push({
+        field: colName,
+        headerName: `${field.label}${columnSpec[i].columnSuffix}`,
+        width: 0,
+        sortable: false,
+        filterable: false,
+        disableColumnMenu: true,
+        valueGetter: (params) => {
+          const row = params.row as EventRegistration;
+          const answerForField = row.field_answers.find((a) => a.field === field.id);
+          const cols = resolveAnswerToStrings(field, answerForField, locale);
+          return cols[i]?.value ?? "";
+        },
+      });
+    }
+  }
+
   return (
     <>
       {/* Registration settings summary */}
@@ -546,6 +580,7 @@ export default function ProjectRegistrationsContent({
                     valueGetter: (params) =>
                       params.row.cancelled_at ? params.row.cancelled_at.split(".")[0] + "Z" : "",
                   },
+                  ...customFieldColumns,
                   {
                     field: "__actions__",
                     headerName: "",
@@ -593,6 +628,7 @@ export default function ProjectRegistrationsContent({
                   columnVisibilityModel: {
                     registered_at_iso: false,
                     cancelled_at_iso: false,
+                    ...Object.fromEntries(customFieldColumnNames.map((name) => [name, false])),
                   },
                 },
                 sorting: {
@@ -626,8 +662,9 @@ export default function ProjectRegistrationsContent({
                     "registered_at_iso",
                     "cancelled_at",
                     "cancelled_at_iso",
+                    ...customFieldColumnNames,
                   ],
-                  printFields: ["user_first_name", "user_last_name"],
+                  printFields: ["user_first_name", "user_last_name", ...customFieldColumnNames],
                 } as ToolbarProps,
                 footer: {
                   total: participants.length,

--- a/frontend/src/utils/resolveRegistrationFieldAnswer.test.ts
+++ b/frontend/src/utils/resolveRegistrationFieldAnswer.test.ts
@@ -1,0 +1,196 @@
+import { RegistrationField, RegistrationFieldAnswer } from "../types";
+import { resolveAnswerToStrings } from "./resolveRegistrationFieldAnswer";
+
+const LOCALE = "en";
+
+function makeField(overrides: Partial<RegistrationField> & { id: number }): RegistrationField {
+  return {
+    field_type: "checkbox",
+    order: 0,
+    is_required: false,
+    label: "Test field",
+    settings: {},
+    ...overrides,
+  };
+}
+
+function makeAnswer(
+  overrides: Partial<RegistrationFieldAnswer> & { field: number }
+): RegistrationFieldAnswer {
+  return {
+    value_boolean: null,
+    value_option: null,
+    value_number: null,
+    ...overrides,
+  };
+}
+
+describe("resolveAnswerToStrings", () => {
+  describe("checkbox fields", () => {
+    it("returns TRUE when value_boolean is true", () => {
+      const field = makeField({ id: 1, field_type: "checkbox" });
+      const answer = makeAnswer({ field: 1, value_boolean: true });
+      const result = resolveAnswerToStrings(field, answer, LOCALE);
+      expect(result).toEqual([{ columnSuffix: "", value: "TRUE" }]);
+    });
+
+    it("returns FALSE when value_boolean is false", () => {
+      const field = makeField({ id: 1, field_type: "checkbox" });
+      const answer = makeAnswer({ field: 1, value_boolean: false });
+      const result = resolveAnswerToStrings(field, answer, LOCALE);
+      expect(result).toEqual([{ columnSuffix: "", value: "FALSE" }]);
+    });
+
+    it("returns empty string when value_boolean is null", () => {
+      const field = makeField({ id: 1, field_type: "checkbox" });
+      const answer = makeAnswer({ field: 1, value_boolean: null });
+      const result = resolveAnswerToStrings(field, answer, LOCALE);
+      expect(result).toEqual([{ columnSuffix: "", value: "" }]);
+    });
+
+    it("returns empty when no answer provided", () => {
+      const field = makeField({ id: 1, field_type: "checkbox" });
+      const result = resolveAnswerToStrings(field, undefined, LOCALE);
+      expect(result).toEqual([{ columnSuffix: "", value: "" }]);
+    });
+  });
+
+  describe("option_select fields", () => {
+    it("returns option title for a valid selection", () => {
+      const field = makeField({
+        id: 2,
+        field_type: "option_select",
+        options: [
+          { id: 10, title: "Vegan", order: 0 },
+          { id: 11, title: "Vegetarian", order: 1 },
+        ],
+      });
+      const answer = makeAnswer({ field: 2, value_option: 11 });
+      const result = resolveAnswerToStrings(field, answer, LOCALE);
+      expect(result).toEqual([{ columnSuffix: "", value: "Vegetarian" }]);
+    });
+
+    it("returns empty string when selected option no longer exists", () => {
+      const field = makeField({
+        id: 2,
+        field_type: "option_select",
+        options: [{ id: 10, title: "Vegan", order: 0 }],
+      });
+      const answer = makeAnswer({ field: 2, value_option: 99 });
+      const result = resolveAnswerToStrings(field, answer, LOCALE);
+      expect(result).toEqual([{ columnSuffix: "", value: "" }]);
+    });
+
+    it("returns empty when no answer provided", () => {
+      const field = makeField({
+        id: 2,
+        field_type: "option_select",
+        options: [{ id: 10, title: "Vegan", order: 0 }],
+      });
+      const result = resolveAnswerToStrings(field, undefined, LOCALE);
+      expect(result).toEqual([{ columnSuffix: "", value: "" }]);
+    });
+  });
+
+  describe("inventory fields", () => {
+    it("returns two columns: -item and -amount", () => {
+      const field = makeField({
+        id: 3,
+        field_type: "inventory",
+        options: [
+          { id: 20, title: "T-shirt", order: 0 },
+          { id: 21, title: "Mug", order: 1 },
+        ],
+      });
+      const answer = makeAnswer({ field: 3, value_option: 20, value_number: 3 });
+      const result = resolveAnswerToStrings(field, answer, LOCALE);
+      expect(result).toEqual([
+        { columnSuffix: "-item", value: "T-shirt" },
+        { columnSuffix: "-amount", value: "3" },
+      ]);
+    });
+
+    it("returns empty values when no answer provided", () => {
+      const field = makeField({
+        id: 3,
+        field_type: "inventory",
+        options: [],
+      });
+      const result = resolveAnswerToStrings(field, undefined, LOCALE);
+      expect(result).toEqual([
+        { columnSuffix: "-item", value: "" },
+        { columnSuffix: "-amount", value: "" },
+      ]);
+    });
+
+    it("returns empty when selected option no longer exists", () => {
+      const field = makeField({
+        id: 3,
+        field_type: "inventory",
+        options: [{ id: 20, title: "T-shirt", order: 0 }],
+      });
+      const answer = makeAnswer({ field: 3, value_option: 99, value_number: 2 });
+      const result = resolveAnswerToStrings(field, answer, LOCALE);
+      expect(result).toEqual([
+        { columnSuffix: "-item", value: "" },
+        { columnSuffix: "-amount", value: "2" },
+      ]);
+    });
+  });
+
+  describe("time_slot_select fields", () => {
+    it("returns localized time range for options with start/end time", () => {
+      const field = makeField({
+        id: 4,
+        field_type: "time_slot_select",
+        options: [
+          {
+            id: 30,
+            title: "Morning",
+            order: 0,
+            start_time: "2026-06-01T09:00:00Z",
+            end_time: "2026-06-01T12:00:00Z",
+          },
+        ],
+      });
+      const answer = makeAnswer({ field: 4, value_option: 30 });
+      const result = resolveAnswerToStrings(field, answer, LOCALE);
+      expect(result).toHaveLength(1);
+      expect(result[0].columnSuffix).toBe("");
+      // Should contain en-dash separator between start and end times
+      expect(result[0].value).toContain("\u2013");
+      // Should contain date and time components
+      expect(result[0].value).toContain("Jun");
+    });
+
+    it("falls back to option title when start/end times are missing", () => {
+      const field = makeField({
+        id: 4,
+        field_type: "time_slot_select",
+        options: [{ id: 31, title: "Afternoon", order: 0 }],
+      });
+      const answer = makeAnswer({ field: 4, value_option: 31 });
+      const result = resolveAnswerToStrings(field, answer, LOCALE);
+      expect(result).toEqual([{ columnSuffix: "", value: "Afternoon" }]);
+    });
+
+    it("returns empty when no answer provided", () => {
+      const field = makeField({
+        id: 4,
+        field_type: "time_slot_select",
+        options: [],
+      });
+      const result = resolveAnswerToStrings(field, undefined, LOCALE);
+      expect(result).toEqual([{ columnSuffix: "", value: "" }]);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns empty when field has no id", () => {
+      const field = makeField({ id: (undefined as unknown) as number, field_type: "checkbox" });
+      const answer = makeAnswer({ field: 0, value_boolean: true });
+      const result = resolveAnswerToStrings(field, answer, LOCALE);
+      expect(result).toEqual([{ columnSuffix: "", value: "" }]);
+    });
+  });
+});

--- a/frontend/src/utils/resolveRegistrationFieldAnswer.ts
+++ b/frontend/src/utils/resolveRegistrationFieldAnswer.ts
@@ -1,0 +1,101 @@
+import { RegistrationField, RegistrationFieldAnswer, RegistrationFieldOption } from "../types";
+
+export type ResolvedColumn = {
+  columnSuffix: string;
+  value: string;
+};
+
+function formatTimeRange(startIso: string, endIso: string, locale: string): string {
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  const dateFmt = new Intl.DateTimeFormat(locale, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  const timeFmt = new Intl.DateTimeFormat(locale, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  const sameDay =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate();
+
+  if (sameDay) {
+    return `${dateFmt.format(start)}, ${timeFmt.format(start)} \u2013 ${timeFmt.format(end)}`;
+  }
+  return `${dateFmt.format(start)}, ${timeFmt.format(start)} \u2013 ${dateFmt.format(
+    end
+  )}, ${timeFmt.format(end)}`;
+}
+
+function findOption(options: RegistrationFieldOption[] | undefined, optionId: number | null) {
+  if (optionId == null || !options) return undefined;
+  return options.find((opt) => opt.id != null && opt.id === optionId);
+}
+
+/**
+ * Resolves a single RegistrationFieldAnswer to a human-readable string
+ * for CSV/print export.
+ *
+ * Returns an array because inventory fields expand into two columns
+ * ({label}-item and {label}-amount).
+ */
+export function resolveAnswerToStrings(
+  field: RegistrationField,
+  answer: RegistrationFieldAnswer | undefined,
+  locale: string
+): ResolvedColumn[] {
+  if (answer == null || field.id == null) {
+    const empty: ResolvedColumn = { columnSuffix: "", value: "" };
+    if (field.field_type === "inventory") {
+      return [
+        { columnSuffix: "-item", value: "" },
+        { columnSuffix: "-amount", value: "" },
+      ];
+    }
+    return [empty];
+  }
+
+  switch (field.field_type) {
+    case "checkbox":
+      return [
+        {
+          columnSuffix: "",
+          value:
+            answer.value_boolean === true ? "TRUE" : answer.value_boolean === false ? "FALSE" : "",
+        },
+      ];
+
+    case "option_select": {
+      const option = findOption(field.options, answer.value_option);
+      return [{ columnSuffix: "", value: option?.title ?? "" }];
+    }
+
+    case "inventory": {
+      const option = findOption(field.options, answer.value_option);
+      return [
+        { columnSuffix: "-item", value: option?.title ?? "" },
+        {
+          columnSuffix: "-amount",
+          value: answer.value_number != null ? String(answer.value_number) : "",
+        },
+      ];
+    }
+
+    case "time_slot_select": {
+      const option = findOption(field.options, answer.value_option);
+      if (option?.start_time && option?.end_time) {
+        return [
+          { columnSuffix: "", value: formatTimeRange(option.start_time, option.end_time, locale) },
+        ];
+      }
+      return [{ columnSuffix: "", value: option?.title ?? "" }];
+    }
+
+    default:
+      return [{ columnSuffix: "", value: "" }];
+  }
+}


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

implements #1962
