### PR TITLE
Include registration field answers in confirmation email

### DIFF
--- a/backend/climateconnect_api/utility/email_setup.py
+++ b/backend/climateconnect_api/utility/email_setup.py
@@ -156,8 +156,8 @@ def send_email(
                 "Variables": variables,
                 "Subject": subject,
                 "TemplateErrorReporting": {
-                    "Email": "christoph.stoll@climateconnect.earth",
-                    "Name": "Christoph Stoll",
+                    "Email": "harald.walker@climateconnect.earth",
+                    "Name": "Harald Walker",
                 },
             }
         ]

--- a/backend/organization/tasks.py
+++ b/backend/organization/tasks.py
@@ -78,13 +78,15 @@ def send_event_registration_confirmation_email(
         return
 
     try:
-        registration = EventRegistration.objects.select_related(
-            "registration_config"
-        ).prefetch_related(
-            "field_answers__field",
-            "field_answers__value_option",
-            "field_answers__field__options",
-        ).get(id=registration_id)
+        registration = (
+            EventRegistration.objects.select_related("registration_config")
+            .prefetch_related(
+                "field_answers__field",
+                "field_answers__value_option",
+                "field_answers__field__options",
+            )
+            .get(id=registration_id)
+        )
     except EventRegistration.DoesNotExist:
         logger.error(
             "[EventRegistration] Cannot send confirmation: Registration %s not found",

--- a/backend/organization/tasks.py
+++ b/backend/organization/tasks.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 
 
 @app.task(bind=True, max_retries=3, default_retry_delay=60)
-def send_event_registration_confirmation_email(self, user_id: int, event_slug: str):
+def send_event_registration_confirmation_email(
+    self, user_id: int, event_slug: str, registration_id: int
+):
     """
     Send a registration confirmation email to a user who just registered for an event.
 
@@ -35,7 +37,9 @@ def send_event_registration_confirmation_email(self, user_id: int, event_slug: s
     Args:
         user_id: Primary key of the registering User.
         event_slug: URL slug of the event Project.
+        registration_id: Primary key of the EventRegistration record.
     """
+    from organization.models.event_registration import EventRegistration
     from organization.models.project import Project
     from organization.utility.email import (
         send_event_registration_confirmation_to_user,
@@ -74,7 +78,24 @@ def send_event_registration_confirmation_email(self, user_id: int, event_slug: s
         return
 
     try:
-        send_event_registration_confirmation_to_user(user=user, project=project)
+        registration = EventRegistration.objects.select_related(
+            "registration_config"
+        ).prefetch_related(
+            "field_answers__field",
+            "field_answers__value_option",
+            "field_answers__field__options",
+        ).get(id=registration_id)
+    except EventRegistration.DoesNotExist:
+        logger.error(
+            "[EventRegistration] Cannot send confirmation: Registration %s not found",
+            registration_id,
+        )
+        return
+
+    try:
+        send_event_registration_confirmation_to_user(
+            user=user, project=project, registration=registration
+        )
     except Exception as exc:
         logger.error(
             "[EventRegistration] Failed to send confirmation email to user %s "

--- a/backend/organization/tests/test_email_field_answers.py
+++ b/backend/organization/tests/test_email_field_answers.py
@@ -49,6 +49,7 @@ class TestBuildFieldAnswersHtml(TestCase):
             },
         )
         from climateconnect_api.models import Language
+
         self.language, _ = Language.objects.get_or_create(
             language_code="en",
             defaults={"name": "English", "native_name": "English"},
@@ -109,7 +110,9 @@ class TestBuildFieldAnswersHtml(TestCase):
     def test_checked_checkbox_included(self):
         """A checked checkbox includes its description (HTML-stripped) with ✓ prefix."""
         field = self._create_field(
-            RegistrationFieldType.CHECKBOX, 0, "Terms",
+            RegistrationFieldType.CHECKBOX,
+            0,
+            "Terms",
             {"description": "<p>I agree to the terms</p>"},
         )
         self._create_answer(field, value_boolean=True)
@@ -125,7 +128,9 @@ class TestBuildFieldAnswersHtml(TestCase):
     def test_unchecked_checkbox_not_included(self):
         """An unchecked checkbox is not included in the email."""
         field = self._create_field(
-            RegistrationFieldType.CHECKBOX, 0, "Terms",
+            RegistrationFieldType.CHECKBOX,
+            0,
+            "Terms",
             {"description": "I agree to the terms"},
         )
         self._create_answer(field, value_boolean=False)
@@ -139,7 +144,9 @@ class TestBuildFieldAnswersHtml(TestCase):
     def test_option_select_included(self):
         """Option select shows field title and selected option title."""
         field = self._create_field(
-            RegistrationFieldType.OPTION_SELECT, 0, "Workshop",
+            RegistrationFieldType.OPTION_SELECT,
+            0,
+            "Workshop",
             {"title": "Preferred workshop"},
         )
         option = self._create_option(field, "Solar panel installation", 0)
@@ -155,7 +162,9 @@ class TestBuildFieldAnswersHtml(TestCase):
     def test_inventory_included(self):
         """Inventory shows field title, option title, and quantity."""
         field = self._create_field(
-            RegistrationFieldType.INVENTORY, 0, "Meals",
+            RegistrationFieldType.INVENTORY,
+            0,
+            "Meals",
             {"title": "Meal preference"},
         )
         option = self._create_option(field, "Vegetarian", 0)
@@ -171,13 +180,19 @@ class TestBuildFieldAnswersHtml(TestCase):
     def test_time_slot_included(self):
         """Time slot shows field title and formatted time range."""
         field = self._create_field(
-            RegistrationFieldType.TIME_SLOT_SELECT, 0, "Pickup",
+            RegistrationFieldType.TIME_SLOT_SELECT,
+            0,
+            "Pickup",
             {"title": "Pickup slot"},
         )
         start = timezone.now() + timedelta(days=10, hours=10)
         end = start + timedelta(hours=2)
         option = self._create_option(
-            field, "", 0, start_time=start, end_time=end,
+            field,
+            "",
+            0,
+            start_time=start,
+            end_time=end,
         )
         self._create_answer(field, value_option=option)
 
@@ -191,11 +206,15 @@ class TestBuildFieldAnswersHtml(TestCase):
     def test_multiple_fields_ordered_by_order(self):
         """Multiple answers are shown in field order."""
         field_b = self._create_field(
-            RegistrationFieldType.OPTION_SELECT, 1, "Second",
+            RegistrationFieldType.OPTION_SELECT,
+            1,
+            "Second",
             {"title": "Second field"},
         )
         field_a = self._create_field(
-            RegistrationFieldType.OPTION_SELECT, 0, "First",
+            RegistrationFieldType.OPTION_SELECT,
+            0,
+            "First",
             {"title": "First field"},
         )
         option_b = self._create_option(field_b, "Option B", 0)
@@ -226,8 +245,11 @@ class TestBuildFieldAnswersHtml(TestCase):
     def test_optional_fields_no_answers_returns_empty(self):
         """Optional fields with no answers provided returns empty string."""
         self._create_field(
-            RegistrationFieldType.OPTION_SELECT, 0, "Optional",
-            {"title": "Optional field"}, is_required=False,
+            RegistrationFieldType.OPTION_SELECT,
+            0,
+            "Optional",
+            {"title": "Optional field"},
+            is_required=False,
         )
         # No answer created
         html = _build_field_answers_html(self.registration, "en")
@@ -239,12 +261,18 @@ class TestBuildFieldAnswersHtml(TestCase):
     def test_mix_answered_unanswered_only_answered_shown(self):
         """Only fields with answers are included; unanswered optional fields are skipped."""
         field_a = self._create_field(
-            RegistrationFieldType.OPTION_SELECT, 0, "Answered",
-            {"title": "Answered field"}, is_required=True,
+            RegistrationFieldType.OPTION_SELECT,
+            0,
+            "Answered",
+            {"title": "Answered field"},
+            is_required=True,
         )
-        field_b = self._create_field(
-            RegistrationFieldType.OPTION_SELECT, 1, "Unanswered",
-            {"title": "Unanswered field"}, is_required=False,
+        self._create_field(
+            RegistrationFieldType.OPTION_SELECT,
+            1,
+            "Unanswered",
+            {"title": "Unanswered field"},
+            is_required=False,
         )
         option_a = self._create_option(field_a, "Selected", 0)
         self._create_answer(field_a, value_option=option_a)
@@ -260,7 +288,9 @@ class TestBuildFieldAnswersHtml(TestCase):
     def test_german_heading(self):
         """German language code produces German heading."""
         field = self._create_field(
-            RegistrationFieldType.OPTION_SELECT, 0, "Workshop",
+            RegistrationFieldType.OPTION_SELECT,
+            0,
+            "Workshop",
             {"title": "Workshop"},
         )
         option = self._create_option(field, "Solar", 0)

--- a/backend/organization/tests/test_email_field_answers.py
+++ b/backend/organization/tests/test_email_field_answers.py
@@ -1,0 +1,270 @@
+"""
+Tests for including registration field answers in the confirmation email.
+
+Covers spec test cases:
+  1. Register with checkbox (checked) → email contains checkbox description
+  2. Register with checkbox (unchecked) → email does not contain checkbox section
+  3. Register with option_select → email contains field title + option title
+  4. Register with inventory → email contains field title + option title × quantity
+  5. Register with time_slot_select → email contains field title + formatted time range
+  6. Register with multiple fields → all answers shown, ordered by field.order
+  7. Register with no custom fields → email has no FieldAnswersHtml section
+  8. Register with optional fields, no answers → email has no FieldAnswersHtml section
+  9. Register with mix of answered and unanswered optional fields → only answered shown
+"""
+
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import TestCase, tag
+from django.utils import timezone
+
+from organization.models.event_registration import (
+    EventRegistration,
+    EventRegistrationConfig,
+    RegistrationFieldAnswer,
+    RegistrationStatus,
+)
+from organization.models.registration_field import (
+    RegistrationField,
+    RegistrationFieldOption,
+    RegistrationFieldType,
+)
+from organization.models import Project, ProjectStatus
+from organization.utility.email import _build_field_answers_html
+
+
+class TestBuildFieldAnswersHtml(TestCase):
+    """
+    Unit tests for the _build_field_answers_html() helper function.
+    """
+
+    def setUp(self):
+        self.project_status, _ = ProjectStatus.objects.update_or_create(
+            id=2,
+            defaults={
+                "name": "active_email_test",
+                "has_end_date": True,
+                "has_start_date": True,
+            },
+        )
+        from climateconnect_api.models import Language
+        self.language, _ = Language.objects.get_or_create(
+            language_code="en",
+            defaults={"name": "English", "native_name": "English"},
+        )
+        self.project = Project.objects.create(
+            name="Email Test Event",
+            url_slug="email-test-event",
+            is_active=True,
+            is_draft=False,
+            status=self.project_status,
+            language=self.language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=10),
+            end_date=timezone.now() + timedelta(days=60),
+        )
+        self.config = EventRegistrationConfig.objects.create(
+            project=self.project,
+            max_participants=100,
+            registration_end_date=timezone.now() + timedelta(days=30),
+            status=RegistrationStatus.OPEN,
+        )
+        self.user = User.objects.create_user(
+            username="email_test_user", password="testpassword"
+        )
+        self.registration = EventRegistration.objects.create(
+            user=self.user,
+            registration_config=self.config,
+        )
+
+    def _create_field(self, field_type, order, label, settings, is_required=False):
+        return RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=field_type,
+            order=order,
+            label=label,
+            settings=settings,
+            is_required=is_required,
+        )
+
+    def _create_option(self, field, title, order, **kwargs):
+        return RegistrationFieldOption.objects.create(
+            field=field,
+            title=title,
+            order=order,
+            **kwargs,
+        )
+
+    def _create_answer(self, field, **kwargs):
+        return RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            **kwargs,
+        )
+
+    # ── Test 1: Checkbox (checked) → email contains description ──────────────
+
+    @tag("field_answers_email")
+    def test_checked_checkbox_included(self):
+        """A checked checkbox includes its description (HTML-stripped) with ✓ prefix."""
+        field = self._create_field(
+            RegistrationFieldType.CHECKBOX, 0, "Terms",
+            {"description": "<p>I agree to the terms</p>"},
+        )
+        self._create_answer(field, value_boolean=True)
+
+        html = _build_field_answers_html(self.registration, "en")
+        self.assertIn("✓", html)
+        self.assertIn("I agree to the terms", html)
+        self.assertNotIn("<p>", html)  # HTML stripped
+
+    # ── Test 2: Checkbox (unchecked) → not shown ─────────────────────────────
+
+    @tag("field_answers_email")
+    def test_unchecked_checkbox_not_included(self):
+        """An unchecked checkbox is not included in the email."""
+        field = self._create_field(
+            RegistrationFieldType.CHECKBOX, 0, "Terms",
+            {"description": "I agree to the terms"},
+        )
+        self._create_answer(field, value_boolean=False)
+
+        html = _build_field_answers_html(self.registration, "en")
+        self.assertEqual(html, "")
+
+    # ── Test 3: Option select → title + option title ─────────────────────────
+
+    @tag("field_answers_email")
+    def test_option_select_included(self):
+        """Option select shows field title and selected option title."""
+        field = self._create_field(
+            RegistrationFieldType.OPTION_SELECT, 0, "Workshop",
+            {"title": "Preferred workshop"},
+        )
+        option = self._create_option(field, "Solar panel installation", 0)
+        self._create_answer(field, value_option=option)
+
+        html = _build_field_answers_html(self.registration, "en")
+        self.assertIn("Preferred workshop", html)
+        self.assertIn("Solar panel installation", html)
+
+    # ── Test 4: Inventory → title + option × quantity ────────────────────────
+
+    @tag("field_answers_email")
+    def test_inventory_included(self):
+        """Inventory shows field title, option title, and quantity."""
+        field = self._create_field(
+            RegistrationFieldType.INVENTORY, 0, "Meals",
+            {"title": "Meal preference"},
+        )
+        option = self._create_option(field, "Vegetarian", 0)
+        self._create_answer(field, value_option=option, value_number=2)
+
+        html = _build_field_answers_html(self.registration, "en")
+        self.assertIn("Meal preference", html)
+        self.assertIn("Vegetarian × 2", html)
+
+    # ── Test 5: Time slot → title + formatted time range ─────────────────────
+
+    @tag("field_answers_email")
+    def test_time_slot_included(self):
+        """Time slot shows field title and formatted time range."""
+        field = self._create_field(
+            RegistrationFieldType.TIME_SLOT_SELECT, 0, "Pickup",
+            {"title": "Pickup slot"},
+        )
+        start = timezone.now() + timedelta(days=10, hours=10)
+        end = start + timedelta(hours=2)
+        option = self._create_option(
+            field, "", 0, start_time=start, end_time=end,
+        )
+        self._create_answer(field, value_option=option)
+
+        html = _build_field_answers_html(self.registration, "en")
+        self.assertIn("Pickup slot", html)
+        self.assertIn("–", html)  # time range separator
+
+    # ── Test 6: Multiple fields → ordered by field.order ─────────────────────
+
+    @tag("field_answers_email")
+    def test_multiple_fields_ordered_by_order(self):
+        """Multiple answers are shown in field order."""
+        field_b = self._create_field(
+            RegistrationFieldType.OPTION_SELECT, 1, "Second",
+            {"title": "Second field"},
+        )
+        field_a = self._create_field(
+            RegistrationFieldType.OPTION_SELECT, 0, "First",
+            {"title": "First field"},
+        )
+        option_b = self._create_option(field_b, "Option B", 0)
+        option_a = self._create_option(field_a, "Option A", 0)
+        self._create_answer(field_b, value_option=option_b)
+        self._create_answer(field_a, value_option=option_a)
+
+        html = _build_field_answers_html(self.registration, "en")
+        # Both fields present
+        self.assertIn("First field", html)
+        self.assertIn("Second field", html)
+        # First field appears before second in the HTML
+        idx_first = html.index("First field")
+        idx_second = html.index("Second field")
+        self.assertLess(idx_first, idx_second)
+
+    # ── Test 7: No custom fields → empty string ──────────────────────────────
+
+    @tag("field_answers_email")
+    def test_no_custom_fields_returns_empty(self):
+        """Registration with no custom fields returns empty string."""
+        html = _build_field_answers_html(self.registration, "en")
+        self.assertEqual(html, "")
+
+    # ── Test 8: Optional fields, no answers → empty string ───────────────────
+
+    @tag("field_answers_email")
+    def test_optional_fields_no_answers_returns_empty(self):
+        """Optional fields with no answers provided returns empty string."""
+        self._create_field(
+            RegistrationFieldType.OPTION_SELECT, 0, "Optional",
+            {"title": "Optional field"}, is_required=False,
+        )
+        # No answer created
+        html = _build_field_answers_html(self.registration, "en")
+        self.assertEqual(html, "")
+
+    # ── Test 9: Mix of answered and unanswered → only answered shown ─────────
+
+    @tag("field_answers_email")
+    def test_mix_answered_unanswered_only_answered_shown(self):
+        """Only fields with answers are included; unanswered optional fields are skipped."""
+        field_a = self._create_field(
+            RegistrationFieldType.OPTION_SELECT, 0, "Answered",
+            {"title": "Answered field"}, is_required=True,
+        )
+        field_b = self._create_field(
+            RegistrationFieldType.OPTION_SELECT, 1, "Unanswered",
+            {"title": "Unanswered field"}, is_required=False,
+        )
+        option_a = self._create_option(field_a, "Selected", 0)
+        self._create_answer(field_a, value_option=option_a)
+        # No answer for field_b
+
+        html = _build_field_answers_html(self.registration, "en")
+        self.assertIn("Answered field", html)
+        self.assertNotIn("Unanswered field", html)
+
+    # ── German language → heading in German ───────────────────────────────────
+
+    @tag("field_answers_email")
+    def test_german_heading(self):
+        """German language code produces German heading."""
+        field = self._create_field(
+            RegistrationFieldType.OPTION_SELECT, 0, "Workshop",
+            {"title": "Workshop"},
+        )
+        option = self._create_option(field, "Solar", 0)
+        self._create_answer(field, value_option=option)
+
+        html = _build_field_answers_html(self.registration, "de")
+        self.assertIn("Deine Anmeldeantworten", html)

--- a/backend/organization/tests/test_event_participant.py
+++ b/backend/organization/tests/test_event_participant.py
@@ -195,9 +195,11 @@ class TestRegisterForEventHappyPath(APITestCase):
             response = self.client.post(_register_url("open-event"))
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        mock_task.delay.assert_called_once_with(
-            user_id=self.user.id, event_slug="open-event"
-        )
+        mock_task.delay.assert_called_once()
+        _, kwargs = mock_task.delay.call_args
+        self.assertEqual(kwargs["user_id"], self.user.id)
+        self.assertEqual(kwargs["event_slug"], "open-event")
+        self.assertIsInstance(kwargs["registration_id"], int)
 
     @tag("event_participant", "registration")
     def test_confirmation_email_not_sent_on_idempotent_reregistration(self):

--- a/backend/organization/utility/email.py
+++ b/backend/organization/utility/email.py
@@ -1,3 +1,4 @@
+import html as html_module
 import logging
 import re
 from organization.utility.project import get_project_name
@@ -559,7 +560,113 @@ def send_guest_cancellation_notification(user, project, admin_message: str):
     )
 
 
-def send_event_registration_confirmation_to_user(user, project):
+def _build_field_answers_html(registration, lang_code):
+    """
+    Build an HTML snippet of the guest's registration field answers for the
+    confirmation email.
+
+    Returns an HTML string with a styled table of answers, or an empty string
+    if no answers have non-null values.
+
+    Args:
+        registration: EventRegistration instance with prefetched field_answers,
+            field, value_option, and field.options.
+        lang_code: User's language code ("en" or "de").
+
+    Returns:
+        str: HTML snippet or empty string.
+    """
+    from organization.models.registration_field import RegistrationFieldType
+
+    answers_by_field = {}
+    for answer in registration.field_answers.all():
+        # Skip answers with no value
+        if (
+            answer.value_boolean is None
+            and answer.value_option is None
+            and answer.value_number is None
+        ):
+            continue
+        # For checkboxes, only include checked ones
+        if answer.field.field_type == RegistrationFieldType.CHECKBOX:
+            if answer.value_boolean is not True:
+                continue
+        answers_by_field[answer.field] = answer
+
+    if not answers_by_field:
+        return ""
+
+    # Sort by field order
+    sorted_fields = sorted(answers_by_field.keys(), key=lambda f: f.order)
+
+    heading = (
+        "Your registration answers" if lang_code == "en"
+        else "Deine Anmeldeantworten"
+    )
+
+    rows = []
+    for field in sorted_fields:
+        answer = answers_by_field[field]
+        field_type = field.field_type
+
+        if field_type == RegistrationFieldType.CHECKBOX:
+            description = (field.settings or {}).get("description", "")
+            # Strip HTML tags for plain text
+            plain_desc = re.sub(r"<[^>]+>", "", description).strip()
+            rows.append(
+                f'<tr><td colspan="2" style="padding: 4px 8px;">✓ {html_module.escape(plain_desc)}</td></tr>'
+            )
+
+        elif field_type == RegistrationFieldType.OPTION_SELECT:
+            field_title = (field.settings or {}).get("title", "")
+            option = answer.value_option
+            answer_text = option.title if option else ""
+            rows.append(
+                f'<tr><td style="padding: 4px 8px; color: #666;">{html_module.escape(field_title)}</td>'
+                f'<td style="padding: 4px 8px;">{html_module.escape(answer_text)}</td></tr>'
+            )
+
+        elif field_type == RegistrationFieldType.INVENTORY:
+            field_title = (field.settings or {}).get("title", "")
+            option = answer.value_option
+            option_title = option.title if option else ""
+            quantity = answer.value_number or 0
+            answer_text = f"{option_title} × {quantity}"
+            rows.append(
+                f'<tr><td style="padding: 4px 8px; color: #666;">{html_module.escape(field_title)}</td>'
+                f'<td style="padding: 4px 8px;">{html_module.escape(answer_text)}</td></tr>'
+            )
+
+        elif field_type == RegistrationFieldType.TIME_SLOT_SELECT:
+            field_title = (field.settings or {}).get("title", "")
+            option = answer.value_option
+            if option and option.start_time and option.end_time:
+                start = option.start_time.strftime("%a, %b %d, %H:%M")
+                end = option.end_time.strftime("%H:%M")
+                answer_text = f"{start} – {end}"
+            elif option:
+                answer_text = option.title
+            else:
+                answer_text = ""
+            rows.append(
+                f'<tr><td style="padding: 4px 8px; color: #666;">{html_module.escape(field_title)}</td>'
+                f'<td style="padding: 4px 8px;">{html_module.escape(answer_text)}</td></tr>'
+            )
+
+    if not rows:
+        return ""
+
+    return (
+        f'<div style="margin-top: 20px; padding-top: 15px; border-top: 1px solid #eee;">'
+        f'<p style="font-weight: bold; margin-bottom: 10px;">{heading}</p>'
+        f'<table style="width: 100%; border-collapse: collapse;">'
+        f'{"".join(rows)}'
+        f'</table>'
+        f'</div>'
+    )
+
+
+def send_event_registration_confirmation_to_user(user, project, registration):
     """
     Send a registration confirmation email to a user who just registered for an event.
 
@@ -567,12 +674,14 @@ def send_event_registration_confirmation_to_user(user, project):
     all other transactional emails in this module.
 
     **Mailjet template variables** (define these in both the EN and DE templates):
-        - ``FirstName``     — user's first name (falls back to username if blank)
-        - ``EventTitle``    — display name of the event (localised for the user's language)
-        - ``EventUrl``      — full, language-aware URL to the event page
-        - ``StartDate``     — localised start date with resolved timezone
-        - ``OrganiserName`` — localised organisation name, or user's full name / username
-        - ``LocationName``  — ``"Online"`` / location name / empty string
+        - ``FirstName``         — user's first name (falls back to username if blank)
+        - ``EventTitle``        — display name of the event (localised for the user's language)
+        - ``EventUrl``          — full, language-aware URL to the event page
+        - ``StartDate``         — localised start date with resolved timezone
+        - ``OrganiserName``     — localised organisation name, or user's full name / username
+        - ``LocationName``      — ``"Online"`` / location name / empty string
+        - ``FieldAnswersHtml``  — pre-rendered HTML of the guest's custom field answers
+          (empty string if no custom fields or no answers)
 
     **Required env variables**:
         ``EVENT_REGISTRATION_CONFIRMATION_TEMPLATE_ID``    — Mailjet template ID (EN)
@@ -590,6 +699,8 @@ def send_event_registration_confirmation_to_user(user, project):
                 "project_parent__parent_organization__translation_org__language",
                 "project_parent__parent_user__user_profile",
             )``.
+        registration: ``EventRegistration`` instance. Must be fetched with
+            ``prefetch_related("field_answers__field", "field_answers__value_option")``.
     """
     lang_code = get_user_lang_code(user)
     display_tz = get_event_display_timezone(user, project)
@@ -601,6 +712,8 @@ def send_event_registration_confirmation_to_user(user, project):
         "en": f"You're registered for {get_project_name(project, 'en')}!",
         "de": f"Du bist für {get_project_name(project, 'de')} angemeldet!",
     }
