### PR TITLE
Implement draft mode for event registration

### DIFF
--- a/backend/organization/migrations/0136_eventregistrationconfig_is_draft.py
+++ b/backend/organization/migrations/0136_eventregistrationconfig_is_draft.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+
+
+def set_draft_configs(apps, schema_editor):
+    """
+    Set is_draft=True for all EventRegistrationConfig records whose
+    related Project is still a draft.
+    """
+    EventRegistrationConfig = apps.get_model("organization", "EventRegistrationConfig")
+    EventRegistrationConfig.objects.filter(project__is_draft=True).update(is_draft=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("organization", "0135_add_devlink_component_to_project"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="eventregistrationconfig",
+            name="is_draft",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "When True, the registration configuration is incomplete and not "
+                    "visible to visitors. The organiser can save partial data and publish "
+                    "later. May only transition from True to False (one-way)."
+                ),
+                verbose_name="Is Draft",
+            ),
+        ),
+        migrations.RunPython(set_draft_configs, migrations.RunPython.noop),
+    ]

--- a/backend/organization/models/event_registration.py
+++ b/backend/organization/models/event_registration.py
@@ -121,6 +121,16 @@ class EventRegistrationConfig(models.Model):
         auto_now=True,
     )
 
+    is_draft = models.BooleanField(
+        default=False,
+        help_text=(
+            "When True, the registration configuration is incomplete and not "
+            "visible to visitors. The organiser can save partial data and publish "
+            "later. May only transition from True to False (one-way)."
+        ),
+        verbose_name="Is Draft",
+    )
+
     notify_admins = models.BooleanField(
         default=True,
         help_text=(

--- a/backend/organization/serializers/event_registration.py
+++ b/backend/organization/serializers/event_registration.py
@@ -109,6 +109,7 @@ class EventRegistrationConfigSerializer(EventRegistrationConfigBaseSerializer):
             "status",
             "available_seats",
             "notify_admins",
+            "is_draft",
         ]
         extra_kwargs = {
             # PositiveIntegerField gives us min_value via the model, but we set
@@ -121,6 +122,7 @@ class EventRegistrationConfigSerializer(EventRegistrationConfigBaseSerializer):
             # Editing after creation is done via PATCH /registration-config/ using
             # EditEventRegistrationConfigSerializer.
             "notify_admins": {"required": False},
+            "is_draft": {"required": False},
         }
 
     def get_available_seats(self, obj):
@@ -696,12 +698,14 @@ class EditEventRegistrationConfigSerializer(EventRegistrationConfigBaseSerialize
             "status",
             "available_seats",
             "notify_admins",
+            "is_draft",
         ]
         extra_kwargs = {
             "max_participants": {"required": False, "allow_null": True, "min_value": 1},
             "registration_end_date": {"required": False, "allow_null": True},
             "status": {"required": False},
             "notify_admins": {"required": False},
+            "is_draft": {"required": False},
         }
 
     def validate_status(self, value):
@@ -750,6 +754,11 @@ class EditEventRegistrationConfigSerializer(EventRegistrationConfigBaseSerialize
         capacity-driven heuristic.
         """
         fields_data = validated_data.pop("fields", None)
+        new_is_draft = validated_data.pop("is_draft", None)
+
+        # Handle is_draft transition (one-way: True → False only).
+        if new_is_draft is not None and not new_is_draft and instance.is_draft:
+            instance.is_draft = False
 
         explicit_status = validated_data.get("status")
 
@@ -787,6 +796,91 @@ class EditEventRegistrationConfigSerializer(EventRegistrationConfigBaseSerialize
         project = self.context.get("project") or (
             self.instance.project if self.instance else None
         )
+
+        # --- is_draft transition validation ---
+        if self.instance and "is_draft" in attrs:
+            new_is_draft = attrs["is_draft"]
+            if new_is_draft and not self.instance.is_draft:
+                # Already published — one-way transition: reject setting is_draft=True
+                raise serializers.ValidationError(
+                    {
+                        "is_draft": "Registration configuration has already been published."
+                    }
+                )
+            if not new_is_draft and self.instance.is_draft:
+                # Transitioning from draft to published — run full validation.
+                # Validate registration_end_date is present and valid.
+                reg_end = attrs.get(
+                    "registration_end_date", self.instance.registration_end_date
+                )
+                if reg_end is None:
+                    raise serializers.ValidationError(
+                        {
+                            "registration_end_date": "Required when publishing registration."
+                        }
+                    )
+                if reg_end <= timezone.now():
+                    raise serializers.ValidationError(
+                        {
+                            "registration_end_date": "Registration end date cannot be in the past."
+                        }
+                    )
+                max_p = attrs.get("max_participants", self.instance.max_participants)
+                if max_p is None:
+                    raise serializers.ValidationError(
+                        {"max_participants": "Required when publishing registration."}
+                    )
+                if project and project.end_date and reg_end > project.end_date:
+                    raise serializers.ValidationError(
+                        {
+                            "registration_end_date": (
+                                "Registration end date must be on or before the event end date."
+                            )
+                        }
+                    )
+                # Validate custom fields when publishing.
+                fields_data = attrs.get("fields")
+                if fields_data is not None and len(fields_data) > 5:
+                    raise serializers.ValidationError(
+                        {"fields": "Maximum 5 custom fields allowed per event."}
+                    )
+
+        # Field count and uniqueness checks — run for both draft and published.
+        if "fields" in attrs:
+            fields_data = attrs["fields"]
+            if len(fields_data) > 5:
+                raise serializers.ValidationError(
+                    {"fields": "Maximum 5 custom fields allowed per event."}
+                )
+            orders = [f.get("order") for f in fields_data if "order" in f]
+            if len(orders) != len(set(orders)):
+                raise serializers.ValidationError(
+                    {"fields": "Field order values must be unique within the event."}
+                )
+            # Verify submitted field IDs belong to this config.
+            submitted_ids = [f["id"] for f in fields_data if f.get("id") is not None]
+            if submitted_ids and self.instance:
+                existing_fields = {
+                    f.id: f
+                    for f in self.instance.fields.filter(
+                        id__in=submitted_ids
+                    ).prefetch_related("options")
+                }
+                unknown = set(submitted_ids) - set(existing_fields.keys())
+                if unknown:
+                    raise serializers.ValidationError(
+                        {
+                            "fields": f"Field IDs not found on this event: {sorted(unknown)}"
+                        }
+                    )
+
+        # --- Draft configs skip publish-time validation below ---
+        effective_is_draft = self.instance.is_draft if self.instance else True
+        if "is_draft" in attrs:
+            effective_is_draft = attrs["is_draft"]
+
+        if effective_is_draft:
+            return attrs
 
         registration_end_date = attrs.get("registration_end_date")
         if registration_end_date is not None:
@@ -867,21 +961,10 @@ class EditEventRegistrationConfigSerializer(EventRegistrationConfigBaseSerialize
                         }
                     )
 
-        # Field count, uniqueness, and ID existence checks.
+        # Answer-lock checks (published only) — immutable text properties
+        # cannot change once registrants have submitted answers.
         if "fields" in attrs:
             fields_data = attrs["fields"]
-            if len(fields_data) > 5:
-                raise serializers.ValidationError(
-                    {"fields": "Maximum 5 custom fields allowed per event."}
-                )
-            orders = [f.get("order") for f in fields_data if "order" in f]
-            if len(orders) != len(set(orders)):
-                raise serializers.ValidationError(
-                    {"fields": "Field order values must be unique within the event."}
-                )
-            # Verify submitted field IDs belong to this config; also enforce
-            # answer-lock: immutable text properties cannot change once registrants
-            # have submitted answers referencing that field or option.
             submitted_ids = [f["id"] for f in fields_data if f.get("id") is not None]
             if submitted_ids and self.instance:
                 existing_fields = {
@@ -890,13 +973,6 @@ class EditEventRegistrationConfigSerializer(EventRegistrationConfigBaseSerialize
                         id__in=submitted_ids
                     ).prefetch_related("options")
                 }
-                unknown = set(submitted_ids) - set(existing_fields.keys())
-                if unknown:
-                    raise serializers.ValidationError(
-                        {
-                            "fields": f"Field IDs not found on this event: {sorted(unknown)}"
-                        }
-                    )
 
                 for i, field_data in enumerate(fields_data):
                     field_id = field_data.get("id")

--- a/backend/organization/serializers/project.py
+++ b/backend/organization/serializers/project.py
@@ -221,14 +221,32 @@ class ProjectSerializer(_LocationNameMixin, serializers.ModelSerializer):
         return 0
 
     def get_registration_config(self, obj):
-        """Return event registration config including available_seats (detail only)."""
+        """Return event registration config including available_seats (detail only).
+
+        Draft configs are only visible to project admins. Non-admin viewers
+        see None — the config is not yet published and should not be exposed.
+        """
         try:
-            return EventRegistrationConfigSerializer(
-                obj.registration_config,
-                context={"include_seat_count": True},
-            ).data
+            rc = obj.registration_config
         except EventRegistrationConfig.DoesNotExist:
             return None
+
+        if rc.is_draft:
+            request = self.context.get("request")
+            if not request or not request.user.is_authenticated:
+                return None
+            is_admin = ProjectMember.objects.filter(
+                project=obj,
+                user=request.user,
+                role__role_type__in=[Role.ALL_TYPE, Role.READ_WRITE_TYPE],
+            ).exists()
+            if not is_admin:
+                return None
+
+        return EventRegistrationConfigSerializer(
+            rc,
+            context={"include_seat_count": True},
+        ).data
 
     def get_my_event_registration(self, obj):
         """
@@ -513,11 +531,28 @@ class ProjectStubSerializer(_LocationNameMixin, serializers.ModelSerializer):
         return serializer.data
 
     def get_registration_config(self, obj):
-        """Return event registration config if present, else None."""
+        """Return event registration config if present, else None.
+
+        Draft configs are only visible to project admins.
+        """
         try:
-            return EventRegistrationConfigSerializer(obj.registration_config).data
+            rc = obj.registration_config
         except EventRegistrationConfig.DoesNotExist:
             return None
+
+        if rc.is_draft:
+            request = self.context.get("request")
+            if not request or not request.user.is_authenticated:
+                return None
+            is_admin = ProjectMember.objects.filter(
+                project=obj,
+                user=request.user,
+                role__role_type__in=[Role.ALL_TYPE, Role.READ_WRITE_TYPE],
+            ).exists()
+            if not is_admin:
+                return None
+
+        return EventRegistrationConfigSerializer(rc).data
 
 
 class ProjectSuggestionSerializer(ProjectStubSerializer):

--- a/backend/organization/tests/test_event_registration_custom_fields.py
+++ b/backend/organization/tests/test_event_registration_custom_fields.py
@@ -115,6 +115,7 @@ class _CustomFieldsBase(APITestCase):
         self.draft_er = EventRegistrationConfig.objects.create(
             project=self.draft_event,
             status=RegistrationStatus.OPEN,
+            is_draft=True,
         )
         ProjectMember.objects.create(
             user=self.organiser, project=self.event, role=self.admin_role
@@ -731,8 +732,8 @@ class TestEditRegistrationConfigFields(_CustomFieldsBase):
             for i in range(6)
         ]
         response = self.client.patch(
-            self.patch_url,
-            {"is_draft": True, "fields": fields},
+            self.draft_patch_url,
+            {"fields": fields},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -745,9 +746,8 @@ class TestEditRegistrationConfigFields(_CustomFieldsBase):
         """A field ID that doesn't belong to this event returns 400."""
         self.client.login(username="organiser_cf", password="testpassword")
         response = self.client.patch(
-            self.patch_url,
+            self.draft_patch_url,
             {
-                "is_draft": True,
                 "fields": [{"id": 999999, "order": 0, "label": "Checkbox 1"}],
             },
             format="json",
@@ -761,9 +761,8 @@ class TestEditRegistrationConfigFields(_CustomFieldsBase):
         """Two fields with the same order value return 400."""
         self.client.login(username="organiser_cf", password="testpassword")
         response = self.client.patch(
-            self.patch_url,
+            self.draft_patch_url,
             {
-                "is_draft": True,
                 "fields": [
                     {
                         "field_type": "checkbox",
@@ -1648,6 +1647,7 @@ class TestInventoryField(_CustomFieldsBase):
         draft_er = EventRegistrationConfig.objects.create(
             project=draft_event,
             status=RegistrationStatus.OPEN,
+            is_draft=True,
         )
         ProjectMember.objects.create(
             user=self.organiser, project=draft_event, role=self.admin_role
@@ -1922,8 +1922,8 @@ class TestInventoryField(_CustomFieldsBase):
             }
         ]
         response = self.client.patch(
-            self.patch_url,
-            {"is_draft": True, "fields": fields},
+            self.draft_patch_url,
+            {"fields": fields},
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/backend/organization/tests/test_event_registration_draft_mode.py
+++ b/backend/organization/tests/test_event_registration_draft_mode.py
@@ -1,0 +1,697 @@
+"""
+Tests for the EventRegistrationConfig is_draft lifecycle feature.
+
+Covers spec acceptance-criteria test cases from
+doc/spec/20260528_1454_validate_registration_config_on_publish.md:
+
+  1  – Create draft project with registration config → config.is_draft = True
+  2  – Create published project with registration config → config.is_draft = False
+  3  – PATCH registration config, save as draft (no is_draft in body) → 200, is_draft stays True
+  4  – PATCH registration config, publish with complete data → 200, is_draft = False
+  5  – PATCH registration config, publish with missing max_participants → 400
+  6  – PATCH registration config, publish with registration_end_date after project.end_date → 400
+  7  – PATCH registration config, set is_draft=True on published config → 400 (one-way)
+  8  – Publish project with draft registration config → 200, config stays draft
+  9  – Publish project with published config, date collision → 400
+  10 – Publish project with published config, no collision → 200
+  11 – Publish project without registration config → 200
+  12 – API response: draft config hidden for non-admin, visible for admin
+"""
+
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import tag
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from climateconnect_api.models import Language, Role, UserProfile
+from location.models import Location
+from organization.models import Project, ProjectMember, ProjectStatus
+from organization.models.event_registration import (
+    EventRegistrationConfig,
+    RegistrationStatus,
+)
+
+from ._helpers import _make_black_image_b64
+
+# ---------------------------------------------------------------------------
+# Shared base mixin — creates common fixtures for draft-mode tests
+# ---------------------------------------------------------------------------
+
+
+class _DraftModeBase(APITestCase):
+    """
+    Shared setUp for is_draft lifecycle tests.
+
+    Creates:
+        self.organiser       — ALL_TYPE project member
+        self.viewer          — authenticated user with no project membership
+        self.project_status  — active status (id=2)
+        self.default_language — English
+        self.image           — base64 encoded image for project creation
+        self.location_data   — test location payload
+        self.event_project_type — project_type payload for events
+    """
+
+    def setUp(self):
+        self.project_status, _ = ProjectStatus.objects.update_or_create(
+            id=2,
+            defaults={
+                "name": "active_draft_mode",
+                "name_de_translation": "aktiv",
+                "has_end_date": True,
+                "has_start_date": True,
+            },
+        )
+        self.default_language, _ = Language.objects.get_or_create(
+            language_code="en",
+            defaults={"name": "English", "native_name": "English"},
+        )
+        self.admin_role = Role.objects.create(
+            name="AdminDraftMode", role_type=Role.ALL_TYPE
+        )
+        self.read_write_role = Role.objects.create(
+            name="ReadWriteDraftMode", role_type=Role.READ_WRITE_TYPE
+        )
+        self.read_only_role = Role.objects.create(
+            name="ReadOnlyDraftMode", role_type=Role.READ_ONLY_TYPE
+        )
+
+        self.organiser = User.objects.create_user(
+            username="organiser_draft_mode", password="testpassword"
+        )
+        self.viewer = User.objects.create_user(
+            username="viewer_draft_mode", password="testpassword"
+        )
+
+        Location.objects.get_or_create(
+            city="Draft City",
+            country="Draftland",
+            defaults={"name": "Draft City, Draftland", "place_id": 8888},
+        )
+        self.image = _make_black_image_b64()
+        self.location_data = {
+            "place_id": 8888,
+            "country": "Draftland",
+            "city": "Draft City",
+            "name": "Draft City",
+            "type": "city",
+            "lon": 13.0,
+            "lat": 52.0,
+        }
+        self.event_project_type = {
+            "name": "Event",
+            "original_name": "Event",
+            "help_text": "Your Project will show up in the Event calendar",
+            "icon": "",
+            "type_id": "event",
+        }
+
+
+# ---------------------------------------------------------------------------
+# 1 & 2: Create flow — config.is_draft inherits project.is_draft
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDraftMode(_DraftModeBase):
+    """Tests 1 & 2: Create flow — config.is_draft inherits project.is_draft."""
+
+    def _base_payload(self, **overrides):
+        data = {
+            "name": "Draft Mode Create Test",
+            "status": self.project_status.id,
+            "short_description": "Testing draft mode creation",
+            "collaborators_welcome": False,
+            "team_members": [],
+            "project_tags": [],
+            "sectors": [],
+            "loc": self.location_data,
+            "image": self.image,
+            "source_language": self.default_language.language_code,
+            "translations": {},
+            "project_type": self.event_project_type,
+            "hubName": None,
+            "start_date": "2026-07-01T10:00:00Z",
+            "end_date": "2026-08-01T20:00:00Z",
+        }
+        data.update(overrides)
+        return data
+
+    @tag("registration_config", "draft_mode")
+    def test_create_draft_project_with_registration_config_sets_is_draft_true(self):
+        """Test 1: Draft project → config.is_draft = True."""
+        url = reverse("organization:create-project-api")
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+        payload = self._base_payload(
+            is_draft=True,
+            registration_config={
+                "max_participants": None,
+                "registration_end_date": None,
+            },
+        )
+        response = self.client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+        project = Project.objects.get(url_slug=response.data["url_slug"])
+        rc = project.registration_config
+        self.assertTrue(rc.is_draft)
+
+    @tag("registration_config", "draft_mode")
+    def test_create_published_project_with_registration_config_sets_is_draft_false(
+        self,
+    ):
+        """Test 2: Published project → config.is_draft = False."""
+        url = reverse("organization:create-project-api")
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+        payload = self._base_payload(
+            is_draft=False,
+            registration_config={
+                "max_participants": 50,
+                "registration_end_date": "2026-07-15T23:59:00Z",
+            },
+        )
+        response = self.client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+        project = Project.objects.get(url_slug=response.data["url_slug"])
+        rc = project.registration_config
+        self.assertFalse(rc.is_draft)
+
+
+# ---------------------------------------------------------------------------
+# 3–7: Registration config PATCH — draft → published transition
+# ---------------------------------------------------------------------------
+
+
+class TestEditRegistrationConfigDraftMode(_DraftModeBase):
+    """
+    Tests 3–7: PATCH /registration-config/ draft → published transition.
+
+    Uses separate projects for each test to avoid state leakage.
+    """
+
+    def _create_draft_project_and_config(self, **rc_overrides):
+        """Helper: create a draft project with a draft registration config."""
+        project = Project.objects.create(
+            name="Draft Edit Test",
+            url_slug="draft-edit-test",
+            is_active=True,
+            is_draft=True,
+            status=self.project_status,
+            language=self.default_language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=10),
+            end_date=timezone.now() + timedelta(days=60),
+        )
+        defaults = {"is_draft": True, "status": RegistrationStatus.OPEN}
+        defaults.update(rc_overrides)
+        rc = EventRegistrationConfig.objects.create(project=project, **defaults)
+        ProjectMember.objects.create(
+            user=self.organiser, project=project, role=self.admin_role
+        )
+        return project, rc
+
+    def _create_published_project_and_config(self, **rc_overrides):
+        """Helper: create a published project with a published registration config."""
+        project = Project.objects.create(
+            name="Published Edit Test",
+            url_slug="published-edit-test",
+            is_active=True,
+            is_draft=False,
+            status=self.project_status,
+            language=self.default_language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=30),
+            end_date=timezone.now() + timedelta(days=90),
+        )
+        defaults = {
+            "is_draft": False,
+            "status": RegistrationStatus.OPEN,
+            "max_participants": 100,
+            "registration_end_date": timezone.now() + timedelta(days=60),
+        }
+        defaults.update(rc_overrides)
+        rc = EventRegistrationConfig.objects.create(project=project, **defaults)
+        ProjectMember.objects.create(
+            user=self.organiser, project=project, role=self.admin_role
+        )
+        return project, rc
+
+    def _patch_url(self, slug):
+        return reverse(
+            "organization:edit-registration-config",
+            kwargs={"url_slug": slug},
+        )
+
+    # -- Test 3: save as draft (no is_draft in body) ---
+
+    @tag("registration_config", "draft_mode")
+    def test_save_as_draft_without_is_draft_in_body_keeps_draft(self):
+        """Test 3: PATCH without is_draft in body → 200, is_draft stays True."""
+        project, rc = self._create_draft_project_and_config()
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+
+        response = self.client.patch(
+            self._patch_url(project.url_slug),
+            {"max_participants": 30},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        rc.refresh_from_db()
+        self.assertTrue(rc.is_draft)
+        self.assertEqual(rc.max_participants, 30)
+
+    # -- Test 4: publish with complete data ---
+
+    @tag("registration_config", "draft_mode")
+    def test_publish_registration_config_with_complete_data_succeeds(self):
+        """Test 4: PATCH is_draft=false with complete data → 200, is_draft=False."""
+        project, rc = self._create_draft_project_and_config()
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+
+        response = self.client.patch(
+            self._patch_url(project.url_slug),
+            {
+                "is_draft": False,
+                "max_participants": 50,
+                "registration_end_date": (
+                    timezone.now() + timedelta(days=30)
+                ).isoformat(),
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        rc.refresh_from_db()
+        self.assertFalse(rc.is_draft)
+        self.assertEqual(rc.max_participants, 50)
+
+    # -- Test 5: publish with missing max_participants ---
+
+    @tag("registration_config", "draft_mode")
+    def test_publish_registration_config_without_max_participants_fails(self):
+        """Test 5: PATCH is_draft=false without max_participants → 400."""
+        project, rc = self._create_draft_project_and_config()
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+
+        response = self.client.patch(
+            self._patch_url(project.url_slug),
+            {
+                "is_draft": False,
+                "registration_end_date": (
+                    timezone.now() + timedelta(days=30)
+                ).isoformat(),
+            },
+            format="json",
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+        self.assertIn("max_participants", response.data)
+        rc.refresh_from_db()
+        self.assertTrue(rc.is_draft)  # Still draft
+
+    # -- Test 5b: publish with missing registration_end_date ---
+
+    @tag("registration_config", "draft_mode")
+    def test_publish_registration_config_without_registration_end_date_fails(self):
+        """PATCH is_draft=false without registration_end_date → 400."""
+        project, rc = self._create_draft_project_and_config()
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+
+        response = self.client.patch(
+            self._patch_url(project.url_slug),
+            {"is_draft": False, "max_participants": 50},
+            format="json",
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+        self.assertIn("registration_end_date", response.data)
+        rc.refresh_from_db()
+        self.assertTrue(rc.is_draft)
+
+    # -- Test 6: publish with date collision ---
+
+    @tag("registration_config", "draft_mode")
+    def test_publish_registration_config_with_date_collision_fails(self):
+        """Test 6: registration_end_date > project.end_date → 400."""
+        project, rc = self._create_draft_project_and_config()
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+
+        # Set registration_end_date after project.end_date
+        after_event_end = project.end_date + timedelta(days=5)
+        response = self.client.patch(
+            self._patch_url(project.url_slug),
+            {
+                "is_draft": False,
+                "max_participants": 50,
+                "registration_end_date": after_event_end.isoformat(),
+            },
+            format="json",
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+        self.assertIn("registration_end_date", response.data)
+        self.assertIn("event end date", str(response.data["registration_end_date"]))
+
+    # -- Test 7: one-way transition rejection ---
+
+    @tag("registration_config", "draft_mode")
+    def test_cannot_set_is_draft_true_on_published_config(self):
+        """Test 7: PATCH is_draft=true on a published config → 400."""
+        project, rc = self._create_published_project_and_config()
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+
+        response = self.client.patch(
+            self._patch_url(project.url_slug),
+            {"is_draft": True},
+            format="json",
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+        self.assertIn("is_draft", response.data)
+        rc.refresh_from_db()
+        self.assertFalse(rc.is_draft)  # Still published
+
+
+# ---------------------------------------------------------------------------
+# 8–11: Project PATCH — publish project with draft/published config
+# ---------------------------------------------------------------------------
+
+
+class TestPublishProjectWithRegistrationConfig(_DraftModeBase):
+    """
+    Tests 8–11: PATCH /api/projects/{slug}/ with is_draft transition.
+
+    Tests date collision checks when publishing projects with registration configs.
+    """
+
+    def _create_project_and_config(
+        self, *, project_is_draft, config_is_draft, slug, **rc_overrides
+    ):
+        project = Project.objects.create(
+            name=f"Publish Test {slug}",
+            url_slug=slug,
+            is_active=True,
+            is_draft=project_is_draft,
+            status=self.project_status,
+            language=self.default_language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=30),
+            end_date=timezone.now() + timedelta(days=90),
+        )
+        defaults = {
+            "is_draft": config_is_draft,
+            "status": RegistrationStatus.OPEN,
+            "max_participants": 50,
+            "registration_end_date": timezone.now() + timedelta(days=60),
+        }
+        defaults.update(rc_overrides)
+        EventRegistrationConfig.objects.create(project=project, **defaults)
+        ProjectMember.objects.create(
+            user=self.organiser, project=project, role=self.admin_role
+        )
+        return project
+
+    def _project_url(self, slug):
+        return reverse("organization:project-api-view", kwargs={"url_slug": slug})
+
+    # -- Test 8: publish project with draft config → succeeds ---
+
+    @tag("registration_config", "draft_mode")
+    def test_publish_project_with_draft_registration_config_succeeds(self):
+        """Test 8: Publishing a project with draft config → 200, config stays draft."""
+        project = self._create_project_and_config(
+            project_is_draft=True,
+            config_is_draft=True,
+            slug="publish-draft-config",
+            max_participants=None,
+            registration_end_date=None,
+        )
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+
+        response = self.client.patch(
+            self._project_url(project.url_slug),
+            {"is_draft": False},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        project.refresh_from_db()
+        self.assertFalse(project.is_draft)
+        rc = project.registration_config
+        rc.refresh_from_db()
+        self.assertTrue(rc.is_draft)  # Config stays draft
+
+    # -- Test 9: publish project with published config, date collision → 400 ---
+
+    @tag("registration_config", "draft_mode")
+    def test_publish_project_with_published_config_date_collision_fails(self):
+        """Test 9: registration_end_date > new end_date → 400."""
+        project = self._create_project_and_config(
+            project_is_draft=True,
+            config_is_draft=False,
+            slug="publish-date-collision",
+        )
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+
+        # Change end_date to be before the registration_end_date
+        new_end = timezone.now() + timedelta(days=10)  # reg end is +60
+        response = self.client.patch(
+            self._project_url(project.url_slug),
+            {"is_draft": False, "end_date": new_end.isoformat()},
+            format="json",
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+        self.assertIn("registration_config", response.data)
+        self.assertIn("registration_end_date", response.data["registration_config"])
+
+    # -- Test 9b: publish project with published config, changing end_date to collide ---
+
+    @tag("registration_config", "draft_mode")
+    def test_publish_project_end_date_change_causes_date_collision(self):
+        """Publish project, changing end_date to be before existing reg_end → 400."""
+        project = self._create_project_and_config(
+            project_is_draft=False,
+            config_is_draft=False,
+            slug="end-date-change-collision",
+        )
+        # Re-draft the project to allow re-publishing
+        project.is_draft = True
+        project.save(update_fields=["is_draft"])
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+
+        # Change end_date to be before registration_end_date (+60 days)
+        new_end = timezone.now() + timedelta(days=10)
+        response = self.client.patch(
+            self._project_url(project.url_slug),
+            {"is_draft": False, "end_date": new_end.isoformat()},
+            format="json",
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+        )
+        self.assertIn("registration_config", response.data)
+
+    # -- Test 10: publish project with published config, no collision → 200 ---
+
+    @tag("registration_config", "draft_mode")
+    def test_publish_project_with_published_config_no_collision_succeeds(self):
+        """Test 10: registration_end_date ≤ end_date → 200."""
+        project = self._create_project_and_config(
+            project_is_draft=True,
+            config_is_draft=False,
+            slug="publish-no-collision",
+        )
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+
+        response = self.client.patch(
+            self._project_url(project.url_slug),
+            {"is_draft": False},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        project.refresh_from_db()
+        self.assertFalse(project.is_draft)
+
+    # -- Test 11: publish project without registration config → 200 ---
+
+    @tag("registration_config", "draft_mode")
+    def test_publish_project_without_registration_config_succeeds(self):
+        """Test 11: Project without registration config → 200, no registration validation."""
+        project = Project.objects.create(
+            name="No Reg Config",
+            url_slug="no-reg-config",
+            is_active=True,
+            is_draft=True,
+            status=self.project_status,
+            language=self.default_language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=30),
+            end_date=timezone.now() + timedelta(days=90),
+        )
+        ProjectMember.objects.create(
+            user=self.organiser, project=project, role=self.admin_role
+        )
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+
+        response = self.client.patch(
+            self._project_url(project.url_slug),
+            {"is_draft": False},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        project.refresh_from_db()
+        self.assertFalse(project.is_draft)
+
+    # -- Test 11b: non-event project is unaffected ---
+
+    @tag("registration_config", "draft_mode")
+    def test_publish_non_event_project_unaffected(self):
+        """Non-event project publish → 200, no registration validation."""
+        project = Project.objects.create(
+            name="Non Event Project",
+            url_slug="non-event-project",
+            is_active=True,
+            is_draft=True,
+            status=self.project_status,
+            language=self.default_language,
+            project_type="PK",  # not an event
+            start_date=timezone.now() + timedelta(days=30),
+            end_date=timezone.now() + timedelta(days=90),
+        )
+        ProjectMember.objects.create(
+            user=self.organiser, project=project, role=self.admin_role
+        )
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+
+        response = self.client.patch(
+            self._project_url(project.url_slug),
+            {"is_draft": False},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
+
+# ---------------------------------------------------------------------------
+# 12: API response filtering — draft configs hidden for non-admins
+# ---------------------------------------------------------------------------
+
+
+class TestDraftConfigAPIResponseFiltering(_DraftModeBase):
+    """
+    Test 12: API response filtering for draft registration configs.
+
+    Draft configs should be:
+      - Hidden (None) for non-authenticated users
+      - Hidden (None) for non-admin users
+      - Visible for project admins
+    """
+
+    def setUp(self):
+        super().setUp()
+        # The list endpoint requires a UserProfile on each user.
+        UserProfile.objects.get_or_create(user=self.organiser)
+        UserProfile.objects.get_or_create(user=self.viewer)
+        self.event = Project.objects.create(
+            name="Filter Test Event",
+            url_slug="filter-test-event",
+            is_active=True,
+            is_draft=False,
+            status=self.project_status,
+            language=self.default_language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=30),
+            end_date=timezone.now() + timedelta(days=90),
+        )
+        self.rc = EventRegistrationConfig.objects.create(
+            project=self.event,
+            max_participants=50,
+            registration_end_date=timezone.now() + timedelta(days=60),
+            status=RegistrationStatus.OPEN,
+            is_draft=True,
+        )
+        ProjectMember.objects.create(
+            user=self.organiser, project=self.event, role=self.admin_role
+        )
+        # viewer has no membership on this event
+
+    def _detail_url(self):
+        return reverse(
+            "organization:project-api-view",
+            kwargs={"url_slug": self.event.url_slug},
+        )
+
+    def _list_url(self):
+        return reverse("organization:list-projects")
+
+    @tag("registration_config", "draft_mode")
+    def test_draft_config_hidden_for_unauthenticated_detail_view(self):
+        """Unauthenticated GET detail → registration_config is None."""
+        response = self.client.get(self._detail_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data.get("registration_config"))
+
+    @tag("registration_config", "draft_mode")
+    def test_draft_config_hidden_for_non_admin_detail_view(self):
+        """Non-admin GET detail → registration_config is None."""
+        self.client.login(username="viewer_draft_mode", password="testpassword")
+        response = self.client.get(self._detail_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data.get("registration_config"))
+
+    @tag("registration_config", "draft_mode")
+    def test_draft_config_visible_for_admin_detail_view(self):
+        """Admin GET detail → registration_config is present with is_draft=True."""
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+        response = self.client.get(self._detail_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        rc = response.data.get("registration_config")
+        self.assertIsNotNone(rc)
+        self.assertTrue(rc["is_draft"])
+
+    @tag("registration_config", "draft_mode")
+    def test_draft_config_hidden_for_non_admin_list_view(self):
+        """Non-admin GET list → registration_config is None."""
+        self.client.login(username="viewer_draft_mode", password="testpassword")
+        response = self.client.get(self._list_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Find our project in the results
+        results = response.data.get("results", [])
+        our_project = next(
+            (p for p in results if p["url_slug"] == self.event.url_slug), None
+        )
+        if our_project:
+            self.assertIsNone(our_project.get("registration_config"))
+
+    @tag("registration_config", "draft_mode")
+    def test_draft_config_visible_for_admin_list_view(self):
+        """Admin GET list → registration_config is present with is_draft=True."""
+        self.client.login(username="organiser_draft_mode", password="testpassword")
+        response = self.client.get(self._list_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get("results", [])
+        our_project = next(
+            (p for p in results if p["url_slug"] == self.event.url_slug), None
+        )
+        if our_project:
+            rc = our_project.get("registration_config")
+            self.assertIsNotNone(rc)
+            self.assertTrue(rc["is_draft"])
+
+    @tag("registration_config", "draft_mode")
+    def test_published_config_visible_for_all_detail_view(self):
+        """Published config → visible to everyone."""
+        self.rc.is_draft = False
+        self.rc.save(update_fields=["is_draft"])
+        response = self.client.get(self._detail_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        rc = response.data.get("registration_config")
+        self.assertIsNotNone(rc)
+        self.assertFalse(rc["is_draft"])

--- a/backend/organization/views/event_registration_views.py
+++ b/backend/organization/views/event_registration_views.py
@@ -564,10 +564,14 @@ class EditRegistrationConfigView(APIView):
             )
 
         # ── 4. Validate and save ─────────────────────────────────────────────
-        # Derive is_draft from the project's stored state, not the request body.
-        # Draft events skip publish-time field validation (e.g. empty checkbox
+        # Derive is_draft from the config's own state, not the project's.
+        # Draft configs skip publish-time field validation (e.g. empty checkbox
         # description) without requiring the frontend to pass extra state.
-        is_draft = project.is_draft
+        # When is_draft is in the request body, the serializer handles the
+        # draft → published transition and runs full validation.
+        is_draft = rc.is_draft
+        if "is_draft" in request.data:
+            is_draft = bool(request.data["is_draft"])
         serializer = EditEventRegistrationConfigSerializer(
             rc,
             data=request.data,

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -596,9 +596,11 @@ class CreateProjectView(APIView):
         # Create EventRegistrationConfig (and any nested custom fields) atomically.
         # Using serializer.save() so the serializer's create() handles nested fields.
         if er_serializer is not None:
-            er_serializer.save(project=project)
+            er_serializer.save(project=project, is_draft=is_draft)
             logger.info(
-                "EventRegistrationConfig created for project %s", project.url_slug
+                "EventRegistrationConfig created for project %s (is_draft=%s)",
+                project.url_slug,
+                is_draft,
             )
 
         if translations_object and translations and source_language:
@@ -961,6 +963,29 @@ class ProjectAPIView(APIView):
         if "is_draft" in request.data:
             # One way transition: draft → published, never back
             project.is_draft = False
+            # Date collision check: if the project has a published registration
+            # config, validate registration_end_date <= new end_date.
+            if hasattr(project, "registration_config"):
+                rc = project.registration_config
+                if not rc.is_draft and rc.registration_end_date:
+                    effective_end = (
+                        parse(request.data["end_date"])
+                        if "end_date" in request.data
+                        else project.end_date
+                    )
+                    if effective_end and rc.registration_end_date > effective_end:
+                        return Response(
+                            {
+                                "registration_config": {
+                                    "registration_end_date": (
+                                        "Registration end date must be on or before "
+                                        "the event end date. Update the registration "
+                                        "settings before publishing."
+                                    )
+                                }
+                            },
+                            status=status.HTTP_400_BAD_REQUEST,
+                        )
         if "is_personal_project" in request.data:
             if request.data["is_personal_project"] is True:
                 project_parents = ProjectParents.objects.get(project=project)

--- a/doc/spec/20260528_1454_validate_registration_config_on_publish.md
+++ b/doc/spec/20260528_1454_validate_registration_config_on_publish.md
@@ -1,0 +1,490 @@
+# Validate Registration Config on Project Publish
+
+**Status**: DRAFT
+**Type**: Feature
+**Date and time created**: 2026-05-28 14:54
+**Epic**: [`EPIC_event_registration.md`](./EPIC_event_registration.md)
+**Related Specs**:
+- [`20260513_1310_edit_project_form_button_reorganization.md`](./20260513_1310_edit_project_form_button_reorganization.md) ← added the "Edit registration settings" button to the edit project form
+- [`20260416_1000_event_registration_custom_fields.md`](./20260416_1000_event_registration_custom_fields.md) ← foundational custom fields spec; defines publish-time validation rules for fields
+
+---
+
+## Problem Statement
+
+When an organiser creates a draft event with online registration, both the project details and the registration configuration are allowed to be incomplete — the create validator explicitly relaxes requirements for drafts. However, when the organiser later edits the project and attempts to publish it (draft → published transition), there is **no validation of the registration configuration's completeness or correctness**. This means a published event can have an incomplete or invalid registration configuration (e.g. missing `max_participants`, missing or past `registration_end_date`, `registration_end_date` after the event's `end_date`, or custom fields without required settings).
+
+The root cause is twofold:
+
+1. **Backend**: `ProjectAPIView.patch()` unconditionally sets `is_draft = False` when the `is_draft` key is present in the request, but does not validate the existing `EventRegistrationConfig` against publish-time rules. The `CreateProjectView` does this validation (lines 541–563), but the edit/publish path does not.
+2. **Frontend**: `checkIfProjectValid(false)` in `EditProjectRoot.tsx` validates project-level fields (image, location, dates) but does not check registration configuration completeness. The `EditEventRegistrationModal` has its own validation, but it is disconnected from the publish flow — the user can publish without ever opening the modal.
+
+### The State Dependency Challenge
+
+The edit project form and the registration configuration editor are **two separate forms with separate APIs**. When the user edits project details (e.g. changes `end_date`) in the edit project form — **unsaved** — and then opens the `EditEventRegistrationModal`, the modal validates `registration_end_date ≤ end_date` against the unsaved value. But when the modal saves via its own API (`PATCH /registration-config/`), the backend uses the **old** `end_date`. This can fail or create an invalid state.
+
+### Solution: Independent Draft Lifecycles
+
+The registration configuration is treated as a **separate entity** with its own `is_draft` flag, independent of the project's `is_draft`. This eliminates the state dependency by allowing the two entities to have independent lifecycles:
+
+- A project can be published while its registration config is still draft.
+- The registration config is completed and published separately.
+- Date collision validation (`registration_end_date ≤ end_date`) runs at project publish time for any published registration config, and at config publish time against the current project state.
+
+This approach also naturally supports the upcoming feature to **add registration configuration to an already-published event** — the same draft → publish lifecycle applies.
+
+---
+
+## Core Requirements
+
+1. `EventRegistrationConfig` gains an `is_draft` field. When a draft project is created with registration, the config is also draft. When a published project is created, the config is published (as today).
+2. Publishing a project with a **draft** registration config is allowed — the event goes live but registration is not yet visible to visitors. Only a date collision check (`registration_end_date > end_date`) is enforced.
+3. Publishing a project with a **published** registration config triggers full publish-time validation (same rules as today).
+4. The registration config editor (modal) shows the draft state and offers two actions: "Save as draft" (relaxed validation) and "Publish registration" (full validation).
+5. The project detail page does **not** show registration UI (register button, guest count, etc.) when the config is draft — only admins see a setup prompt.
+6. The edit project form shows a **soft warning** (not a blocker) when the config is draft at publish time.
+7. The registrations tab shows a setup prompt for admins when the config is draft.
+
+**Explicitly Out of Scope:**
+
+- Changing the create project flow (`ShareProjectRoot`) — it already validates registration config on publish. Only the `is_draft` assignment changes.
+- Adding the ability to create a registration config from the edit form for events that don't have one yet (future task, but this spec's architecture supports it).
+- Changing the `PATCH /registration-config/` endpoint's existing behavior for published configs.
+
+### Non-Functional Requirements
+
+- **No breaking changes** to existing API contracts. The `PATCH /registration-config/` endpoint continues to work for published configs. The `is_draft` field is additive.
+- **Toggle gate**: all new frontend UI must be gated behind `isEnabled("EVENT_REGISTRATION")`. No new toggle required.
+- **Migration**: a minor migration adds `is_draft` to `EventRegistrationConfig` with `default=False`. Existing published configs remain `is_draft=False`. Existing draft project configs are set to `is_draft=True` via a data migration.
+- **Consistent validation rules**: the same `EventRegistrationConfigSerializer` validation logic is reused — it already reads `is_draft` from context. The only change is the source of the flag.
+
+### AI Agent Insights and Additions
+
+- **Current `is_draft` source**: `EventRegistrationConfigSerializer.validate()` reads `is_draft` from `self.context["is_draft"]`. Currently, the context is populated from the project's `is_draft` in both `CreateProjectView` (line 556) and `EditRegistrationConfigView` (line 570). The change is to use the config's own `is_draft` field instead.
+
+- **`shouldShowRegisterButton()`** in `frontend/src/utils/eventRegistrationHelpers.ts` (line 9–18) already checks `!project.is_draft`. It must also check `!project.registration_config.is_draft` (or the config's effective draft state).
+
+- **`getRegistrationUIState()`** in `frontend/src/utils/eventRegistrationHelpers.ts` (line 80–106) returns `"hidden"` when `project.is_draft` is true (line 90). It must also return `"hidden"` when `registration_config.is_draft` is true — unless the viewer is an admin (admins should see a setup prompt instead).
+
+- **`EditEventRegistrationModal`** in `frontend/src/components/project/EditEventRegistrationModal.tsx` (line 96) currently has a single "Save" button (line 540–549). It needs two buttons when the config is draft: "Save as draft" (relaxed validation) and "Publish registration" (full validation). The `isDraft` prop (line 166) is currently derived from `project.is_draft`. It should be derived from the config's own `is_draft` state, OR a new `isConfigDraft` prop should be added.
+
+- **`EditRegistrationConfigView.patch()`** in `backend/organization/views/event_registration_views.py` (line 534) currently derives `is_draft` from `project.is_draft` (line 570). It must: (a) read `is_draft` from the config's own field, (b) accept `is_draft` in the request body to allow the draft → published transition, (c) run full validation when transitioning to published.
+
+- **`ProjectAPIView.patch()`** in `backend/organization/views/project_views.py` (line 961–963): when setting `is_draft = False`, check if the project has a registration config that is **not** draft. If so, validate the config's `registration_end_date` against the project's `end_date` (incoming or existing). If the config is draft, skip this check — the config will be validated when it is published.
+
+- **Create flow**: `CreateProjectView.post()` creates the registration config via `er_serializer.save(project=project)` (line 599). When the project is draft (`is_draft=True`), set `registration_config.is_draft = True` on the created config. When the project is published, `is_draft=False` (as today).
+
+- **Registrations tab**: `ProjectRegistrationsContent.tsx` (line 47) renders the guest list and management UI. When the config is draft, it should show a setup prompt instead: "Registration is not yet set up. [Complete registration setup]" — clicking opens the `EditEventRegistrationModal`.
+
+- **Draft registration config hidden from visitors**: The project detail page checks `project.registration_config` to decide whether to render registration modals and buttons (lines 819, 827, 842 in `ProjectPageRoot.tsx`). When `registration_config.is_draft` is true, these should not render for non-admin users. For admins, a setup prompt should be shown.
+
+---
+
+## System Impact
+
+### Actors
+- **Event organiser** (admin role): edits the project, publishes, and separately publishes the registration config.
+- **Event visitor/member**: sees registration UI only when the config is published.
+- **Backend API**: enforces draft/published state on registration config independently from the project.
+
+### Entities Changed
+- `EventRegistrationConfig`: gains `is_draft` BooleanField.
+- No new entities.
+
+### Flows Changed
+- **Edit project → Publish**: no longer blocked by incomplete registration config. Soft warning shown if config is still draft.
+- **Registration config → Publish**: new flow — full validation, sets `is_draft = False`.
+- **Project detail page**: registration UI hidden when config is draft (visitors). Setup prompt shown (admins).
+- **Registrations tab**: setup prompt when config is draft (admins).
+
+### Integration Changes
+- `PATCH /registration-config/` accepts `is_draft` in request body for draft → published transition.
+- `PATCH /api/projects/{slug}/` validates date collision when publishing with a published registration config.
+- `EventRegistrationConfigSerializer` context uses config's own `is_draft`.
+
+---
+
+## Software Architecture
+
+### Data Model
+
+Add `is_draft` to `EventRegistrationConfig`:
+
+```python
+is_draft = models.BooleanField(
+    default=False,
+    help_text=(
+        "When True, the registration configuration is incomplete and not visible "
+        "to visitors. The organiser can save partial data and publish later. "
+        "May only transition from True to False (one-way)."
+    ),
+    verbose_name="Is Draft",
+)
+```
+
+**Migration**: 
+1. Schema migration: add `is_draft` with `default=False`.
+2. Data migration: set `is_draft=True` for all `EventRegistrationConfig` records whose related `Project.is_draft=True`.
+
+### API — Registration Config PATCH with is_draft
+
+`PATCH /api/projects/{slug}/registration-config/`:
+
+**Request to save as draft** (relaxed validation):
+```json
+{
+  "max_participants": 50,
+  "registration_end_date": "2026-06-30T18:00:00Z"
+}
+```
+(`is_draft` is not sent — config stays draft. Validation is relaxed.)
+
+**Request to publish registration** (full validation):
+```json
+{
+  "max_participants": 50,
+  "registration_end_date": "2026-06-30T18:00:00Z",
+  "is_draft": false
+}
+```
+
+**Error response** (400, when publishing with incomplete config):
+```json
+{
+  "max_participants": "Required when publishing registration.",
+  "registration_end_date": "Required when publishing registration."
+}
+```
+
+**Error response** (400, date collision):
+```json
+{
+  "registration_end_date": "Registration end date must be on or before the event end date."
+}
+```
+
+### API — Project Publish with Draft Registration Config
+
+`PATCH /api/projects/{slug}/`:
+
+When `is_draft` transitions to False:
+1. If the project has a registration config with `is_draft=True`: allow publish. Only check date collision if `registration_end_date` is set.
+2. If the project has a registration config with `is_draft=False`: validate the config is still valid (e.g. `registration_end_date` not in the past, still ≤ `end_date`). If invalid, return 400.
+3. If the project has no registration config: no registration validation.
+
+**Error response** (400, published config has date collision after end_date change):
+```json
+{
+  "registration_config": {
+    "registration_end_date": "Registration end date must be on or before the event end date. Update the registration settings before publishing."
+  }
+}
+```
+
+### Backend — EditRegistrationConfigView Changes
+
+In `EditRegistrationConfigView.patch()`:
+
+```python
+# Current (line 570):
+is_draft = project.is_draft
+
+# New:
+is_draft = rc.is_draft  # Use config's own draft state
+
+# Additionally: handle is_draft transition in request body
+if "is_draft" in request.data and not request.data["is_draft"] and rc.is_draft:
+    # Transitioning from draft to published — run full validation
+    is_draft = False
+    # One-way transition: draft → published, never back
+```
+
+### Backend — EventRegistrationConfigSerializer Context
+
+The serializer already reads `is_draft` from context. The change is in what populates the context:
+
+```python
+# CreateProjectView (line 556) — change:
+"is_draft": is_draft,  # project's is_draft
+
+# To:
+"is_draft": is_draft,  # project's is_draft (for create, config inherits project's draft state)
+```
+
+```python
+# EditRegistrationConfigView (line 570) — change:
+is_draft = project.is_draft
+
+# To:
+is_draft = rc.is_draft  # config's own is_draft, overridden by request body if transitioning
+```
+
+### Backend — ProjectAPIView.patch() Date Collision Check
+
+```python
+# After line 963 (project.is_draft = False):
+if hasattr(project, 'registration_config'):
+    rc = project.registration_config
+    if not rc.is_draft and rc.registration_end_date:
+        effective_end = (
+            parse(request.data["end_date"])
+            if "end_date" in request.data
+            else project.end_date
+        )
+        if effective_end and rc.registration_end_date > effective_end:
+            return Response(
+                {"registration_config": {
+                    "registration_end_date": "Registration end date must be on or before the event end date."
+                }},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+```
+
+### Frontend — Registration UI State
+
+`getRegistrationUIState()` in `eventRegistrationHelpers.ts`:
+
+```typescript
+// Add after line 90 (project.is_draft check):
+if (project.registration_config?.is_draft) return "hidden";
+```
+
+`shouldShowRegisterButton()`:
+
+```typescript
+// Add to the existing check:
+&& !project.registration_config?.is_draft
+```
+
+### Frontend — EditEventRegistrationModal
+
+The modal needs to handle the config's draft state:
+
+1. **New prop**: `isConfigDraft?: boolean` (default: derived from `project.is_draft` for backward compatibility).
+2. **Draft indicator**: when `isConfigDraft` is true, show a `Chip` or `Alert` at the top: "Registration configuration is in draft mode. Complete the setup and publish to make registration visible to visitors."
+3. **Two buttons when draft**:
+   - "Save as draft" — calls the existing `PATCH /registration-config/` endpoint without `is_draft: false`. Validation is relaxed.
+   - "Publish registration" — calls `PATCH /registration-config/` with `is_draft: false`. Full validation runs. If validation fails, errors are shown inline.
+4. **Single button when published**: "Save" — same as today.
+5. **`required` prop on fields**: when `isConfigDraft` is true, `max_participants` and `registration_end_date` are NOT required (relaxed). When false, they are required (as today).
+
+### Frontend — Edit Project Form Warning
+
+In `EditProjectRoot.tsx`, extend `checkIfProjectValid(false)`:
+
+```typescript
+// After existing checks, before return true:
+if (
+  project.project_type?.type_id === "event" &&
+  project.registration_config?.is_draft &&
+  isEnabled("EVENT_REGISTRATION")
+) {
+  // Soft warning — not a blocker
+  setRegistrationConfigWarning(
+    texts.registration_config_still_draft_warning
+  );
+  // Don't return false — allow publish
+}
+```
+
+In `EditProjectContent.tsx`, show the warning:
+
+- Below the "Edit registration settings" button, display a `Typography` with `color="warning"`: "Registration configuration is not yet complete. You can publish the event now and complete the registration settings later."
+- The button itself is NOT highlighted with an error — it's informational.
+
+### Frontend — Registrations Tab Setup Prompt
+
+In `ProjectRegistrationsContent.tsx`, when `registration_config.is_draft` is true and the user is an admin:
+
+- Instead of the guest list, show:
+  - A heading: "Registration setup incomplete"
+  - A description: "Complete the registration configuration to start accepting sign-ups."
+  - A button: "Complete registration setup" → opens `EditEventRegistrationModal`.
+
+### Backend — API Response Filtering for Draft Configs
+
+Two serializers include `registration_config` in project responses:
+
+1. **`ProjectSerializer.get_registration_config()`** (`project.py`, line 223) — detail view, includes seat count.
+2. **`ProjectStubSerializer.get_registration_config()`** (`project.py`, line 515) — list/browse view, no seat count.
+
+Both must be updated to return `None` when the config is draft and the viewer is not an admin:
+
+```python
+def get_registration_config(self, obj):
+    try:
+        rc = obj.registration_config
+    except EventRegistrationConfig.DoesNotExist:
+        return None
+
+    # Draft configs are only visible to project admins.
+    if rc.is_draft:
+        request = self.context.get("request")
+        if not request or not request.user.is_authenticated:
+            return None
+        is_admin = ProjectMember.objects.filter(
+            project=obj,
+            user=request.user,
+            role__role_type__in=[Role.ALL_TYPE, Role.READ_WRITE_TYPE],
+        ).exists()
+        if not is_admin:
+            return None
+
+    return EventRegistrationConfigSerializer(
+        rc, context={"include_seat_count": True},
+    ).data
+```
+
+The same pattern applies to `ProjectStubSerializer.get_registration_config()` (without `include_seat_count`).
+
+Additionally, the `is_draft` field must be added to `EventRegistrationConfigSerializer.Meta.fields` so the frontend can read the draft state from the response.
+
+### Frontend — Project Detail Page Admin Prompt
+
+In `ProjectPageRoot.tsx`, when `registration_config.is_draft` is true and the user is an admin:
+
+- Show a subtle `Alert` or `Chip` near the event header: "Registration is not yet set up. [Set up registration]"
+- The "Register" button is NOT shown (already handled by `getRegistrationUIState` returning `"hidden"`).
+- The admin's "Edit registration settings" button in `ProjectContentSideButtons.tsx` is always visible (already the case).
+
+---
+
+## Acceptance Criteria
+
+### Model & Migration
+- [ ] `EventRegistrationConfig` has an `is_draft` BooleanField with `default=False`.
+- [ ] Data migration sets `is_draft=True` for configs belonging to draft projects.
+
+### Backend — Registration Config Publish
+- [ ] `PATCH /registration-config/` accepts `is_draft: false` in the request body to transition from draft to published.
+- [ ] When transitioning to published, full validation runs (same rules as create with `is_draft=False`).
+- [ ] When `is_draft` is not sent (or `is_draft: true`), relaxed validation runs (same as today for draft projects).
+- [ ] One-way transition: setting `is_draft: true` on a published config is rejected (400).
+- [ ] Date collision check: `registration_end_date ≤ project.end_date` is enforced at config publish time.
+
+### Backend — Project Publish
+- [ ] Publishing a project with a **draft** registration config succeeds. No registration validation beyond date collision.
+- [ ] Publishing a project with a **published** registration config that has `registration_end_date > new end_date` is rejected (400).
+- [ ] Publishing a project without registration config is unaffected.
+- [ ] Non-event projects are unaffected.
+
+### Backend — Create Flow
+- [ ] Creating a draft project with registration config sets `config.is_draft = True`.
+- [ ] Creating a published project with registration config sets `config.is_draft = False` (as today).
+
+### Frontend — Registration Button Visibility
+- [ ] Visitors/members do NOT see registration UI when `registration_config.is_draft` is true.
+- [ ] Admins see a setup prompt on the project detail page when config is draft.
+- [ ] Admins see a setup prompt on the registrations tab when config is draft.
+
+### Frontend — Registration Config Modal
+- [ ] When config is draft, the modal shows a draft indicator and two buttons: "Save as draft" and "Publish registration".
+- [ ] "Save as draft" saves with relaxed validation (same as today's draft behavior).
+- [ ] "Publish registration" runs full validation and sends `is_draft: false`.
+- [ ] When config is published, the modal shows a single "Save" button (no change from today).
+- [ ] Validation errors are shown inline when "Publish registration" fails.
+
+### Frontend — Edit Project Form
+- [ ] When publishing a draft event whose registration config is still draft, a soft warning is displayed (not a blocker).
+- [ ] "Save as Draft" continues to work without requiring a published registration config.
+- [ ] When publishing a draft event whose registration config is published but has a date collision with the new `end_date`, the publish is blocked with an error.
+
+---
+
+## Test Cases
+
+### Backend Tests
+
+| Scenario | Expected |
+|----------|----------|
+| Create draft project with registration config | `config.is_draft = True` |
+| Create published project with registration config | `config.is_draft = False`, full validation runs |
+| PATCH registration config, save as draft (no `is_draft` in body) | 200, config saved, `is_draft` remains True |
+| PATCH registration config, publish with complete data | 200, `is_draft` set to False |
+| PATCH registration config, publish with missing `max_participants` | 400, error on `max_participants` |
+| PATCH registration config, publish with `registration_end_date` after `project.end_date` | 400, date collision error |
+| PATCH registration config, set `is_draft: true` on published config | 400, one-way transition rejected |
+| Publish project with draft registration config | 200, project published, config stays draft |
+| Publish project with published registration config, date collision | 400, error on `registration_config.registration_end_date` |
+| Publish project with published registration config, no collision | 200, project published |
+| Publish project without registration config | 200, no registration validation |
+| Data migration: draft project configs | `is_draft=True` for configs of draft projects |
+
+### Frontend Tests
+
+| Scenario | Expected |
+|----------|----------|
+| Visitor views event with draft config | No registration button visible |
+| Admin views event with draft config | Setup prompt visible, registration button hidden |
+| Admin opens registrations tab with draft config | Setup prompt with "Complete setup" button |
+| Admin opens modal for draft config | Draft indicator, two buttons (Save as draft / Publish) |
+| Admin clicks "Publish registration" with complete data | Config published, modal closes |
+| Admin clicks "Publish registration" with missing data | Inline errors shown |
+| Admin clicks "Save as draft" with partial data | Config saved as draft |
+| Admin opens modal for published config | Single "Save" button (unchanged) |
+| Admin publishes project with draft config | Soft warning, publish succeeds |
+| Admin publishes project with published config, date collision | Error, publish blocked |
+| Admin saves project as draft with draft config | Saves normally |
+
+---
+
+## Files to Change
+
+### Backend
+
+| File | Change |
+|------|--------|
+| `backend/organization/models/event_registration.py` | Add `is_draft` BooleanField to `EventRegistrationConfig` |
+| `backend/organization/migrations/` | New migration: add `is_draft` field + data migration for existing draft configs |
+| `backend/organization/views/event_registration_views.py` | `EditRegistrationConfigView.patch()`: use config's `is_draft`, handle `is_draft` transition in request body, full validation on publish |
+| `backend/organization/views/project_views.py` | `ProjectAPIView.patch()`: date collision check when publishing with published config. `CreateProjectView.post()`: set `config.is_draft` from project's `is_draft` |
+| `backend/organization/serializers/event_registration.py` | `EventRegistrationConfigSerializer`: add `is_draft` to `Meta.fields`. `validate()`: no change needed (already reads `is_draft` from context). `EditEventRegistrationConfigSerializer.validate()`: add `is_draft` transition validation |
+| `backend/organization/serializers/project.py` | `ProjectSerializer.get_registration_config()` and `ProjectStubSerializer.get_registration_config()`: return `None` for draft configs when viewer is not an admin |
+| `backend/organization/views/test_event_registration_views.py` | Add test cases for draft → published transition |
+| `backend/organization/views/test_project_views.py` | Add test cases for project publish with draft/published config |
+
+### Frontend
+
+| File | Change |
+|------|--------|
+| `frontend/src/utils/eventRegistrationHelpers.ts` | `getRegistrationUIState()`: return `"hidden"` for draft config. `shouldShowRegisterButton()`: check `config.is_draft` |
+| `frontend/src/components/project/EditEventRegistrationModal.tsx` | Add `isConfigDraft` prop. Draft indicator. Two buttons when draft. Relaxed `required` when draft |
+| `frontend/src/components/project/Buttons/RegistrationActionButton.tsx` | No changes needed (driven by `RegistrationUIState`) |
+| `frontend/src/components/project/ProjectPageRoot.tsx` | Admin setup prompt when config is draft |
+| `frontend/src/components/project/ProjectRegistrationsContent.tsx` | Setup prompt when config is draft (instead of guest list) |
+| `frontend/src/components/project/Buttons/ProjectContentSideButtons.tsx` | Pass `isConfigDraft` to modal |
+| `frontend/src/components/editProject/EditProjectRoot.tsx` | Soft warning on publish when config is draft. Date collision check for published config |
+| `frontend/src/components/editProject/EditProjectContent.tsx` | Display warning text below registration button when config is draft |
+| `frontend/src/components/shareProject/ShareProjectRoot.tsx` | No changes needed (config `is_draft` is set backend-side) |
+
+---
+
+## Dependency Notes
+
+- **Depends on**: `EditEventRegistrationModal` (already built). `EVENT_REGISTRATION` toggle (already exists). `REGISTRATION_CUSTOM_FIELDS` toggle (already exists).
+- **Enables**: Future task to add registration config to an already-published event — create a draft config, then publish it. Same flow.
+- **Migration**: minor — one field addition + one data migration.
+
+---
+
+## Log
+
+- 2026-05-28 14:54 — Spec created. Initial draft with two approaches.
+- 2026-05-28 15:29 — Approach B chosen. Registration config gets its own `is_draft` flag. Spec rewritten.
+- 2026-05-28 15:48 — Open questions resolved: `is_draft` boolean (not status enum), draft configs hidden from non-admin API responses, `is_draft` added to serializer fields.
+
+---
+
+## Design Decisions (Resolved)
+
+1. **`is_draft` boolean over status enum**: The `is_draft` field is a separate `BooleanField`, not a new value in the `RegistrationStatus` enum. Rationale: draft/setup state is orthogonal to the registration lifecycle (open → full → ended). Mixing them conflates two concerns with different transition rules (draft is one-way; status is bidirectional). The boolean also follows the existing `Project.is_draft` pattern.
+
+2. **Draft configs excluded from non-admin API responses**: The project detail API omits `registration_config` from the response when `is_draft=True` and the viewer is not an admin. This prevents visitors from seeing incomplete registration data. Admins always see the config (with `is_draft` flag) so they can access the setup prompt.
+
+3. **`is_draft` included in API responses**: The `is_draft` field is included in `EventRegistrationConfigSerializer`'s `fields` list. The frontend needs it to decide whether to show draft UI (setup prompt, draft indicator, etc.).
+
+4. **Registration status display for draft configs**: When the config is draft, admins see "Draft" as the registration status indicator (a computed display value in the frontend, not stored). The actual `status` field stays "open" (default) but is meaningless while draft.
+
+5. **Notification behavior for draft configs**: `notify_admins` is set on the config. When the config is draft, no registration emails should be sent (registration is not possible). This is already implicitly handled since the registration button is hidden and the `POST /registrations/` endpoint requires a non-draft config.
+
+6. **"Add registration to existing event"**: This future feature creates a draft `EventRegistrationConfig` for a published project, then opens the modal. The admin completes the config and publishes it. No additional toggle is needed beyond `EVENT_REGISTRATION`. The UI entry point (e.g. a button on the project detail page) is out of scope for this task.

--- a/doc/spec/20260528_1454_validate_registration_config_on_publish.md
+++ b/doc/spec/20260528_1454_validate_registration_config_on_publish.md
@@ -375,7 +375,6 @@ In `ProjectPageRoot.tsx`, when `registration_config.is_draft` is true and the us
 ### Frontend — Registration Button Visibility
 - [ ] Visitors/members do NOT see registration UI when `registration_config.is_draft` is true.
 - [ ] Admins see a setup prompt on the project detail page when config is draft.
-- [ ] Admins see a setup prompt on the registrations tab when config is draft.
 
 ### Frontend — Registration Config Modal
 - [ ] When config is draft, the modal shows a draft indicator and two buttons: "Save as draft" and "Publish registration".

--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -1314,6 +1314,34 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       en: "Send a notification to team admins when someone registers or cancels.",
       de: "Sende eine Benachrichtigung an Team-Admins, wenn sich jemand an- oder abmeldet.",
     },
+    registration_config_draft_indicator: {
+      en:
+        "Registration configuration is in draft mode. Complete the setup and publish to make registration visible to visitors.",
+      de:
+        "Die Anmeldekonfiguration ist im Entwurfsmodus. Schließe die Einrichtung ab und veröffentliche sie, um die Anmeldung für Besucher sichtbar zu machen.",
+    },
+    publish_registration: {
+      en: "Publish registration",
+      de: "Anmeldung veröffentlichen",
+    },
+    registration_setup_incomplete: {
+      en: "Registration setup incomplete",
+      de: "Anmeldeeinrichtung unvollständig",
+    },
+    registration_setup_incomplete_description: {
+      en: "Complete the registration configuration to start accepting sign-ups.",
+      de: "Schließe die Anmeldekonfiguration ab, um Anmeldungen zu akzeptieren.",
+    },
+    complete_registration_setup: {
+      en: "Complete registration setup",
+      de: "Anmeldeeinrichtung abschließen",
+    },
+    registration_config_still_draft_warning: {
+      en:
+        "Registration configuration is not yet complete. You can publish the event now and complete the registration settings later.",
+      de:
+        "Die Anmeldekonfiguration ist noch nicht vollständig. Du kannst das Event jetzt veröffentlichen und die Anmeldeeinstellungen später abschließen.",
+    },
     registration_custom_fields: {
       en: "Additional registration fields",
       de: "Zusätzliche Anmeldefelder",

--- a/frontend/src/components/editProject/EditProjectContent.tsx
+++ b/frontend/src/components/editProject/EditProjectContent.tsx
@@ -86,6 +86,7 @@ type Args = {
   errors: any;
   contentRef?: RefObject<any>;
   projectTypeOptions?: any;
+  registrationConfigWarning?: string | null;
 };
 
 export default function EditProjectContent({
@@ -96,6 +97,7 @@ export default function EditProjectContent({
   errors,
   contentRef,
   projectTypeOptions,
+  registrationConfigWarning,
 }: Args) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
@@ -182,6 +184,11 @@ export default function EditProjectContent({
           >
             {texts.edit_registration_settings}
           </Button>
+        )}
+        {showEditRegistrationButton && registrationConfigWarning && (
+          <Typography variant="body2" color="warning.main" sx={{ mt: 0.5, mb: 1 }}>
+            {registrationConfigWarning}
+          </Typography>
         )}
         <div className={classes.block}>
           {project.is_personal_project ? (

--- a/frontend/src/components/editProject/EditProjectRoot.tsx
+++ b/frontend/src/components/editProject/EditProjectRoot.tsx
@@ -22,6 +22,7 @@ import getProjectTypeTexts from "../../../public/data/projectTypeTexts";
 import ROLE_TYPES from "../../../public/data/role_types";
 import { Project, Role, Sector } from "../../types";
 import UserContext from "../context/UserContext";
+import { useFeatureToggles } from "../featureToggle";
 import NavigationButtons from "../general/NavigationButtons";
 import TranslateTexts from "../general/TranslateTexts";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
@@ -97,7 +98,9 @@ export default function EditProjectRoot({
     start_date: "",
     end_date: "",
   });
+  const [registrationConfigWarning, setRegistrationConfigWarning] = useState<string | null>(null);
   const contentRef = useRef(null);
+  const { isEnabled } = useFeatureToggles();
 
   const sourceLanguage = project.language ? project.language : locale;
   const targetLanguage = locales.find((l) => l !== sourceLanguage);
@@ -156,6 +159,18 @@ export default function EditProjectRoot({
         );
         return false;
       }
+    }
+
+    // Soft warning when publishing with a draft registration config
+    if (
+      !isDraft &&
+      project.project_type?.type_id === "event" &&
+      project.registration_config?.is_draft &&
+      isEnabled("EVENT_REGISTRATION")
+    ) {
+      setRegistrationConfigWarning(texts.registration_config_still_draft_warning);
+    } else {
+      setRegistrationConfigWarning(null);
     }
 
     return true;
@@ -397,6 +412,7 @@ export default function EditProjectRoot({
             errors={errors}
             contentRef={contentRef}
             projectTypeOptions={projectTypeOptions}
+            registrationConfigWarning={registrationConfigWarning}
           />
           <Divider className={classes.divider} />
           <NavigationButtons

--- a/frontend/src/components/project/EditEventRegistrationModal.test.tsx
+++ b/frontend/src/components/project/EditEventRegistrationModal.test.tsx
@@ -100,6 +100,7 @@ function makeRegistration(overrides: Partial<EventRegistrationData> = {}): Event
     registration_end_date: FUTURE_DATE,
     status: "open",
     notify_admins: true,
+    is_draft: false,
     ...overrides,
   };
 }
@@ -308,9 +309,10 @@ describe("EditEventRegistrationModal", () => {
         eventRegistration: makeRegistration({
           max_participants: null,
           registration_end_date: null,
+          is_draft: true,
         }),
       });
-      fireEvent.click(screen.getByRole("button", { name: /save/i }));
+      fireEvent.click(screen.getByRole("button", { name: /save as draft/i }));
       await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
       // Neither field should appear in the payload
       const { payload } = mockApiRequest.mock.calls[0][0];
@@ -321,10 +323,10 @@ describe("EditEventRegistrationModal", () => {
     it("shows an error for an entered max_participants that is less than 1 (draft)", async () => {
       renderModal({
         project: draftProject,
-        eventRegistration: makeRegistration({ max_participants: null }),
+        eventRegistration: makeRegistration({ max_participants: null, is_draft: true }),
       });
       fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "0" } });
-      fireEvent.click(screen.getByRole("button", { name: /save/i }));
+      fireEvent.click(screen.getByRole("button", { name: /publish registration/i }));
       await waitFor(() => {
         expect(screen.getByText(/must be greater than 0/i)).toBeInTheDocument();
       });
@@ -334,9 +336,9 @@ describe("EditEventRegistrationModal", () => {
     it("does NOT show a 'must be in the future' error for a past date (draft)", async () => {
       renderModal({
         project: draftProject,
-        eventRegistration: makeRegistration({ registration_end_date: PAST_DATE }),
+        eventRegistration: makeRegistration({ registration_end_date: PAST_DATE, is_draft: true }),
       });
-      fireEvent.click(screen.getByRole("button", { name: /save/i }));
+      fireEvent.click(screen.getByRole("button", { name: /save as draft/i }));
       await waitFor(() => expect(mockApiRequest).toHaveBeenCalledTimes(1));
       expect(screen.queryByText(/must be in the future/i)).not.toBeInTheDocument();
     });
@@ -345,9 +347,12 @@ describe("EditEventRegistrationModal", () => {
       const afterEventEnd = "2100-01-01T00:00:00.000Z";
       renderModal({
         project: draftProject,
-        eventRegistration: makeRegistration({ registration_end_date: afterEventEnd }),
+        eventRegistration: makeRegistration({
+          registration_end_date: afterEventEnd,
+          is_draft: true,
+        }),
       });
-      fireEvent.click(screen.getByRole("button", { name: /save/i }));
+      fireEvent.click(screen.getByRole("button", { name: /publish registration/i }));
       await waitFor(() => {
         expect(screen.getByText(/before.*event end/i)).toBeInTheDocument();
       });

--- a/frontend/src/components/project/EditEventRegistrationModal.tsx
+++ b/frontend/src/components/project/EditEventRegistrationModal.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useState } from "react";
 import {
+  Alert,
   Box,
   Button,
   Chip,
@@ -163,29 +164,31 @@ export default function EditEventRegistrationModal({
     !isStatusFull ||
     (parseInt(maxParticipants, 10) > participantCount && !isNaN(parseInt(maxParticipants, 10)));
 
-  const isDraft = !!project.is_draft;
+  const isDraft = !!eventRegistration.is_draft;
 
-  const validate = (): boolean => {
+  const validate = (publishing = false): boolean => {
     const newErrors: FormErrors = {};
 
     const parsedMax = parseInt(maxParticipants, 10);
     const hasParticipants = maxParticipants !== "";
 
+    // When publishing (is_draft=false), fields are required. When saving as draft, relaxed.
+    const enforceRequired = publishing || !isDraft;
     if (
-      isDraft
-        ? hasParticipants && (isNaN(parsedMax) || parsedMax < 1)
-        : !hasParticipants || isNaN(parsedMax) || parsedMax < 1
+      enforceRequired
+        ? !hasParticipants || isNaN(parsedMax) || parsedMax < 1
+        : hasParticipants && (isNaN(parsedMax) || parsedMax < 1)
     ) {
       newErrors.max_participants = texts.max_participants_must_be_greater_than_0;
     }
 
     const hasEndDate = registrationEndDate !== null;
 
-    if (isDraft ? hasEndDate && !registrationEndDate!.isValid() : !hasEndDate) {
+    if (enforceRequired ? !hasEndDate : hasEndDate && !registrationEndDate!.isValid()) {
       newErrors.registration_end_date = texts.registration_end_date_required;
     } else if (hasEndDate && registrationEndDate!.isValid()) {
-      // "must be in the future" only enforced for published projects
-      if (!isDraft && registrationEndDate!.isBefore(dayjs())) {
+      // "must be in the future" only enforced for published configs
+      if (enforceRequired && registrationEndDate!.isBefore(dayjs())) {
         newErrors.registration_end_date = texts.registration_end_date_must_be_in_the_future;
       } else if (project.end_date && registrationEndDate!.isAfter(dayjs(project.end_date))) {
         newErrors.registration_end_date = texts.registration_end_date_must_be_before_event_end_date;
@@ -195,7 +198,7 @@ export default function EditEventRegistrationModal({
     setErrors(newErrors);
 
     // Validate custom fields when publishing
-    if (!isDraft && isCustomFieldsEnabled) {
+    if (enforceRequired && isCustomFieldsEnabled) {
       const { errors: fe, hasError } = validateRegistrationFields(
         fields,
         false,
@@ -260,8 +263,8 @@ export default function EditEventRegistrationModal({
 
   // ── Save handler ──────────────────────────────────────────────────────────
 
-  const handleSave = async () => {
-    if (!validate()) return;
+  const handleSave = async (publishing = false) => {
+    if (!validate(publishing)) return;
 
     setSaving(true);
     setErrors({});
@@ -280,6 +283,11 @@ export default function EditEventRegistrationModal({
       payload.status = selectedStatus;
     }
     payload.notify_admins = notifyAdmins;
+
+    // When publishing, set is_draft to false for the draft → published transition.
+    if (publishing) {
+      payload.is_draft = false;
+    }
 
     if (isCustomFieldsEnabled) {
       payload.fields = fields.map(({ _clientKey, ...field }) => ({
@@ -378,6 +386,11 @@ export default function EditEventRegistrationModal({
         </DialogTitle>
 
         <DialogContent dividers>
+          {isDraft && (
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              {texts.registration_config_draft_indicator}
+            </Alert>
+          )}
           <Box className={classes.fieldsRow}>
             <Box className={classes.field}>
               <TextField
@@ -537,15 +550,31 @@ export default function EditEventRegistrationModal({
           <Button variant="outlined" onClick={onClose} disabled={saving} aria-label={texts.cancel}>
             {texts.cancel}
           </Button>
+          {isDraft && (
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={() => handleSave(false)}
+              disabled={saving}
+              startIcon={saving ? <CircularProgress size={16} color="inherit" /> : undefined}
+              aria-label={texts.save_as_draft}
+            >
+              {saving ? texts.save_as_draft + "…" : texts.save_as_draft}
+            </Button>
+          )}
           <Button
             variant="contained"
             color="primary"
-            onClick={handleSave}
+            onClick={() => handleSave(isDraft)}
             disabled={saving}
             startIcon={saving ? <CircularProgress size={16} color="inherit" /> : undefined}
-            aria-label={texts.save}
+            aria-label={isDraft ? texts.publish_registration : texts.save}
           >
-            {saving ? texts.save + "…" : texts.save}
+            {saving
+              ? (isDraft ? texts.publish_registration : texts.save) + "…"
+              : isDraft
+              ? texts.publish_registration
+              : texts.save}
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/src/components/project/EditEventRegistrationModal.tsx
+++ b/frontend/src/components/project/EditEventRegistrationModal.tsx
@@ -353,6 +353,9 @@ export default function EditEventRegistrationModal({
             if (firstMsg) apiErrors.fields = firstMsg;
           }
         }
+        if (data.is_draft) {
+          apiErrors.general = Array.isArray(data.is_draft) ? data.is_draft[0] : data.is_draft;
+        }
         if (data.detail || data.non_field_errors) {
           apiErrors.general = data.detail ?? data.non_field_errors?.[0];
         }

--- a/frontend/src/components/project/ProjectPageRoot.tsx
+++ b/frontend/src/components/project/ProjectPageRoot.tsx
@@ -816,37 +816,43 @@ export default function ProjectPageRoot({
         confirmText={texts.yes}
         cancelText={texts.no}
       />
-      {isEventRegistrationEnabled && project.registration_config && (
-        <EventRegistrationModal
-          open={registrationModalOpen}
-          onClose={() => handleRegistrationModalClose()}
-          project={project}
-          onRegistrationSuccess={handleRegistrationSuccess}
-        />
-      )}
-      {isEventRegistrationEnabled && project.registration_config && (
-        <ViewRegistrationAnswersModal
-          open={modifyRegistrationModalOpen}
-          onClose={() => setModifyRegistrationModalOpen(false)}
-          registration={myEventRegistration}
-          title={texts.registration_answers_modal_title_self as string}
-          fields={currentEventRegistration?.fields ?? []}
-          event={{
-            name: project.name,
-            start_date: project.start_date,
-            end_date: project.end_date,
-          }}
-          cancelAction={{ onCancelClick: () => setCancelRegistrationModalOpen(true) }}
-        />
-      )}
-      {isEventRegistrationEnabled && project.registration_config && (
-        <CancelRegistrationModal
-          open={cancelRegistrationModalOpen}
-          onClose={() => setCancelRegistrationModalOpen(false)}
-          project={project}
-          onCancellationSuccess={handleCancelRegistrationSuccess}
-        />
-      )}
+      {isEventRegistrationEnabled &&
+        project.registration_config &&
+        !project.registration_config.is_draft && (
+          <EventRegistrationModal
+            open={registrationModalOpen}
+            onClose={() => handleRegistrationModalClose()}
+            project={project}
+            onRegistrationSuccess={handleRegistrationSuccess}
+          />
+        )}
+      {isEventRegistrationEnabled &&
+        project.registration_config &&
+        !project.registration_config.is_draft && (
+          <ViewRegistrationAnswersModal
+            open={modifyRegistrationModalOpen}
+            onClose={() => setModifyRegistrationModalOpen(false)}
+            registration={myEventRegistration}
+            title={texts.registration_answers_modal_title_self as string}
+            fields={currentEventRegistration?.fields ?? []}
+            event={{
+              name: project.name,
+              start_date: project.start_date,
+              end_date: project.end_date,
+            }}
+            cancelAction={{ onCancelClick: () => setCancelRegistrationModalOpen(true) }}
+          />
+        )}
+      {isEventRegistrationEnabled &&
+        project.registration_config &&
+        !project.registration_config.is_draft && (
+          <CancelRegistrationModal
+            open={cancelRegistrationModalOpen}
+            onClose={() => setCancelRegistrationModalOpen(false)}
+            project={project}
+            onCancellationSuccess={handleCancelRegistrationSuccess}
+          />
+        )}
     </div>
   );
 }

--- a/frontend/src/components/project/ProjectRegistrationsContent.tsx
+++ b/frontend/src/components/project/ProjectRegistrationsContent.tsx
@@ -310,6 +310,36 @@ export default function ProjectRegistrationsContent({
     );
   }
 
+  if (eventRegistration.is_draft) {
+    return (
+      <Box sx={{ mt: 3, textAlign: "center" }}>
+        <Typography variant="h6" sx={{ mb: 1 }}>
+          {texts.registration_setup_incomplete}
+        </Typography>
+        <Typography color="textSecondary" sx={{ mb: 2 }}>
+          {texts.registration_setup_incomplete_description}
+        </Typography>
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<SettingsIcon />}
+          onClick={() => setEditModalOpen(true)}
+        >
+          {texts.complete_registration_setup}
+        </Button>
+        {editModalOpen && (
+          <EditEventRegistrationModal
+            open={editModalOpen}
+            onClose={() => setEditModalOpen(false)}
+            onSaved={onEventRegistrationUpdated}
+            project={project}
+            eventRegistration={eventRegistration}
+          />
+        )}
+      </Box>
+    );
+  }
+
   const STATUS_CONFIG = {
     open: {
       label: texts.registration_status_open,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,6 +36,8 @@ export type EventRegistrationData = {
   status: "open" | "closed" | "full" | "ended";
   /** When true, team admins receive an email on registration/cancellation. */
   notify_admins: boolean;
+  /** When true, the registration configuration is incomplete and not visible to visitors. */
+  is_draft: boolean;
   /** Custom registration fields configured by the organiser (Phase 4a). */
   fields?: RegistrationField[];
 };

--- a/frontend/src/utils/eventRegistrationHelpers.ts
+++ b/frontend/src/utils/eventRegistrationHelpers.ts
@@ -14,6 +14,7 @@ export const shouldShowRegisterButton = (
     isEventRegistrationEnabled &&
     !project.is_draft &&
     project.registration_config &&
+    !project.registration_config.is_draft &&
     project.registration_config.status !== "ended"
   );
 };
@@ -88,6 +89,9 @@ export const getRegistrationUIState = (
 
   // Draft projects should never show a registration button
   if (project.is_draft) return "hidden";
+
+  // Draft registration configs are not visible to visitors
+  if (project.registration_config.is_draft) return "hidden";
 
   // Priority 1 — always show attended label, even if status is ended
   if (hasAttended) return "attended";


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Implements #2021
