### PR TITLE
Improve draft mode handling of event registration config

### DIFF
--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -1337,10 +1337,8 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       de: "Anmeldeeinrichtung abschließen",
     },
     registration_config_still_draft_warning: {
-      en:
-        "Registration configuration is not yet complete. You can publish the event now and complete the registration settings later.",
-      de:
-        "Die Anmeldekonfiguration ist noch nicht vollständig. Du kannst das Event jetzt veröffentlichen und die Anmeldeeinstellungen später abschließen.",
+      en: "Registration configuration is not yet complete.",
+      de: "Die Anmeldekonfiguration ist noch nicht vollständig.",
     },
     registration_custom_fields: {
       en: "Additional registration fields",

--- a/frontend/src/components/editProject/EditProjectContent.tsx
+++ b/frontend/src/components/editProject/EditProjectContent.tsx
@@ -1,4 +1,4 @@
-import { Button, Switch, TextField, Typography, useMediaQuery, Theme } from "@mui/material";
+import { Box, Button, Switch, TextField, Typography, useMediaQuery, Theme } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import React, { RefObject, useContext, useState } from "react";
 import getProjectTypeTexts from "../../../public/data/projectTypeTexts";
@@ -70,9 +70,6 @@ const useStyles = makeStyles<Theme>((theme) => ({
     justifyContent: "space-between",
     alignItems: "center",
   },
-  editRegistrationBtn: {
-    float: "right",
-  },
   warning: {
     color: theme.palette.error.main,
   },
@@ -86,7 +83,6 @@ type Args = {
   errors: any;
   contentRef?: RefObject<any>;
   projectTypeOptions?: any;
-  registrationConfigWarning?: string | null;
 };
 
 export default function EditProjectContent({
@@ -97,7 +93,6 @@ export default function EditProjectContent({
   errors,
   contentRef,
   projectTypeOptions,
-  registrationConfigWarning,
 }: Args) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
@@ -174,21 +169,22 @@ export default function EditProjectContent({
           <Typography component="span">{projectTypeTexts.organizations[typeId]}</Typography>
         </div>
         {showEditRegistrationButton && (
-          <Button
-            variant="outlined"
-            color="primary"
-            startIcon={<SettingsIcon />}
-            onClick={() => setEditRegistrationOpen(true)}
-            aria-label={texts.edit_registration_settings}
-            className={classes.editRegistrationBtn}
-          >
-            {texts.edit_registration_settings}
-          </Button>
-        )}
-        {showEditRegistrationButton && registrationConfigWarning && (
-          <Typography variant="body2" color="warning.main" sx={{ mt: 0.5, mb: 1 }}>
-            {registrationConfigWarning}
-          </Typography>
+          <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end", mb: 1 }}>
+            <Button
+              variant="outlined"
+              color="primary"
+              startIcon={<SettingsIcon />}
+              onClick={() => setEditRegistrationOpen(true)}
+              aria-label={texts.edit_registration_settings}
+            >
+              {texts.edit_registration_settings}
+            </Button>
+            {project.registration_config?.is_draft && (
+              <Typography variant="body2" color="warning.main" sx={{ mt: 0.5 }}>
+                {texts.registration_config_still_draft_warning}
+              </Typography>
+            )}
+          </Box>
         )}
         <div className={classes.block}>
           {project.is_personal_project ? (

--- a/frontend/src/components/editProject/EditProjectRoot.tsx
+++ b/frontend/src/components/editProject/EditProjectRoot.tsx
@@ -22,7 +22,6 @@ import getProjectTypeTexts from "../../../public/data/projectTypeTexts";
 import ROLE_TYPES from "../../../public/data/role_types";
 import { Project, Role, Sector } from "../../types";
 import UserContext from "../context/UserContext";
-import { useFeatureToggles } from "../featureToggle";
 import NavigationButtons from "../general/NavigationButtons";
 import TranslateTexts from "../general/TranslateTexts";
 import ConfirmDialog from "../dialogs/ConfirmDialog";
@@ -98,9 +97,7 @@ export default function EditProjectRoot({
     start_date: "",
     end_date: "",
   });
-  const [registrationConfigWarning, setRegistrationConfigWarning] = useState<string | null>(null);
   const contentRef = useRef(null);
-  const { isEnabled } = useFeatureToggles();
 
   const sourceLanguage = project.language ? project.language : locale;
   const targetLanguage = locales.find((l) => l !== sourceLanguage);
@@ -159,18 +156,6 @@ export default function EditProjectRoot({
         );
         return false;
       }
-    }
-
-    // Soft warning when publishing with a draft registration config
-    if (
-      !isDraft &&
-      project.project_type?.type_id === "event" &&
-      project.registration_config?.is_draft &&
-      isEnabled("EVENT_REGISTRATION")
-    ) {
-      setRegistrationConfigWarning(texts.registration_config_still_draft_warning);
-    } else {
-      setRegistrationConfigWarning(null);
     }
 
     return true;
@@ -412,7 +397,6 @@ export default function EditProjectRoot({
             errors={errors}
             contentRef={contentRef}
             projectTypeOptions={projectTypeOptions}
-            registrationConfigWarning={registrationConfigWarning}
           />
           <Divider className={classes.divider} />
           <NavigationButtons


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

minor improvement for #2021