+
+    field_answers_html = _build_field_answers_html(registration, lang_code)
 
     variables = {
         "FirstName": user.first_name or user.username,
@@ -614,6 +727,7 @@ def send_event_registration_confirmation_to_user(user, project):
         "StartDate": start_date_str,
         "OrganiserName": get_organiser_name(project, lang_code),
         "LocationName": get_location_name(project, lang_code),
+        "FieldAnswersHtml": field_answers_html,
     }
 
     send_email(

--- a/backend/organization/utility/email.py
+++ b/backend/organization/utility/email.py
@@ -560,6 +560,58 @@ def send_guest_cancellation_notification(user, project, admin_message: str):
     )
 
 
+_DE_DAYS = {
+    "Mon": "Mo",
+    "Tue": "Di",
+    "Wed": "Mi",
+    "Thu": "Do",
+    "Fri": "Fr",
+    "Sat": "Sa",
+    "Sun": "So",
+}
+_DE_MONTHS_SHORT = {
+    1: "Jan",
+    2: "Feb",
+    3: "Mär",
+    4: "Apr",
+    5: "Mai",
+    6: "Jun",
+    7: "Jul",
+    8: "Aug",
+    9: "Sep",
+    10: "Okt",
+    11: "Nov",
+    12: "Dez",
+}
+
+
+def _format_time_range_localized(start, end, lang_code):
+    """
+    Format a start/end datetime pair as a localised time-range string.
+
+    English: "Mon, Jan 1, 10:00 – 12:00"
+    German:  "Mo, 1. Jan, 10:00 – 12:00"
+    """
+    start_day_en = start.strftime("%a")
+    start_month = start.month
+    start_day_num = start.day
+    start_time = start.strftime("%H:%M")
+    end_time = end.strftime("%H:%M")
+
+    if lang_code == "de":
+        day_str = _DE_DAYS.get(start_day_en, start_day_en)
+        month_str = _DE_MONTHS_SHORT.get(start_month, start.strftime("%b"))
+        return f"{day_str}, {start_day_num}. {month_str}, {start_time} – {end_time}"
+
+    month_str = start.strftime("%b")
+    return f"{start_day_en}, {month_str} {start_day_num}, {start_time} – {end_time}"
+
+
+_FIELD_CELL_STYLE = (
+    "padding: 4px 0px 8px; color: #55575d; vertical-align: top; width: 50%"
+)
+
+
 def _build_field_answers_html(registration, lang_code):
     """
     Build an HTML snippet of the guest's registration field answers for the
@@ -600,8 +652,7 @@ def _build_field_answers_html(registration, lang_code):
     sorted_fields = sorted(answers_by_field.keys(), key=lambda f: f.order)
 
     heading = (
-        "Your registration answers" if lang_code == "en"
-        else "Deine Anmeldeantworten"
+        "Your registration answers:" if lang_code == "en" else "Deine Anmeldeantworten:"
     )
 
     rows = []
@@ -614,7 +665,8 @@ def _build_field_answers_html(registration, lang_code):
             # Strip HTML tags for plain text
             plain_desc = re.sub(r"<[^>]+>", "", description).strip()
             rows.append(
-                f'<tr><td colspan="2" style="padding: 4px 8px;">✓ {html_module.escape(plain_desc)}</td></tr>'
+                f'<tr><td style="{_FIELD_CELL_STYLE}">{html_module.escape(plain_desc)}</td>'
+                f'<td style="{_FIELD_CELL_STYLE}">✓</td></tr>'
             )
 
         elif field_type == RegistrationFieldType.OPTION_SELECT:
@@ -622,8 +674,8 @@ def _build_field_answers_html(registration, lang_code):
             option = answer.value_option
             answer_text = option.title if option else ""
             rows.append(
-                f'<tr><td style="padding: 4px 8px; color: #666;">{html_module.escape(field_title)}</td>'
-                f'<td style="padding: 4px 8px;">{html_module.escape(answer_text)}</td></tr>'
+                f'<tr><td style="{_FIELD_CELL_STYLE}">{html_module.escape(field_title)}</td>'
+                f'<td style="{_FIELD_CELL_STYLE}">{html_module.escape(answer_text)}</td></tr>'
             )
 
         elif field_type == RegistrationFieldType.INVENTORY:
@@ -633,36 +685,36 @@ def _build_field_answers_html(registration, lang_code):
             quantity = answer.value_number or 0
             answer_text = f"{option_title} × {quantity}"
             rows.append(
-                f'<tr><td style="padding: 4px 8px; color: #666;">{html_module.escape(field_title)}</td>'
-                f'<td style="padding: 4px 8px;">{html_module.escape(answer_text)}</td></tr>'
+                f'<tr><td style="{_FIELD_CELL_STYLE}">{html_module.escape(field_title)}</td>'
+                f'<td style="{_FIELD_CELL_STYLE}">{html_module.escape(answer_text)}</td></tr>'
             )
 
         elif field_type == RegistrationFieldType.TIME_SLOT_SELECT:
             field_title = (field.settings or {}).get("title", "")
             option = answer.value_option
             if option and option.start_time and option.end_time:
-                start = option.start_time.strftime("%a, %b %d, %H:%M")
-                end = option.end_time.strftime("%H:%M")
-                answer_text = f"{start} – {end}"
+                answer_text = _format_time_range_localized(
+                    option.start_time, option.end_time, lang_code
+                )
             elif option:
                 answer_text = option.title
             else:
                 answer_text = ""
             rows.append(
-                f'<tr><td style="padding: 4px 8px; color: #666;">{html_module.escape(field_title)}</td>'
-                f'<td style="padding: 4px 8px;">{html_module.escape(answer_text)}</td></tr>'
+                f'<tr><td style="{_FIELD_CELL_STYLE}">{html_module.escape(field_title)}</td>'
+                f'<td style="{_FIELD_CELL_STYLE}">{html_module.escape(answer_text)}</td></tr>'
             )
 
     if not rows:
         return ""
 
     return (
-        f'<div style="margin-top: 20px; padding-top: 15px; border-top: 1px solid #eee;">'
-        f'<p style="font-weight: bold; margin-bottom: 10px;">{heading}</p>'
+        f'<div style="margin-top: 20px; margin-bottom: 20px">'
+        f'<p style="font-weight: bold; margin-bottom: 10px; color: #55575d;">{heading}</p>'
         f'<table style="width: 100%; border-collapse: collapse;">'
         f'{"".join(rows)}'
-        f'</table>'
-        f'</div>'
+        f"</table>"
+        f"</div>"
     )
 
 

--- a/backend/organization/views/event_registration_views.py
+++ b/backend/organization/views/event_registration_views.py
@@ -278,10 +278,12 @@ class EventRegistrationsView(APIView):
         # transaction commits, at which point DRF may resolve a different user.
         _user_id = request.user.id
         _event_slug = project.url_slug
+        _registration_id = registration.id
         transaction.on_commit(
             lambda: _send_registration_email.delay(
                 user_id=_user_id,
                 event_slug=_event_slug,
+                registration_id=_registration_id,
             )
         )
 

--- a/doc/spec/20260601_1031_include_field_answers_in_registration_email.md
+++ b/doc/spec/20260601_1031_include_field_answers_in_registration_email.md
@@ -154,21 +154,22 @@ The `_build_field_answers_html()` helper:
    The heading text is localised: EN = "Your registration answers", DE = "Deine Anmeldeantworten" (mirrors the frontend modal header pattern from `registration_answers_modal_title` / `registration_answers_modal_title_self`).
 6. If no answers have non-null values, return empty string.
 
-**Plain-text email**: Mailjet auto-generates a plain-text version from the HTML. Table structure will be lost but the text content (field titles, answer values, checkmarks) will appear. The `{{#if}}` conditional also works in text mode. This is acceptable for a first iteration.
+**Plain-text email**: Mailjet auto-generates a plain-text version from the HTML. Table structure will be lost but the text content (field titles, answer values, checkmarks) will appear. The `{% if %}` conditional also works in text mode. This is acceptable for a first iteration.
 
 ### Mailjet Template Update
 
 The Mailjet template needs to include the `FieldAnswersHtml` variable. Instructions:
 
 1. Open the Mailjet template editor for the event registration confirmation template (both EN and DE).
-2. In the email body, after the existing event details section, add a conditional block:
+2. In the email body, after the existing event details section, add an **HTML block** (not a Template Language block). According to the [Mailjet documentation](https://documentation.mailjet.com/hc/en-us/articles/16886347025947-Mailjet-Templating-Language), raw HTML should be placed in an HTML block when combined with template language structures.
+3. Inside the HTML block, add the conditional and variable:
+   ```html
+   {% if var:FieldAnswersHtml != "" %}
+   {{var:FieldAnswersHtml}}
+   {% endif %}
    ```
-   {{#if var:FieldAnswersHtml}}<br/>
-   {{{var:FieldAnswersHtml}}}
-   {{/if}}
-   ```
-3. The triple braces `{{{...}}}` render the HTML unescaped. The `{{#if}}` block ensures the section only appears when answers exist.
-4. Save and test with a registration that has custom field answers.
+4. Mailjet's `{{var:...}}` renders HTML content as-is (no escaping). The `{% if %}` block ensures the section only appears when answers exist (comparing against empty string, consistent with existing template patterns like `LocationName`).
+5. Save and test with a registration that has custom field answers.
 
 ---
 
@@ -243,6 +244,8 @@ No frontend changes required — this is a backend + Mailjet template task.
 
 - 2026-06-01 10:31 — Spec created. Initial draft.
 - 2026-06-01 10:51 — Decisions finalized: checkbox → plain text with ✓ prefix (option B), heading → "Your registration answers" / "Deine Anmeldeantworten", non-checkbox labels → `settings.title`, inline styles (no custom CSS), Mailjet plain-text auto-generation accepted.
+- 2026-06-01 11:38 — Mailjet template syntax corrected: `{% if var:FieldAnswersHtml != "" %}` (not `{{#if}}`), consistent with existing template patterns.
+- 2026-06-01 11:55 — Mailjet template syntax simplified: `{{var:FieldAnswersHtml}}` (double braces, not triple). Use an HTML block in the DnD editor for raw HTML content with template language.
 
 ---
 
@@ -250,7 +253,7 @@ No frontend changes required — this is a backend + Mailjet template task.
 
 1. **HTML stripping for checkbox descriptions**: The checkbox `settings.description` can contain HTML (bold, links). For the email, we strip HTML tags to plain text with a `✓` prefix. This matches the modal's visual pattern (checked icon + description) but in text form. Rich formatting is lost but email rendering is safe.
 
-2. **Mailjet template update**: The spec includes step-by-step instructions for updating the Mailjet template. The key is using `{{{var:FieldAnswersHtml}}}` (triple braces) for unescaped HTML rendering and `{{#if var:FieldAnswersHtml}}` for conditional display. No custom CSS classes are needed — all styling is inline. If the template is not updated, the variable is simply ignored.
+2. **Mailjet template update**: The spec includes step-by-step instructions for updating the Mailjet template. Use an **HTML block** (not a Template Language block) with `{{var:FieldAnswersHtml}}` (double braces) and a `{% if var:FieldAnswersHtml != "" %}` conditional. No custom CSS classes are needed — all styling is inline. If the template is not updated, the variable is simply ignored. See [Mailjet documentation](https://documentation.mailjet.com/hc/en-us/articles/16886347025947-Mailjet-Templating-Language) for details on HTML blocks vs Template Language blocks.
 
 3. **Mailjet plain-text version**: Mailjet auto-generates a plain-text version from the HTML. Table structure will be lost but the text content appears. The `{{#if}}` conditional works in text mode. Acceptable for this iteration.
 

--- a/doc/spec/20260601_1031_include_field_answers_in_registration_email.md
+++ b/doc/spec/20260601_1031_include_field_answers_in_registration_email.md
@@ -1,0 +1,263 @@
+# Include Registration Field Answers in Confirmation Email
+
+**Status**: DRAFT
+**Type**: Feature
+**Date and time created**: 2026-06-01 10:31
+**GitHub Issue**: [#2023](https://github.com/climateconnect/climateconnect/issues/2023)
+**Epic**: [`EPIC_event_registration.md`](./EPIC_event_registration.md)
+**Related Specs**:
+- [`20260416_1000_event_registration_custom_fields.md`](./20260416_1000_event_registration_custom_fields.md) ← foundational custom fields spec
+- [`20260526_1130_guest_view_modify_registration.md`](./20260526_1130_guest_view_modify_registration.md) ← guest views/modify registration (shows answers in UI)
+
+---
+
+## Problem Statement
+
+When a guest registers for an event with custom registration fields, they receive a confirmation email. The email currently includes event details (title, date, organiser, location) but does **not** include the answers the guest provided for custom fields. The guest can view their answers in the frontend via the `ViewRegistrationAnswersModal`, but the confirmation email does not reflect this information. This means the guest has no email record of what they submitted.
+
+**Core Requirements (User/Stakeholder Stated):**
+
+1. If a registration config has custom fields and the guest provided answers, include those answers in the confirmation email.
+2. If there are no custom fields, or if all fields were optional and the guest did not provide any answers, do not add anything to the email.
+3. The answers should be presented in a similar style to the frontend `ViewRegistrationAnswersModal` — field label + answer value.
+4. The Mailjet template needs to be updated to display the answers, with clear instructions provided.
+
+**Explicitly Out of Scope:**
+
+- Changing the confirmation email subject or other existing template variables.
+- Including answers in the admin notification email (separate email, different template).
+- Including answers in the organiser message email.
+- Adding answers to the cancellation email.
+- Changing the `ViewRegistrationAnswersModal` or frontend answer display.
+
+### Non-Functional Requirements
+
+- **No breaking changes**: the existing template variables remain unchanged. The new variable is additive — if the template does not include it, nothing breaks.
+- **Graceful degradation**: if the Mailjet template is not updated to include the new variable, the email still sends correctly (the variable is simply ignored).
+- **Localization**: field labels and option titles are stored as-is by the organiser (not localised by the system). The email displays them verbatim, same as the frontend export.
+- **Performance**: the additional DB queries to fetch field answers and options should be minimal (the answers are already created in the same transaction as the registration).
+
+### AI Agent Insights and Additions
+
+- **Email function**: `send_event_registration_confirmation_to_user()` in `backend/organization/utility/email.py:562` builds the Mailjet template variables and calls `send_email()`. This is the only function that needs to change.
+
+- **Celery task**: `send_event_registration_confirmation_email` in `backend/organization/tasks.py:24` receives `user_id` and `event_slug`. It needs an additional `registration_id` parameter to efficiently fetch the field answers without an extra lookup query. The view dispatches the task at `event_registration_views.py:282`.
+
+- **Answer data model**: `RegistrationFieldAnswer` has three value columns: `value_boolean`, `value_option` (FK → `RegistrationFieldOption`), `value_number`. One row per `(registration, field)`. The `RegistrationField` has `field_type`, `label`, `settings`, and `order`. The `RegistrationFieldOption` has `title`, `start_time`, `end_time`.
+
+- **Answer resolution logic** (mirrors frontend `resolveAnswerToStrings()` in `frontend/src/utils/resolveRegistrationFieldAnswer.ts`):
+  - `checkbox`: `value_boolean === true` → show field label (the description is HTML from `settings.description`; strip to plain text for email).
+  - `option_select`: look up `value_option` → show `option.title`.
+  - `inventory`: look up `value_option` → show `"OptionTitle × value_number"`.
+  - `time_slot_select`: look up `value_option` → show formatted time range from `option.start_time`/`option.end_time`, falling back to `option.title`.
+
+- **Mailjet template variable approach**: Pass a single HTML string variable `FieldAnswersHtml` containing the pre-rendered answers. This avoids Mailjet's complex array/loop syntax and gives full control over the HTML. If no answers exist, pass an empty string. The template renders it with `{{{var:FieldAnswersHtml}}}` (triple braces for unescaped HTML in Mailjet's template language).
+
+- **Mailjet template update**: The template needs a conditional section that only renders when `FieldAnswersHtml` is non-empty. Mailjet supports `{{#if var:FieldAnswersHtml}}...{{/if}}` conditional blocks. If the template is not updated, the variable is simply ignored — no breaking change.
+
+- **HTML sanitization**: The checkbox field's `settings.description` can contain HTML (rich text). For the email, strip HTML tags to plain text to avoid rendering issues. Option titles and time slots are plain text.
+
+- **Field ordering**: Answers should be sorted by `field.order` (ascending), matching the frontend display order.
+
+---
+
+## System Impact
+
+### Actors
+- **Guest**: receives a confirmation email that now includes their field answers.
+- **Organiser**: no change to their workflow.
+
+### Entities Changed
+- No model changes. No new entities.
+
+### Flows Changed
+- **Registration confirmation email**: now includes field answers when present.
+
+### Integration Changes
+- The Celery task signature gains a `registration_id` parameter.
+- The Mailjet template variables gain a `FieldAnswersHtml` variable.
+- The Mailjet template needs a conditional section for `FieldAnswersHtml`.
+
+---
+
+## Software Architecture
+
+### API — No API Changes
+
+This task only changes the email sending logic. No API endpoints are modified.
+
+### Backend — Celery Task Signature Change
+
+The `send_event_registration_confirmation_email` task in `backend/organization/tasks.py` needs a `registration_id` parameter:
+
+```python
+@app.task(bind=True, max_retries=3, default_retry_delay=60)
+def send_event_registration_confirmation_email(self, user_id: int, event_slug: str, registration_id: int):
+```
+
+The view dispatches it with the new parameter:
+
+```python
+transaction.on_commit(
+    lambda: _send_registration_email.delay(
+        user_id=_user_id,
+        event_slug=_event_slug,
+        registration_id=_registration_id,
+    )
+)
+```
+
+### Backend — Email Function Changes
+
+In `send_event_registration_confirmation_to_user()`, add a `registration` parameter and build the `FieldAnswersHtml` variable:
+
+```python
+def send_event_registration_confirmation_to_user(user, project, registration):
+    # ... existing code ...
+
+    field_answers_html = _build_field_answers_html(registration, lang_code)
+
+    variables = {
+        # ... existing variables ...
+        "FieldAnswersHtml": field_answers_html,
+    }
+```
+
+The `_build_field_answers_html()` helper:
+
+1. Fetch `RegistrationFieldAnswer` objects for the registration, with `select_related("field", "value_option")`.
+2. Filter to only answers that have a non-null value (skip unanswered optional fields).
+3. Sort by `field.order`.
+4. For each answer, resolve to a display representation:
+   - **`checkbox`**: if `value_boolean is True`, render the `field.settings.description` as **plain text** (strip HTML tags) with a `✓` prefix. No label column — the description IS the answer (matches `ViewRegistrationAnswersModal` pattern). Unchecked checkboxes (`value_boolean` is not True) are skipped entirely.
+   - **`option_select`**: label = `field.settings.title`, answer = `option.title`.
+   - **`inventory`**: label = `field.settings.title`, answer = `"{option.title} × {value_number}"`.
+   - **`time_slot_select`**: label = `field.settings.title`, answer = formatted time range from `option.start_time`/`option.end_time`, falling back to `option.title`.
+   - Non-checkbox field labels use `field.settings.title` (the user-facing title), **not** `field.label` (the organiser-facing internal label used for export).
+5. Render as an HTML snippet with inline styles (no custom CSS classes needed):
+   ```html
+   <div style="margin-top: 20px; padding-top: 15px; border-top: 1px solid #eee;">
+     <p style="font-weight: bold; margin-bottom: 10px;">Your registration answers</p>
+     <table style="width: 100%; border-collapse: collapse;">
+       <!-- Checkbox: single column with ✓ prefix -->
+       <tr>
+         <td colspan="2" style="padding: 4px 8px;">✓ I agree to the terms</td>
+       </tr>
+       <!-- Other field types: two columns (label + answer) -->
+       <tr>
+         <td style="padding: 4px 8px; color: #666;">Preferred workshop</td>
+         <td style="padding: 4px 8px;">Solar panel installation</td>
+       </tr>
+     </table>
+   </div>
+   ```
+   The heading text is localised: EN = "Your registration answers", DE = "Deine Anmeldeantworten" (mirrors the frontend modal header pattern from `registration_answers_modal_title` / `registration_answers_modal_title_self`).
+6. If no answers have non-null values, return empty string.
+
+**Plain-text email**: Mailjet auto-generates a plain-text version from the HTML. Table structure will be lost but the text content (field titles, answer values, checkmarks) will appear. The `{{#if}}` conditional also works in text mode. This is acceptable for a first iteration.
+
+### Mailjet Template Update
+
+The Mailjet template needs to include the `FieldAnswersHtml` variable. Instructions:
+
+1. Open the Mailjet template editor for the event registration confirmation template (both EN and DE).
+2. In the email body, after the existing event details section, add a conditional block:
+   ```
+   {{#if var:FieldAnswersHtml}}<br/>
+   {{{var:FieldAnswersHtml}}}
+   {{/if}}
+   ```
+3. The triple braces `{{{...}}}` render the HTML unescaped. The `{{#if}}` block ensures the section only appears when answers exist.
+4. Save and test with a registration that has custom field answers.
+
+---
+
+## Acceptance Criteria
+
+- [ ] When a guest registers for an event with custom fields and provides answers, the confirmation email includes those answers in a readable format.
+- [ ] When a guest registers for an event without custom fields, the confirmation email is unchanged (no extra section).
+- [ ] When a guest registers for an event with optional custom fields but provides no answers, the confirmation email is unchanged.
+- [ ] Checkbox fields show the description (stripped of HTML) when checked. Unchecked checkboxes are not shown.
+- [ ] Option select fields show the field title and selected option title.
+- [ ] Inventory fields show the field title, selected option title, and quantity.
+- [ ] Time slot fields show the field title and formatted time range.
+- [ ] Answers are ordered by field order (matching the frontend display).
+- [ ] The Mailjet template renders the answers section only when `FieldAnswersHtml` is non-empty.
+- [ ] Both EN and DE Mailjet templates are updated.
+- [ ] The existing template variables (`FirstName`, `EventTitle`, etc.) are unchanged.
+
+---
+
+## Test Cases
+
+### Backend Tests
+
+| Scenario | Expected |
+|----------|----------|
+| Register with checkbox (checked) | Email contains checkbox description |
+| Register with checkbox (unchecked) | Email does not contain checkbox section |
+| Register with option_select | Email contains field title + selected option title |
+| Register with inventory | Email contains field title + option title × quantity |
+| Register with time_slot_select | Email contains field title + formatted time range |
+| Register with multiple fields | All answers shown, ordered by field.order |
+| Register with no custom fields | Email has no FieldAnswersHtml section |
+| Register with optional fields, no answers | Email has no FieldAnswersHtml section |
+| Register with mix of answered and unanswered optional fields | Only answered fields shown |
+
+### Frontend Tests
+
+No frontend changes required — this is a backend + Mailjet template task.
+
+---
+
+## Files to Change
+
+### Backend
+
+| File | Change |
+|------|--------|
+| `backend/organization/tasks.py` | Add `registration_id` parameter to `send_event_registration_confirmation_email`; fetch registration with related answers; pass to email function |
+| `backend/organization/utility/email.py` | Add `registration` parameter to `send_event_registration_confirmation_to_user`; add `_build_field_answers_html()` helper; add `FieldAnswersHtml` to template variables |
+| `backend/organization/views/event_registration_views.py` | Pass `registration_id` to the Celery task dispatch |
+| `backend/organization/tests/test_event_registration_*.py` | Add test cases for email with field answers |
+
+### Mailjet Templates (manual update)
+
+| Template | Change |
+|----------|--------|
+| Event Registration Confirmation (EN) | Add conditional `FieldAnswersHtml` section |
+| Event Registration Confirmation (DE) | Add conditional `FieldAnswersHtml` section |
+
+---
+
+## Dependency Notes
+
+- **Depends on**: Custom fields infrastructure (Phase 4a — already complete). Registration confirmation email (already complete).
+- **Enables**: Nothing directly, but improves the guest experience.
+- **No new migrations required**.
+- **No new API endpoints required**.
+
+---
+
+## Log
+
+- 2026-06-01 10:31 — Spec created. Initial draft.
+- 2026-06-01 10:51 — Decisions finalized: checkbox → plain text with ✓ prefix (option B), heading → "Your registration answers" / "Deine Anmeldeantworten", non-checkbox labels → `settings.title`, inline styles (no custom CSS), Mailjet plain-text auto-generation accepted.
+
+---
+
+## Notes and Open Questions
+
+1. **HTML stripping for checkbox descriptions**: The checkbox `settings.description` can contain HTML (bold, links). For the email, we strip HTML tags to plain text with a `✓` prefix. This matches the modal's visual pattern (checked icon + description) but in text form. Rich formatting is lost but email rendering is safe.
+
+2. **Mailjet template update**: The spec includes step-by-step instructions for updating the Mailjet template. The key is using `{{{var:FieldAnswersHtml}}}` (triple braces) for unescaped HTML rendering and `{{#if var:FieldAnswersHtml}}` for conditional display. No custom CSS classes are needed — all styling is inline. If the template is not updated, the variable is simply ignored.
+
+3. **Mailjet plain-text version**: Mailjet auto-generates a plain-text version from the HTML. Table structure will be lost but the text content appears. The `{{#if}}` conditional works in text mode. Acceptable for this iteration.
+
+4. **Field label source**: Non-checkbox fields use `field.settings.title` (user-facing) as the label, not `field.label` (organiser-facing internal label for export). This matches the frontend `ViewRegistrationAnswersModal` pattern.
+
+5. **Heading localization**: The section heading "Your registration answers" (EN) / "Deine Anmeldeantworten" (DE) mirrors the frontend modal header pattern. The heading is resolved in the backend based on the user's language, not passed as a template variable.
+
+6. **Future: structured template variables**: If the template needs more control over answer styling (e.g. different styles per field type), the backend could pass structured array variables instead of a single HTML string. This would require Mailjet's `{{#each}}` loop syntax. The current approach (single HTML string) is simpler and sufficient for this iteration.
+
+7. **Future: include answers in admin notification**: The admin notification email (`send_admin_event_notification`) does not include field answers. This could be a future enhancement but is out of scope for this task.

--- a/doc/spec/EPIC_event_registration.md
+++ b/doc/spec/EPIC_event_registration.md
@@ -149,6 +149,14 @@ guest's registration.
 |-------|-------------|------|--------|
 | Export event registration results with custom field data | [#1962](https://github.com/climateconnect/climateconnect/issues/1962) | [`20260527_0830_export_event_registration_with_custom_fields.md`](./20260527_0830_export_event_registration_with_custom_fields.md) | ✅ Done   |
 
+#### Phase 4z — Registration Email with Field Answers (cross-cutting)
+
+When a guest registers for an event with custom fields, include the provided answers in the confirmation email. If no custom fields exist or no answers were provided, the email is unchanged.
+
+| Story | GitHub Issue | Spec | Status |
+|-------|-------------|------|--------|
+| Include field answers in registration confirmation email | [#2023](https://github.com/climateconnect/climateconnect/issues/2023) | [`20260601_1031_include_field_answers_in_registration_email.md`](./20260601_1031_include_field_answers_in_registration_email.md) | ⚪ |
+
 #### Phase 4c+ — Further Field Types (TBD)
 
 Additional field types (e.g. free text, number, date) to be defined based on user feedback after Phase 4a ships.


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Implements #2023
