### PR TITLE
Allow the user to turn event registration on/off when editing an event

### DIFF
--- a/backend/organization/migrations/0137_eventregistrationconfig_registration_enabled.py
+++ b/backend/organization/migrations/0137_eventregistrationconfig_registration_enabled.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("organization", "0136_eventregistrationconfig_is_draft"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="eventregistrationconfig",
+            name="registration_enabled",
+            field=models.BooleanField(
+                default=True,
+                help_text=(
+                    "When False, registration features are hidden for this event. "
+                    "The config is preserved and can be re-enabled later. "
+                    "Unlike is_draft, this field is reversible."
+                ),
+                verbose_name="Registration Enabled",
+            ),
+        ),
+    ]

--- a/backend/organization/models/event_registration.py
+++ b/backend/organization/models/event_registration.py
@@ -131,6 +131,16 @@ class EventRegistrationConfig(models.Model):
         verbose_name="Is Draft",
     )
 
+    registration_enabled = models.BooleanField(
+        default=True,
+        help_text=(
+            "When False, registration features are hidden for this event. "
+            "The config is preserved and can be re-enabled later. "
+            "Unlike is_draft, this field is reversible."
+        ),
+        verbose_name="Registration Enabled",
+    )
+
     notify_admins = models.BooleanField(
         default=True,
         help_text=(

--- a/backend/organization/serializers/event_registration.py
+++ b/backend/organization/serializers/event_registration.py
@@ -110,6 +110,7 @@ class EventRegistrationConfigSerializer(EventRegistrationConfigBaseSerializer):
             "available_seats",
             "notify_admins",
             "is_draft",
+            "registration_enabled",
         ]
         extra_kwargs = {
             # PositiveIntegerField gives us min_value via the model, but we set
@@ -123,6 +124,7 @@ class EventRegistrationConfigSerializer(EventRegistrationConfigBaseSerializer):
             # EditEventRegistrationConfigSerializer.
             "notify_admins": {"required": False},
             "is_draft": {"required": False},
+            "registration_enabled": {"required": False},
         }
 
     def get_available_seats(self, obj):
@@ -699,6 +701,7 @@ class EditEventRegistrationConfigSerializer(EventRegistrationConfigBaseSerialize
             "available_seats",
             "notify_admins",
             "is_draft",
+            "registration_enabled",
         ]
         extra_kwargs = {
             "max_participants": {"required": False, "allow_null": True, "min_value": 1},
@@ -706,6 +709,7 @@ class EditEventRegistrationConfigSerializer(EventRegistrationConfigBaseSerialize
             "status": {"required": False},
             "notify_admins": {"required": False},
             "is_draft": {"required": False},
+            "registration_enabled": {"required": False},
         }
 
     def validate_status(self, value):

--- a/backend/organization/serializers/project.py
+++ b/backend/organization/serializers/project.py
@@ -223,12 +223,15 @@ class ProjectSerializer(_LocationNameMixin, serializers.ModelSerializer):
     def get_registration_config(self, obj):
         """Return event registration config including available_seats (detail only).
 
-        Draft configs are only visible to project admins. Non-admin viewers
-        see None — the config is not yet published and should not be exposed.
+        Disabled configs are hidden from everyone. Draft configs are only
+        visible to project admins.
         """
         try:
             rc = obj.registration_config
         except EventRegistrationConfig.DoesNotExist:
+            return None
+
+        if not rc.registration_enabled:
             return None
 
         if rc.is_draft:
@@ -533,11 +536,15 @@ class ProjectStubSerializer(_LocationNameMixin, serializers.ModelSerializer):
     def get_registration_config(self, obj):
         """Return event registration config if present, else None.
 
-        Draft configs are only visible to project admins.
+        Disabled configs are hidden from everyone. Draft configs are only
+        visible to project admins.
         """
         try:
             rc = obj.registration_config
         except EventRegistrationConfig.DoesNotExist:
+            return None
+
+        if not rc.registration_enabled:
             return None
 
         if rc.is_draft:

--- a/backend/organization/tests/test_registration_enabled.py
+++ b/backend/organization/tests/test_registration_enabled.py
@@ -1,0 +1,363 @@
+"""
+Tests for the registration_enabled feature (Phase 4w backend).
+
+Covers spec test cases:
+  1. POST to create config for event without config
+  2. POST when config already exists and enabled
+  3. POST when config exists but disabled (re-enable)
+  4. POST by non-admin
+  5. POST for non-event project
+  6. PATCH to disable enabled config
+  7. PATCH to re-enable disabled config
+  8. Disabled config excluded from project detail response
+  9. Disabled config excluded from project list response
+  10. Disabled config with custom fields preserved
+  11. PATCH to disable published config
+"""
+
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import tag
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from climateconnect_api.models import Language, Role, UserProfile
+from organization.models import Project, ProjectMember, ProjectStatus
+from organization.models.event_registration import (
+    EventRegistration,
+    EventRegistrationConfig,
+    RegistrationStatus,
+)
+
+
+class TestRegistrationEnabled(APITestCase):
+    """
+    Tests for POST and PATCH on /api/projects/{slug}/registration-config/
+    with registration_enabled toggle.
+    """
+
+    def setUp(self):
+        self.project_status, _ = ProjectStatus.objects.update_or_create(
+            id=2,
+            defaults={
+                "name": "active_reg_toggle",
+                "has_end_date": True,
+                "has_start_date": True,
+            },
+        )
+        self.language, _ = Language.objects.get_or_create(
+            language_code="en",
+            defaults={"name": "English", "native_name": "English"},
+        )
+
+        # Organiser
+        self.organiser = User.objects.create_user(
+            username="reg_toggle_org",
+            password="testpassword",
+            email="org@example.com",
+        )
+        self.admin_role = Role.objects.create(
+            name="Admin_reg_toggle", role_type=Role.ALL_TYPE
+        )
+
+        # Non-admin
+        self.non_admin = User.objects.create_user(
+            username="reg_toggle_nonadmin",
+            password="testpassword",
+        )
+        # UserProfile required for list endpoint
+        UserProfile.objects.get_or_create(user=self.organiser, defaults={"name": "Org"})
+        UserProfile.objects.get_or_create(
+            user=self.non_admin, defaults={"name": "NonAdmin"}
+        )
+
+        # Event project without registration
+        self.event_no_reg = Project.objects.create(
+            name="Event No Reg",
+            url_slug="event-no-reg",
+            is_active=True,
+            is_draft=False,
+            status=self.project_status,
+            language=self.language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=10),
+            end_date=timezone.now() + timedelta(days=60),
+        )
+        self.admin = ProjectMember.objects.create(
+            user=self.organiser,
+            project=self.event_no_reg,
+            role=self.admin_role,
+        )
+
+        # Event project with enabled config
+        self.event_with_reg = Project.objects.create(
+            name="Event With Reg",
+            url_slug="event-with-reg",
+            is_active=True,
+            is_draft=False,
+            status=self.project_status,
+            language=self.language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=10),
+            end_date=timezone.now() + timedelta(days=60),
+        )
+        self.enabled_config = EventRegistrationConfig.objects.create(
+            project=self.event_with_reg,
+            max_participants=50,
+            registration_end_date=timezone.now() + timedelta(days=30),
+            status=RegistrationStatus.OPEN,
+            is_draft=False,
+            registration_enabled=True,
+        )
+        # Add a member so there are active registrations
+        self.reg_user = User.objects.create_user(
+            username="reg_toggle_participant", password="testpassword"
+        )
+        EventRegistration.objects.create(
+            user=self.reg_user, registration_config=self.enabled_config
+        )
+
+        # Event project with disabled config
+        self.event_disabled_reg = Project.objects.create(
+            name="Event Disabled Reg",
+            url_slug="event-disabled-reg",
+            is_active=True,
+            is_draft=False,
+            status=self.project_status,
+            language=self.language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=10),
+            end_date=timezone.now() + timedelta(days=60),
+        )
+        self.disabled_config = EventRegistrationConfig.objects.create(
+            project=self.event_disabled_reg,
+            max_participants=30,
+            status=RegistrationStatus.OPEN,
+            is_draft=False,
+            registration_enabled=False,
+        )
+
+        # Non-event project
+        self.non_event = Project.objects.create(
+            name="Non Event",
+            url_slug="non-event",
+            is_active=True,
+            is_draft=False,
+            status=self.project_status,
+            language=self.language,
+            project_type="HO",
+            start_date=timezone.now() + timedelta(days=10),
+            end_date=timezone.now() + timedelta(days=60),
+        )
+
+        # Admin member on all event projects
+        for project in [
+            self.event_no_reg,
+            self.event_with_reg,
+            self.event_disabled_reg,
+            self.non_event,
+        ]:
+            ProjectMember.objects.get_or_create(
+                user=self.organiser,
+                project=project,
+                defaults={"role": self.admin_role},
+            )
+
+    def _post_url(self, slug):
+        return f"/api/projects/{slug}/registration-config/"
+
+    def _patch_url(self, slug):
+        return f"/api/projects/{slug}/registration-config/"
+
+    # ── 1. POST to create config for event without config ────────────────────
+
+    @tag("registration_enabled", "post")
+    def test_post_creates_draft_config(self):
+        """POST creates a draft config with registration_enabled=True."""
+        self.client.login(username="reg_toggle_org", password="testpassword")
+        response = self.client.post(
+            self._post_url("event-no-reg"), data={}, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertTrue(response.data["is_draft"])
+        self.assertTrue(response.data["registration_enabled"])
+        self.assertEqual(response.data["status"], "open")
+        self.assertIsNone(response.data["max_participants"])
+        self.assertIsNone(response.data["registration_end_date"])
+
+    # ── 2. POST when config already exists and enabled ───────────────────────
+
+    @tag("registration_enabled", "post")
+    def test_post_returns_409_when_enabled(self):
+        """POST returns 409 when a config already exists and is enabled."""
+        self.client.login(username="reg_toggle_org", password="testpassword")
+        response = self.client.post(
+            self._post_url("event-with-reg"), data={}, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    # ── 3. POST when config exists but disabled (re-enable) ──────────────────
+
+    @tag("registration_enabled", "post")
+    def test_post_re_enables_disabled_config(self):
+        """POST re-enables an existing disabled config."""
+        self.client.login(username="reg_toggle_org", password="testpassword")
+        response = self.client.post(
+            self._post_url("event-disabled-reg"),
+            data={},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.assertTrue(response.data["registration_enabled"])
+        self.assertFalse(response.data["is_draft"])
+        self.disabled_config.refresh_from_db()
+        self.assertTrue(self.disabled_config.registration_enabled)
+
+    # ── 4. POST by non-admin ────────────────────────────────────────────────
+
+    @tag("registration_enabled", "post")
+    def test_post_by_non_admin_returns_403(self):
+        """POST by non-admin returns 403."""
+        self.client.login(username="reg_toggle_nonadmin", password="testpassword")
+        response = self.client.post(
+            self._post_url("event-no-reg"), data={}, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # ── 5. POST for non-event project ───────────────────────────────────────
+
+    @tag("registration_enabled", "post")
+    def test_post_for_non_event_returns_400(self):
+        """POST for non-event project returns 400."""
+        self.client.login(username="reg_toggle_org", password="testpassword")
+        response = self.client.post(
+            self._post_url("non-event"), data={}, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # ── 6. PATCH to disable enabled config ───────────────────────────────────
+
+    @tag("registration_enabled", "patch")
+    def test_patch_disables_enabled_config(self):
+        """PATCH registration_enabled=false disables the config."""
+        self.client.login(username="reg_toggle_org", password="testpassword")
+        response = self.client.patch(
+            self._patch_url("event-with-reg"),
+            data={"registration_enabled": False},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.assertFalse(response.data["registration_enabled"])
+        self.enabled_config.refresh_from_db()
+        self.assertFalse(self.enabled_config.registration_enabled)
+
+    # ── 7. PATCH to re-enable disabled config ────────────────────────────────
+
+    @tag("registration_enabled", "patch")
+    def test_patch_re_enables_disabled_config(self):
+        """PATCH registration_enabled=true re-enables the config."""
+        self.client.login(username="reg_toggle_org", password="testpassword")
+        response = self.client.patch(
+            self._patch_url("event-disabled-reg"),
+            data={"registration_enabled": True},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.assertTrue(response.data["registration_enabled"])
+        self.disabled_config.refresh_from_db()
+        self.assertTrue(self.disabled_config.registration_enabled)
+
+    # ── 8. Disabled config excluded from project detail response ─────────────
+
+    @tag("registration_enabled", "filter")
+    def test_disabled_config_excluded_from_detail(self):
+        """Disabled config is null in project detail response."""
+        self.client.login(username="reg_toggle_org", password="testpassword")
+        response = self.client.get(f"/api/projects/event-disabled-reg/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data.get("registration_config"))
+
+    # ── 9. Disabled config excluded from project list response ───────────────
+
+    @tag("registration_enabled", "filter")
+    def test_disabled_config_excluded_from_list(self):
+        """Disabled config is null in project list response."""
+        self.client.login(username="reg_toggle_org", password="testpassword")
+        response = self.client.get("/api/projects/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = (
+            response.data
+            if isinstance(response.data, list)
+            else response.data.get("results", [])
+        )
+        for p in results:
+            if p["url_slug"] == "event-disabled-reg":
+                self.assertIsNone(p.get("registration_config"))
+                return
+        self.fail("event-disabled-reg not found in project list")
+
+    # ── 10. Disabled config with custom fields preserved ─────────────────────
+
+    @tag("registration_enabled", "filter")
+    def test_disabled_config_fields_preserved_in_db(self):
+        """Custom fields are preserved in DB after disabling."""
+        from organization.models.registration_field import (
+            RegistrationField,
+            RegistrationFieldType,
+        )
+
+        RegistrationField.objects.create(
+            registration_config=self.disabled_config,
+            field_type=RegistrationFieldType.OPTION_SELECT,
+            order=0,
+            label="Workshop",
+            settings={"title": "Preferred workshop"},
+        )
+        # Disable
+        self.client.login(username="reg_toggle_org", password="testpassword")
+        self.client.patch(
+            self._patch_url("event-disabled-reg"),
+            data={"registration_enabled": False},
+            content_type="application/json",
+        )
+        # Re-enable
+        response = self.client.patch(
+            self._patch_url("event-disabled-reg"),
+            data={"registration_enabled": True},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(
+            RegistrationField.objects.filter(
+                registration_config=self.disabled_config
+            ).exists()
+        )
+
+    # ── 11. PATCH to disable published config ────────────────────────────────
+
+    @tag("registration_enabled", "patch")
+    def test_patch_disables_published_config(self):
+        """Disabling a published config preserves status."""
+        self.client.login(username="reg_toggle_org", password="testpassword")
+        response = self.client.patch(
+            self._patch_url("event-with-reg"),
+            data={"registration_enabled": False},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.enabled_config.refresh_from_db()
+        self.assertFalse(self.enabled_config.registration_enabled)
+        # Status should be preserved
+        self.assertEqual(self.enabled_config.status, RegistrationStatus.OPEN)
+
+    # ── 12. POST by unauthenticated returns 401 ─────────────────────────────
+
+    @tag("registration_enabled", "post")
+    def test_post_unauthenticated_returns_401(self):
+        """POST by unauthenticated user returns 401."""
+        response = self.client.post(
+            self._post_url("event-no-reg"), data={}, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/backend/organization/views/event_registration_views.py
+++ b/backend/organization/views/event_registration_views.py
@@ -23,6 +23,7 @@ from organization.models.registration_field import (
 )
 from organization.serializers.event_registration import (
     EditEventRegistrationConfigSerializer,
+    EventRegistrationConfigSerializer,
     EventRegistrationSerializer,
     EventRegistrationSubmissionSerializer,
     SendOrganizerEmailSerializer,
@@ -496,15 +497,20 @@ class EventRegistrationsView(APIView):
 
 class EditRegistrationConfigView(APIView):
     """
+    POST /api/projects/{url_slug}/registration-config/
     PATCH /api/projects/{url_slug}/registration-config/
 
-    Allows an event organiser (or team admin) to update registration settings
-    for an event that already has EventRegistrationConfig enabled.
+    POST: Creates a new draft registration config for an event, or re-enables
+          an existing disabled config. Requires project admin role.
 
-    Editable fields:
+    PATCH: Allows an event organiser (or team admin) to update registration
+           settings for an event that already has EventRegistrationConfig.
+
+    Editable fields (PATCH):
         - max_participants  (positive integer or null for unlimited)
         - registration_end_date  (datetime)
         - status  ("open" or "closed" only — "full" and "ended" are system-managed)
+        - registration_enabled  (boolean — disable/enable registration)
 
     Status change rules:
         - "open" → "closed"   Organiser manually closes registration.
@@ -514,24 +520,87 @@ class EditRegistrationConfigView(APIView):
           returns 400 — extend registration_end_date first, then reopen.
         - "full" and "ended" cannot be set via the API (400 Bad Request).
         - Setting status to its current stored value is idempotent (200 OK).
-
-    Behaviour:
-        - 200 OK          — settings updated; returns updated registration_config.
-        - 400 Bad Request — validation error (past date, invalid status, etc.).
-        - 401 Unauthorized — unauthenticated request.
-        - 403 Forbidden    — authenticated user without edit rights on the project.
-        - 404 Not Found    — project or EventRegistrationConfig does not exist.
-
-    Response body (200 OK):
-        {
-            "max_participants": 80,
-            "registration_end_date": "2026-07-01T18:00:00Z",
-            "status": "open" | "closed" | "full" | "ended",
-            "available_seats": 75
-        }
     """
 
     permission_classes = [IsAuthenticated]
+
+    def post(self, request, url_slug):
+        """Create or re-enable a registration config for an event."""
+
+        # ── 1. Look up project ──────────────────────────────────────────────
+        try:
+            project = Project.objects.get(url_slug=url_slug)
+        except Project.DoesNotExist:
+            return Response(
+                {"message": "Project not found: {}".format(url_slug)},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # ── 2. Verify event project type ────────────────────────────────────
+        from organization.models.type import ProjectTypesChoices
+
+        if (
+            not project.project_type
+            or project.project_type != ProjectTypesChoices.event
+        ):
+            return Response(
+                {"message": "Registration is only available for event projects."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # ── 3. Check edit rights ────────────────────────────────────────────
+        has_edit_rights = ProjectMember.objects.filter(
+            user=request.user,
+            role__role_type__in=[Role.ALL_TYPE, Role.READ_WRITE_TYPE],
+            project=project,
+        ).exists()
+        if not has_edit_rights:
+            return Response(
+                {"message": "You do not have permission to edit this project."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        # ── 4. Check for existing config ────────────────────────────────────
+        try:
+            rc = project.registration_config
+            if rc.registration_enabled:
+                return Response(
+                    {"message": "Registration is already enabled for this event."},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            # Re-enable existing disabled config
+            rc.registration_enabled = True
+            rc.save(update_fields=["registration_enabled", "updated_at"])
+            serializer = EventRegistrationConfigSerializer(
+                rc, context={"include_seat_count": True}
+            )
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except EventRegistrationConfig.DoesNotExist:
+            pass
+
+        # ── 5. Create new draft config ──────────────────────────────────────
+        # Don't allow adding registration to past events.
+        if project.end_date and project.end_date < timezone.now():
+            return Response(
+                {"message": "Cannot add registration to a past event."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        rc = EventRegistrationConfig.objects.create(
+            project=project,
+            is_draft=True,
+            registration_enabled=True,
+            status=RegistrationStatus.OPEN,
+        )
+        serializer = EventRegistrationConfigSerializer(
+            rc, context={"include_seat_count": True}
+        )
+        logger.info(
+            "[EventRegistration] Organiser %s created registration config for '%s'",
+            request.user.id,
+            url_slug,
+        )
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def patch(self, request, url_slug):
 
@@ -565,7 +634,18 @@ class EditRegistrationConfigView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        # ── 4. Validate and save ─────────────────────────────────────────────
+        # ── 4. Handle registration_enabled toggle ────────────────────────────
+        # When only registration_enabled is in the request body, skip full
+        # validation — it's a simple boolean toggle.
+        if "registration_enabled" in request.data and len(request.data) == 1:
+            rc.registration_enabled = bool(request.data["registration_enabled"])
+            rc.save(update_fields=["registration_enabled", "updated_at"])
+            serializer = EventRegistrationConfigSerializer(
+                rc, context={"include_seat_count": True}
+            )
+            return Response(serializer.data, status=status.HTTP_200_OK)
+
+        # ── 5. Validate and save ─────────────────────────────────────────────
         # Derive is_draft from the config's own state, not the project's.
         # Draft configs skip publish-time field validation (e.g. empty checkbox
         # description) without requiring the frontend to pass extra state.

--- a/backend/organization/views/project_views.py
+++ b/backend/organization/views/project_views.py
@@ -596,7 +596,9 @@ class CreateProjectView(APIView):
         # Create EventRegistrationConfig (and any nested custom fields) atomically.
         # Using serializer.save() so the serializer's create() handles nested fields.
         if er_serializer is not None:
-            er_serializer.save(project=project, is_draft=is_draft)
+            er_serializer.save(
+                project=project, is_draft=is_draft, registration_enabled=True
+            )
             logger.info(
                 "EventRegistrationConfig created for project %s (is_draft=%s)",
                 project.url_slug,

--- a/doc/spec/20260602_0755_add_registration_to_existing_event.md
+++ b/doc/spec/20260602_0755_add_registration_to_existing_event.md
@@ -14,7 +14,7 @@
 
 Currently, registration configuration can only be added during event creation. If an organiser creates an event without enabling registration, there is **no way to add it later** — the `showEditRegistrationButton` in `EditProjectContent.tsx` requires `!!project.registration_config` to be true, and there is no backend endpoint to create a registration config for an existing project.
 
-Similarly, if an organiser decides to disable registration for an event that already has a config, there is no way to do so without deleting the config entirely (which is not possible through the UI either).
+Similarly, if an organiser decides to disable registration for an event that already has a config, there is no way to do so (event registration can only be closed).
 
 **Core Requirements (from #2001):**
 
@@ -34,7 +34,6 @@ Similarly, if an organiser decides to disable registration for an event that alr
 ### Non-Functional Requirements
 
 - **No breaking changes**: existing API contracts are preserved. New endpoints are additive.
-- **Toggle gate**: all new frontend UI is gated behind `isEnabled("EVENT_REGISTRATION")`.
 - **Preservation**: disabling registration does NOT delete the config or any custom fields. Re-enabling restores the previous state.
 - **One-way draft transition**: the existing `is_draft` one-way transition (draft → published) is preserved. Disabling registration is a separate concept from draft/published state.
 
@@ -54,7 +53,7 @@ Similarly, if an organiser decides to disable registration for an event that alr
 
 - **API approach — POST on the existing endpoint**: Extend `EditRegistrationConfigView` to handle POST (create) in addition to PATCH (update). When POST is called and no config exists, create a draft config with `registration_enabled=True`. When PATCH is called with `registration_enabled=False`, hide the config. This keeps the API surface minimal — one endpoint handles both create and update.
 
-- **Frontend approach — switch in edit form**: Add a `Switch` component in `EditProjectContent.tsx` (similar to the existing status toggle) that controls `registration_enabled`. When toggled ON, POST to create a draft config. When toggled OFF, PATCH to set `registration_enabled=False`. The switch replaces the current `showEditRegistrationButton` condition — the button is shown when the switch is ON.
+- **Frontend approach — switch in edit form**: Add a `Switch` component in `EditProjectContent.tsx` (similar to the existing status toggle) that controls `registration_enabled`. When toggled ON, POST to create a draft config. When toggled OFF, PATCH to set `registration_enabled=False`. The switch replaces the current `showEditRegistrationButton` condition — the button is shown when the switch is ON. No feature toggle check needed — the `EVENT_REGISTRATION` toggle is already active on production.
 
 - **Interaction with existing draft warning**: The existing warning ("Registration configuration is not yet complete") in `EditProjectContent.tsx` is shown when `project.registration_config?.is_draft` is true. This continues to work — when the user toggles ON and creates a draft config, the warning appears automatically.
 
@@ -204,17 +203,20 @@ def get_registration_config(self, obj):
 
 In `EditProjectContent.tsx`, add a registration toggle switch:
 
-1. **Switch component**: A `Switch` with label "Online registration" (similar to the existing create flow `EventRegistrationStep.tsx`).
-2. **Initial state**: `!!project.registration_config && project.registration_config.registration_enabled !== false`.
-3. **Toggle ON**:
+1. **Placement**: In the same row as the "Edit registration settings" button, below the project type toggle. Only visible when `project.project_type?.type_id === "event"`.
+2. **Switch component**: A `Switch` with label "Online registration" (similar to the existing create flow `EventRegistrationStep.tsx`).
+3. **Layout**: Switch and button in a horizontal row — switch on the left, "Edit registration settings" button on the right (when switch is ON).
+4. **Initial state**: `!!project.registration_config && project.registration_config.registration_enabled !== false`.
+5. **Toggle ON**:
    - If `project.registration_config` exists but `registration_enabled === false`, PATCH `{registration_enabled: true}`.
    - If `project.registration_config` does not exist, POST to create a new draft config.
    - On success, update `project.registration_config` in local state.
-4. **Toggle OFF**:
+6. **Toggle OFF**:
+   - If there are active registrations for this event, show a confirmation dialog warning the organiser that registration will be hidden but existing registrations are preserved.
    - PATCH `{registration_enabled: false}`.
    - On success, set `project.registration_config` to `null` in local state (or set `registration_enabled: false`).
-5. **When switch is ON**: Show the "Edit registration settings" button and the draft warning (if applicable).
-6. **When switch is OFF**: Hide the button and warning.
+7. **When switch is ON**: Show the "Edit registration settings" button and the draft warning (if applicable).
+8. **When switch is OFF**: Hide the button and warning.
 
 ### Frontend — Registration Config Modal (no changes)
 
@@ -321,7 +323,7 @@ The `EditEventRegistrationModal` does not need changes. It already handles draft
 
 ## Dependency Notes
 
-- **Depends on**: `is_draft` on `EventRegistrationConfig` (already implemented). `EditEventRegistrationModal` (already built). `EVENT_REGISTRATION` toggle (already exists).
+- **Depends on**: `is_draft` on `EventRegistrationConfig` (already implemented). `EditEventRegistrationModal` (already built).
 - **Enables**: Organisers can add registration to events after creation. This is the natural next step after the `is_draft` feature.
 - **Migration**: minor — one field addition with `default=True`.
 
@@ -331,6 +333,8 @@ The `EditEventRegistrationModal` does not need changes. It already handles draft
 
 - 2026-06-02 07:55 — Spec created. Initial draft.
 - 2026-06-02 08:03 — Added `registration_enabled=True` to create project flow (`CreateProjectView.post()`).
+- 2026-06-02 08:31 — Decisions finalized: switch placement (same row as button, below project type toggle), re-enable preserves config, confirmation dialog on disable with active registrations, REST endpoint (POST+PATCH on same URL).
+- 2026-06-02 08:45 — Removed feature toggle references — `EVENT_REGISTRATION` is already active on production.
 
 ---
 
@@ -354,12 +358,12 @@ The `EditEventRegistrationModal` does not need changes. It already handles draft
 
 ## Notes and Open Questions
 
-1. **Switch vs checkbox**: The create flow uses a `Switch` component for the registration toggle. The edit form should use the same component for consistency.
+1. **Switch placement**: The switch is in the same row as the "Edit registration settings" button, below the project type toggle. Only visible for event project types. This groups the registration controls together.
 
-2. **Switch placement in edit form**: The switch should be placed near the "Edit registration settings" button — either above it (as a group) or in the same section. The button appears only when the switch is ON.
+2. **Re-enable preserves config**: When the user toggles ON and a disabled config exists, the existing config is re-enabled (not replaced). This supports the primary use case: adding registration after event creation, and the corner case of temporarily disabling and re-enabling.
 
-3. **Confirmation dialog on disable**: Should we show a confirmation dialog when the user toggles OFF? The config is preserved, so no data is lost. But the user might not realize that registration will be hidden from visitors. Recommend: no confirmation dialog for this iteration — the switch is easily reversible.
+3. **Confirmation dialog on disable**: Show a confirmation dialog when the user toggles OFF and there are active registrations. The dialog warns that registration will be hidden but existing registrations are preserved. No dialog when there are no registrations.
 
-4. **Impact on active registrations**: If the user disables registration while guests are already registered, the registrations are preserved. The registrations tab will no longer be visible (since the config is filtered out), but the data is still in the database. If the user re-enables registration, the registrations become visible again. This is acceptable behavior.
+4. **Status preserved on disable/re-enable**: When a config is disabled, its `status` (open/closed/full) is preserved. When re-enabled, it returns to its previous status. This is intentional — the organiser might want to re-enable with the same status.
 
-5. **Status preserved on disable/re-enable**: When a config is disabled, its `status` (open/closed/full) is preserved. When re-enabled, it returns to its previous status. This is intentional — the organiser might want to re-enable with the same status.
+5. **REST endpoint**: `POST /api/projects/{slug}/registration-config/` creates, `PATCH /api/projects/{slug}/registration-config/` updates. Same URL, different methods. Standard REST pattern.

--- a/doc/spec/20260602_0755_add_registration_to_existing_event.md
+++ b/doc/spec/20260602_0755_add_registration_to_existing_event.md
@@ -1,0 +1,365 @@
+# Allow the User to Turn Event Registration On/Off When Editing an Event
+
+**Status**: DRAFT
+**Type**: Feature
+**Date and time created**: 2026-06-02 07:55
+**GitHub Issue**: [#2001](https://github.com/climateconnect/climateconnect/issues/2001)
+**Epic**: [`EPIC_event_registration.md`](./EPIC_event_registration.md)
+**Related Specs**:
+- [`20260528_1454_validate_registration_config_on_publish.md`](./20260528_1454_validate_registration_config_on_publish.md) ← introduced `is_draft` on `EventRegistrationConfig`, which is a prerequisite for this feature
+
+---
+
+## Problem Statement
+
+Currently, registration configuration can only be added during event creation. If an organiser creates an event without enabling registration, there is **no way to add it later** — the `showEditRegistrationButton` in `EditProjectContent.tsx` requires `!!project.registration_config` to be true, and there is no backend endpoint to create a registration config for an existing project.
+
+Similarly, if an organiser decides to disable registration for an event that already has a config, there is no way to do so without deleting the config entirely (which is not possible through the UI either).
+
+**Core Requirements (from #2001):**
+
+1. On the edit page of a project of type event, add a switch to enable or disable online event registration.
+2. When the switch is turned ON, show the button to edit the registration configuration.
+3. When the event has a registration configuration, show the switch as ON.
+4. When the switch is changed from ON to OFF, hide all event registration features for the event, but **keep the registration configuration** in case the user turns it ON again.
+5. When the user turns registration ON for an existing published event, they start with a **draft** registration configuration that can be published when ready.
+
+**Explicitly Out of Scope:**
+
+- Deleting a registration config through the UI (the config is preserved when disabled).
+- Changing the create project flow (`ShareProjectRoot`) — it already handles registration enable/disable.
+- Changing the project detail page or registrations tab behavior (they already handle draft/disabled configs).
+- Changing the registration config modal — it already handles draft/published states.
+
+### Non-Functional Requirements
+
+- **No breaking changes**: existing API contracts are preserved. New endpoints are additive.
+- **Toggle gate**: all new frontend UI is gated behind `isEnabled("EVENT_REGISTRATION")`.
+- **Preservation**: disabling registration does NOT delete the config or any custom fields. Re-enabling restores the previous state.
+- **One-way draft transition**: the existing `is_draft` one-way transition (draft → published) is preserved. Disabling registration is a separate concept from draft/published state.
+
+### AI Agent Insights and Additions
+
+- **Current gap**: `showEditRegistrationButton` in `EditProjectContent.tsx` (line 152) requires `!!project.registration_config`. If no config exists, the button is never shown. There is no "Add registration" button or flow.
+
+- **Current gap**: `EditRegistrationConfigView` (`event_registration_views.py`, line 560) returns 404 if no config exists. There is no POST handler to create a config.
+
+- **Design choice — `registration_enabled` field**: The issue requires hiding registration features while preserving the config. Since `is_draft` is a one-way transition (draft → published), we cannot use it to "unpublish" a config. A separate `registration_enabled` boolean on `EventRegistrationConfig` is the cleanest solution. It is orthogonal to `is_draft`:
+  - `is_draft` = config completeness (setup state): incomplete → complete
+  - `registration_enabled` = feature active state: on → off → on (reversible)
+  - When `registration_enabled=False`: config is hidden from everyone (visitors AND admins). Registration features are disabled.
+  - When `registration_enabled=True`: config is visible (subject to `is_draft` and admin permissions as before).
+
+- **When to create the config**: The config should be created **when the user toggles the switch ON** in the edit form. This is the natural point — the user has expressed intent to enable registration. The config starts as `is_draft=True` and `registration_enabled=True`. The user can then configure it via the modal and publish when ready. This mirrors the create flow where the toggle in step 3 enables the registration section in step 4.
+
+- **API approach — POST on the existing endpoint**: Extend `EditRegistrationConfigView` to handle POST (create) in addition to PATCH (update). When POST is called and no config exists, create a draft config with `registration_enabled=True`. When PATCH is called with `registration_enabled=False`, hide the config. This keeps the API surface minimal — one endpoint handles both create and update.
+
+- **Frontend approach — switch in edit form**: Add a `Switch` component in `EditProjectContent.tsx` (similar to the existing status toggle) that controls `registration_enabled`. When toggled ON, POST to create a draft config. When toggled OFF, PATCH to set `registration_enabled=False`. The switch replaces the current `showEditRegistrationButton` condition — the button is shown when the switch is ON.
+
+- **Interaction with existing draft warning**: The existing warning ("Registration configuration is not yet complete") in `EditProjectContent.tsx` is shown when `project.registration_config?.is_draft` is true. This continues to work — when the user toggles ON and creates a draft config, the warning appears automatically.
+
+- **Interaction with project detail page**: The project detail page already handles draft configs (hidden from visitors, setup prompt for admins). When `registration_enabled=False`, the config is hidden from everyone. No changes needed to `ProjectPageRoot.tsx` or `ProjectContentSideButtons.tsx` — they already check for `registration_config` existence.
+
+- **Serializer filtering**: `ProjectSerializer.get_registration_config()` and `ProjectStubSerializer.get_registration_config()` already filter draft configs for non-admins. They must also filter configs where `registration_enabled=False` for everyone (including admins — the config is "disabled", not just "draft").
+
+---
+
+## System Impact
+
+### Actors
+- **Event organiser**: toggles registration on/off for an existing event.
+- **Event visitor/member**: sees registration UI only when the config exists, is enabled, and is published.
+- **Backend API**: creates, enables, and disables registration configs.
+
+### Entities Changed
+- `EventRegistrationConfig`: gains `registration_enabled` BooleanField.
+- No new entities.
+
+### Flows Changed
+- **Edit project → Toggle registration ON**: creates a draft config.
+- **Edit project → Toggle registration OFF**: disables the config (preserved in DB).
+- **Edit project → Toggle registration ON (again)**: re-enables the existing config.
+
+### Integration Changes
+- `POST /api/projects/{slug}/registration-config/`: new endpoint to create a draft config.
+- `PATCH /api/projects/{slug}/registration-config/`: accepts `registration_enabled` in request body.
+- Project serializers filter `registration_enabled=False` configs from all responses.
+
+---
+
+## Software Architecture
+
+### Data Model
+
+Add `registration_enabled` to `EventRegistrationConfig`:
+
+```python
+registration_enabled = models.BooleanField(
+    default=True,
+    help_text=(
+        "When False, registration features are hidden for this event. "
+        "The config is preserved and can be re-enabled later. "
+        "Unlike is_draft, this field is reversible."
+    ),
+    verbose_name="Registration Enabled",
+)
+```
+
+**Migration**:
+1. Schema migration: add `registration_enabled` with `default=True`.
+2. No data migration needed — existing configs are already enabled (default=True).
+
+### Backend — Create Project Flow
+
+`CreateProjectView.post()` must pass `registration_enabled=True` when creating a config:
+
+```python
+er_serializer.save(project=project, is_draft=is_draft, registration_enabled=True)
+```
+
+This ensures configs created via the share project flow are enabled by default.
+
+### API — POST to Create Registration Config
+
+`POST /api/projects/{slug}/registration-config/`:
+
+**Request** (empty body — all defaults):
+```json
+{}
+```
+
+**Behavior**:
+1. Verify the user is a project admin.
+2. Verify the project is an event type.
+3. If a config already exists and `registration_enabled=False`, re-enable it (`registration_enabled=True`) and return the existing config.
+4. If a config already exists and `registration_enabled=True`, return 409 (already exists).
+5. Create a new `EventRegistrationConfig` with `is_draft=True`, `registration_enabled=True`, `status="open"`.
+6. Return 201 with the serialized config.
+
+**Response** (201):
+```json
+{
+  "max_participants": null,
+  "registration_end_date": null,
+  "status": "open",
+  "is_draft": true,
+  "registration_enabled": true,
+  "notify_admins": true,
+  "fields": []
+}
+```
+
+### API — PATCH to Disable Registration Config
+
+`PATCH /api/projects/{slug}/registration-config/`:
+
+**Request** to disable:
+```json
+{
+  "registration_enabled": false
+}
+```
+
+**Behavior**:
+1. Set `registration_enabled=False` on the config.
+2. Return 200 with the updated config.
+
+**Request** to re-enable:
+```json
+{
+  "registration_enabled": true
+}
+```
+
+**Behavior**:
+1. Set `registration_enabled=True` on the config.
+2. Return 200 with the updated config.
+
+**Validation**: `registration_enabled` is a simple boolean toggle. No other fields are validated when toggling. The existing validation logic is skipped when only `registration_enabled` is in the request body.
+
+### API Response Filtering
+
+`ProjectSerializer.get_registration_config()` and `ProjectStubSerializer.get_registration_config()` must filter configs where `registration_enabled=False` for **all** viewers (including admins):
+
+```python
+def get_registration_config(self, obj):
+    try:
+        rc = obj.registration_config
+    except EventRegistrationConfig.DoesNotExist:
+        return None
+
+    # Disabled configs are hidden from everyone.
+    if not rc.registration_enabled:
+        return None
+
+    # Draft configs are only visible to project admins.
+    if rc.is_draft:
+        # ... existing admin check ...
+        pass
+
+    return EventRegistrationConfigSerializer(rc, ...).data
+```
+
+### Frontend — Edit Project Form Switch
+
+In `EditProjectContent.tsx`, add a registration toggle switch:
+
+1. **Switch component**: A `Switch` with label "Online registration" (similar to the existing create flow `EventRegistrationStep.tsx`).
+2. **Initial state**: `!!project.registration_config && project.registration_config.registration_enabled !== false`.
+3. **Toggle ON**:
+   - If `project.registration_config` exists but `registration_enabled === false`, PATCH `{registration_enabled: true}`.
+   - If `project.registration_config` does not exist, POST to create a new draft config.
+   - On success, update `project.registration_config` in local state.
+4. **Toggle OFF**:
+   - PATCH `{registration_enabled: false}`.
+   - On success, set `project.registration_config` to `null` in local state (or set `registration_enabled: false`).
+5. **When switch is ON**: Show the "Edit registration settings" button and the draft warning (if applicable).
+6. **When switch is OFF**: Hide the button and warning.
+
+### Frontend — Registration Config Modal (no changes)
+
+The `EditEventRegistrationModal` does not need changes. It already handles draft/published states and receives `eventRegistration` as a prop. When the user toggles ON and creates a draft config, the modal works as before.
+
+### Frontend — Project Detail Page (no changes)
+
+`ProjectPageRoot.tsx` and `ProjectContentSideButtons.tsx` already handle the case where `registration_config` is null (no registration features shown). The serializer filtering ensures disabled configs are never returned.
+
+---
+
+## Acceptance Criteria
+
+### Model & Migration
+- [ ] `EventRegistrationConfig` has a `registration_enabled` BooleanField with `default=True`.
+- [ ] No data migration needed (existing configs default to enabled).
+
+### Backend — Create Config
+
+- [ ] `POST /api/projects/{slug}/registration-config/` creates a draft config for the event.
+- [ ] Only project admins can create a config.
+- [ ] Returns 409 if a config already exists and is enabled.
+- [ ] Re-enables an existing disabled config if one exists.
+- [ ] Returns 201 with the serialized config.
+- [ ] `CreateProjectView.post()` sets `registration_enabled=True` when creating a config via the share project flow.
+
+### Backend — Disable/Enable Config
+- [ ] `PATCH /registration-config/` accepts `registration_enabled: false` to disable.
+- [ ] `PATCH /registration-config/` accepts `registration_enabled: true` to re-enable.
+- [ ] Disabling does not delete the config or custom fields.
+- [ ] Re-enabling restores the config to its previous state (draft or published).
+
+### Backend — API Response Filtering
+- [ ] Disabled configs (`registration_enabled=False`) are excluded from all project API responses (detail and list).
+- [ ] This applies to all viewers, including admins.
+
+### Frontend — Edit Project Form
+- [ ] A toggle switch for "Online registration" is shown on the edit form for event projects.
+- [ ] When the event has an enabled registration config, the switch is ON.
+- [ ] When the event has no config or a disabled config, the switch is OFF.
+- [ ] Toggling ON creates/enables the config and shows the "Edit registration settings" button.
+- [ ] Toggling OFF disables the config and hides the button.
+- [ ] The draft warning is shown when the config is draft (existing behavior).
+
+### Frontend — Project Detail Page
+- [ ] No changes needed — disabled configs are filtered out by the serializer.
+
+---
+
+## Test Cases
+
+### Backend Tests
+
+| Scenario | Expected |
+|----------|----------|
+| POST to create config for event without config | 201, config created with `is_draft=True`, `registration_enabled=True` |
+| POST when config already exists and enabled | 409 |
+| POST when config exists but disabled | 200, config re-enabled (`registration_enabled=True`) |
+| POST by non-admin | 403 |
+| POST for non-event project | 400 |
+| PATCH to disable enabled config | 200, `registration_enabled=False` |
+| PATCH to re-enable disabled config | 200, `registration_enabled=True` |
+| Disabled config excluded from project detail response | `registration_config: null` |
+| Disabled config excluded from project list response | `registration_config: null` |
+| Disabled config with custom fields preserved | Fields still in DB after re-enable |
+| PATCH to disable published config | 200, config disabled (status preserved) |
+
+### Frontend Tests
+
+| Scenario | Expected |
+|----------|----------|
+| Edit form shows switch ON for event with enabled config | Switch checked |
+| Edit form shows switch OFF for event without config | Switch unchecked |
+| Toggle ON creates draft config, shows button | Config created, button visible |
+| Toggle OFF disables config, hides button | Config disabled, button hidden |
+| Toggle ON (re-enable) shows existing config | Previous config restored |
+| Draft warning shown when config is draft | Warning visible below button |
+
+---
+
+## Files to Change
+
+### Backend
+
+| File | Change |
+|------|--------|
+| `backend/organization/models/event_registration.py` | Add `registration_enabled` BooleanField to `EventRegistrationConfig` |
+| `backend/organization/migrations/` | New migration: add `registration_enabled` field |
+| `backend/organization/views/event_registration_views.py` | Add POST handler to `EditRegistrationConfigView` (create config). Add `registration_enabled` toggle handling in PATCH. |
+| `backend/organization/views/project_views.py` | `CreateProjectView.post()`: pass `registration_enabled=True` when creating config via share project flow. |
+| `backend/organization/serializers/project.py` | `ProjectSerializer.get_registration_config()` and `ProjectStubSerializer.get_registration_config()`: filter `registration_enabled=False` configs |
+| `backend/organization/tests/` | Add test cases for create, disable, re-enable, and API filtering |
+
+### Frontend
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/editProject/EditProjectContent.tsx` | Add registration toggle switch. Handle create/enable/disable via API. Show/hide button based on switch state. |
+| `frontend/src/components/editProject/EditProjectRoot.tsx` | Pass updated registration config state to EditProjectContent |
+| `frontend/src/types.ts` | Add `registration_enabled` to `EventRegistrationData` |
+| `frontend/public/texts/project_texts.tsx` | Add localized text for the toggle switch |
+
+---
+
+## Dependency Notes
+
+- **Depends on**: `is_draft` on `EventRegistrationConfig` (already implemented). `EditEventRegistrationModal` (already built). `EVENT_REGISTRATION` toggle (already exists).
+- **Enables**: Organisers can add registration to events after creation. This is the natural next step after the `is_draft` feature.
+- **Migration**: minor — one field addition with `default=True`.
+
+---
+
+## Log
+
+- 2026-06-02 07:55 — Spec created. Initial draft.
+- 2026-06-02 08:03 — Added `registration_enabled=True` to create project flow (`CreateProjectView.post()`).
+
+---
+
+## Design Decisions (Resolved)
+
+1. **`registration_enabled` boolean (not delete)**: Disabling registration does NOT delete the config. The config is preserved in the database and can be re-enabled later. This matches the issue requirement: "keep the event registration configuration in case the user turns it on again."
+
+2. **Separate from `is_draft`**: `registration_enabled` is orthogonal to `is_draft`. `is_draft` tracks config completeness (one-way: draft → published). `registration_enabled` tracks feature active state (reversible: on → off → on). A config can be in any combination of these states.
+
+3. **Create on toggle ON**: The config is created when the user toggles the switch ON in the edit form. This is the natural point of intent. The config starts as `is_draft=True` and `registration_enabled=True`.
+
+4. **Re-enable on toggle ON (when disabled config exists)**: If the user toggles ON and a disabled config already exists, we re-enable it rather than creating a new one. This preserves the existing configuration.
+
+5. **POST on existing endpoint**: The `EditRegistrationConfigView` is extended to handle POST (create) in addition to PATCH (update). This keeps the API surface minimal.
+
+6. **Disabled configs hidden from everyone**: When `registration_enabled=False`, the config is excluded from all API responses, including admin views. The switch in the edit form is the only way to see that registration exists but is disabled.
+
+7. **Serializer filtering**: `ProjectSerializer.get_registration_config()` and `ProjectStubSerializer.get_registration_config()` filter `registration_enabled=False` configs. This ensures disabled configs are never exposed to any frontend component.
+
+---
+
+## Notes and Open Questions
+
+1. **Switch vs checkbox**: The create flow uses a `Switch` component for the registration toggle. The edit form should use the same component for consistency.
+
+2. **Switch placement in edit form**: The switch should be placed near the "Edit registration settings" button — either above it (as a group) or in the same section. The button appears only when the switch is ON.
+
+3. **Confirmation dialog on disable**: Should we show a confirmation dialog when the user toggles OFF? The config is preserved, so no data is lost. But the user might not realize that registration will be hidden from visitors. Recommend: no confirmation dialog for this iteration — the switch is easily reversible.
+
+4. **Impact on active registrations**: If the user disables registration while guests are already registered, the registrations are preserved. The registrations tab will no longer be visible (since the config is filtered out), but the data is still in the database. If the user re-enables registration, the registrations become visible again. This is acceptable behavior.
+
+5. **Status preserved on disable/re-enable**: When a config is disabled, its `status` (open/closed/full) is preserved. When re-enabled, it returns to its previous status. This is intentional — the organiser might want to re-enable with the same status.

--- a/doc/spec/EPIC_event_registration.md
+++ b/doc/spec/EPIC_event_registration.md
@@ -157,6 +157,14 @@ When a guest registers for an event with custom fields, include the provided ans
 |-------|-------------|------|--------|
 | Include field answers in registration confirmation email | [#2023](https://github.com/climateconnect/climateconnect/issues/2023) | [`20260601_1031_include_field_answers_in_registration_email.md`](./20260601_1031_include_field_answers_in_registration_email.md) | ⚪ |
 
+#### Phase 4w — Add Registration to Existing Event (cross-cutting)
+
+Organisers can enable or disable online registration for an existing event at any time. When enabled, a draft registration configuration is created that can be published when ready. When disabled, the configuration is preserved but hidden.
+
+| Story | GitHub Issue | Spec | Status |
+|-------|-------------|------|--------|
+| Allow the user to turn event registration on/off when editing an event | [#2001](https://github.com/climateconnect/climateconnect/issues/2001) | [`20260602_0755_add_registration_to_existing_event.md`](./20260602_0755_add_registration_to_existing_event.md) | ⚪ |
+
 #### Phase 4c+ — Further Field Types (TBD)
 
 Additional field types (e.g. free text, number, date) to be defined based on user feedback after Phase 4a ships.

--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -1259,9 +1259,9 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
     },
     disable_registration_confirm: {
       en:
-        "There are already registrations for this event. Disabling registration will hide the registration form from visitors, but existing registrations will be preserved. Do you want to continue?",
+        "There are already registrations for this event. Disabling registration will hide the registration form from visitors and you won't be able to see the registrations. Alternatively you can also close the registration via the registration settings. Do you want to continue?",
       de:
-        "Es gibt bereits Anmeldungen für dieses Event. Das Deaktivieren der Anmeldung blendet das Anmeldeformular für Besucher aus, aber bestehende Anmeldungen bleiben erhalten. Möchtest du fortfahren?",
+        "Es gibt bereits Anmeldungen für dieses Event. Das Deaktivieren der Anmeldung blendet das Anmeldeformular für Besucher aus und du wirst nicht mehr sehen können, welche Anmeldungen es gibt. Alternativ kannst du auch die Anmeldung via den Anmeldeeinstellungen schließen. Möchtest du fortfahren?",
     },
     disable_registration: {
       en: "Disable registration",

--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -1253,6 +1253,20 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       en: "Edit registration settings",
       de: "Anmeldeeinstellungen bearbeiten",
     },
+    online_registration: {
+      en: "Online registration",
+      de: "Online-Anmeldung",
+    },
+    disable_registration_confirm: {
+      en:
+        "There are already registrations for this event. Disabling registration will hide the registration form from visitors, but existing registrations will be preserved. Do you want to continue?",
+      de:
+        "Es gibt bereits Anmeldungen für dieses Event. Das Deaktivieren der Anmeldung blendet das Anmeldeformular für Besucher aus, aber bestehende Anmeldungen bleiben erhalten. Möchtest du fortfahren?",
+    },
+    disable_registration: {
+      en: "Disable registration",
+      de: "Anmeldung deaktivieren",
+    },
     registration_settings_saved: {
       en: "Registration settings saved successfully",
       de: "Anmeldeeinstellungen erfolgreich gespeichert",

--- a/frontend/src/components/editProject/EditProjectContent.tsx
+++ b/frontend/src/components/editProject/EditProjectContent.tsx
@@ -96,6 +96,7 @@ type Args = {
   errors: any;
   contentRef?: RefObject<any>;
   projectTypeOptions?: any;
+  savedIsEventType: boolean;
 };
 
 export default function EditProjectContent({
@@ -106,6 +107,7 @@ export default function EditProjectContent({
   errors,
   contentRef,
   projectTypeOptions,
+  savedIsEventType,
 }: Args) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
@@ -157,7 +159,6 @@ export default function EditProjectContent({
   const handleRegistrationSaved = (updated) => {
     handleSetProject({ ...project, registration_config: updated });
   };
-
   const isEventType = project.project_type?.type_id === "event";
   const hasRegistrationConfig = !!project.registration_config;
   const registrationEnabled =
@@ -165,6 +166,7 @@ export default function EditProjectContent({
   const isPastEvent = project.end_date ? new Date(project.end_date) < new Date() : false;
   const showEditRegistrationButton =
     user_role.role_type === ROLE_TYPES.all_type && isEventType && registrationEnabled;
+  const canToggleRegistration = isEventType && savedIsEventType;
 
   const [registrationToggleLoading, setRegistrationToggleLoading] = useState(false);
   const [confirmDisableOpen, setConfirmDisableOpen] = useState(false);
@@ -234,42 +236,6 @@ export default function EditProjectContent({
           />
           <Typography component="span">{projectTypeTexts.organizations[typeId]}</Typography>
         </div>
-        {isEventType && user_role.role_type === ROLE_TYPES.all_type && (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
-            <Switch
-              checked={registrationEnabled}
-              onChange={(e) => handleRegistrationToggle(e.target.checked)}
-              disabled={registrationToggleLoading || (isPastEvent && !hasRegistrationConfig)}
-              inputProps={{ "aria-label": texts.online_registration }}
-            />
-            <Typography component="span">{texts.online_registration}</Typography>
-            {showEditRegistrationButton && (
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "flex-start",
-                  ml: "auto",
-                }}
-              >
-                <Button
-                  variant="outlined"
-                  color="primary"
-                  startIcon={<SettingsIcon />}
-                  onClick={() => setEditRegistrationOpen(true)}
-                  aria-label={texts.edit_registration_settings}
-                >
-                  {texts.edit_registration_settings}
-                </Button>
-                {project.registration_config?.is_draft && (
-                  <Typography variant="body2" color="warning.main" sx={{ mt: 0.5 }}>
-                    {texts.registration_config_still_draft_warning}
-                  </Typography>
-                )}
-              </Box>
-            )}
-          </Box>
-        )}
         <div className={classes.block}>
           {project.is_personal_project ? (
             <>
@@ -313,6 +279,42 @@ export default function EditProjectContent({
             onChangeProjectType={handleChangeProjectType}
           />
         </div>
+        {canToggleRegistration && user_role.role_type === ROLE_TYPES.all_type && (
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+            <Switch
+              checked={registrationEnabled}
+              onChange={(e) => handleRegistrationToggle(e.target.checked)}
+              disabled={registrationToggleLoading || (isPastEvent && !hasRegistrationConfig)}
+              inputProps={{ "aria-label": texts.online_registration }}
+            />
+            <Typography component="span">{texts.allow_online_registration}</Typography>
+            {showEditRegistrationButton && (
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "flex-start",
+                  ml: "auto",
+                }}
+              >
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  startIcon={<SettingsIcon />}
+                  onClick={() => setEditRegistrationOpen(true)}
+                  aria-label={texts.edit_registration_settings}
+                >
+                  {texts.edit_registration_settings}
+                </Button>
+                {project.registration_config?.is_draft && (
+                  <Typography variant="body2" color="warning.main" sx={{ mt: 0.5 }}>
+                    {texts.registration_config_still_draft_warning}
+                  </Typography>
+                )}
+              </Box>
+            )}
+          </Box>
+        )}
         <div className={classes.block}>
           <ProjectDateSection
             projectData={project}

--- a/frontend/src/components/editProject/EditProjectContent.tsx
+++ b/frontend/src/components/editProject/EditProjectContent.tsx
@@ -1,7 +1,21 @@
-import { Box, Button, Switch, TextField, Typography, useMediaQuery, Theme } from "@mui/material";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Switch,
+  TextField,
+  Typography,
+  useMediaQuery,
+  Theme,
+} from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import React, { RefObject, useContext, useState } from "react";
 import getProjectTypeTexts from "../../../public/data/projectTypeTexts";
+import { apiRequest } from "../../../public/lib/apiOperations";
+import Cookies from "universal-cookie";
 import ROLE_TYPES from "../../../public/data/role_types";
 import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
@@ -12,7 +26,6 @@ import { Project, Role } from "../../types";
 import { EditProjectTypeSelector } from "./EditProjectTypeSelector";
 import ProjectDateSection from "../shareProject/ProjectDateSection";
 import SettingsIcon from "@mui/icons-material/Settings";
-import { useFeatureToggles } from "../featureToggle";
 import EditEventRegistrationModal from "../project/EditEventRegistrationModal";
 
 const useStyles = makeStyles<Theme>((theme) => ({
@@ -100,7 +113,6 @@ export default function EditProjectContent({
   const projectTypeTexts = getProjectTypeTexts(texts);
   const typeId = project.project_type?.type_id ?? "project";
   const isNarrowScreen = useMediaQuery<Theme>((theme) => theme.breakpoints.down("sm"));
-  const { isEnabled } = useFeatureToggles();
   const [editRegistrationOpen, setEditRegistrationOpen] = useState(false);
 
   const handleChangeProject = (newValue, key) => {
@@ -146,11 +158,65 @@ export default function EditProjectContent({
     handleSetProject({ ...project, registration_config: updated });
   };
 
+  const isEventType = project.project_type?.type_id === "event";
+  const hasRegistrationConfig = !!project.registration_config;
+  const registrationEnabled =
+    hasRegistrationConfig && project.registration_config?.registration_enabled !== false;
+  const isPastEvent = project.end_date ? new Date(project.end_date) < new Date() : false;
   const showEditRegistrationButton =
-    user_role.role_type === ROLE_TYPES.all_type &&
-    project.project_type?.type_id === "event" &&
-    isEnabled("EVENT_REGISTRATION") &&
-    !!project.registration_config;
+    user_role.role_type === ROLE_TYPES.all_type && isEventType && registrationEnabled;
+
+  const [registrationToggleLoading, setRegistrationToggleLoading] = useState(false);
+  const [confirmDisableOpen, setConfirmDisableOpen] = useState(false);
+  const token = new Cookies().get("auth_token");
+
+  const handleRegistrationToggle = async (checked: boolean) => {
+    if (checked) {
+      setRegistrationToggleLoading(true);
+      try {
+        const resp = await apiRequest({
+          method: "post",
+          url: `/api/projects/${project.url_slug}/registration-config/`,
+          payload: {},
+          token,
+        });
+        handleSetProject({ ...project, registration_config: resp.data });
+      } catch (error) {
+        console.error("Failed to enable registration:", error);
+      } finally {
+        setRegistrationToggleLoading(false);
+      }
+    } else {
+      const rc = project.registration_config;
+      const hasActiveRegistrations =
+        rc?.max_participants != null &&
+        rc?.available_seats != null &&
+        rc.available_seats < rc.max_participants;
+      if (hasActiveRegistrations) {
+        setConfirmDisableOpen(true);
+      } else {
+        await doDisableRegistration();
+      }
+    }
+  };
+
+  const doDisableRegistration = async () => {
+    setConfirmDisableOpen(false);
+    setRegistrationToggleLoading(true);
+    try {
+      await apiRequest({
+        method: "patch",
+        url: `/api/projects/${project.url_slug}/registration-config/`,
+        payload: { registration_enabled: false },
+        token,
+      });
+      handleSetProject({ ...project, registration_config: null });
+    } catch (error) {
+      console.error("Failed to disable registration:", error);
+    } finally {
+      setRegistrationToggleLoading(false);
+    }
+  };
 
   return (
     <div ref={contentRef}>
@@ -168,21 +234,39 @@ export default function EditProjectContent({
           />
           <Typography component="span">{projectTypeTexts.organizations[typeId]}</Typography>
         </div>
-        {showEditRegistrationButton && (
-          <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end", mb: 1 }}>
-            <Button
-              variant="outlined"
-              color="primary"
-              startIcon={<SettingsIcon />}
-              onClick={() => setEditRegistrationOpen(true)}
-              aria-label={texts.edit_registration_settings}
-            >
-              {texts.edit_registration_settings}
-            </Button>
-            {project.registration_config?.is_draft && (
-              <Typography variant="body2" color="warning.main" sx={{ mt: 0.5 }}>
-                {texts.registration_config_still_draft_warning}
-              </Typography>
+        {isEventType && user_role.role_type === ROLE_TYPES.all_type && (
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+            <Switch
+              checked={registrationEnabled}
+              onChange={(e) => handleRegistrationToggle(e.target.checked)}
+              disabled={registrationToggleLoading || (isPastEvent && !hasRegistrationConfig)}
+              inputProps={{ "aria-label": texts.online_registration }}
+            />
+            <Typography component="span">{texts.online_registration}</Typography>
+            {showEditRegistrationButton && (
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "flex-start",
+                  ml: "auto",
+                }}
+              >
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  startIcon={<SettingsIcon />}
+                  onClick={() => setEditRegistrationOpen(true)}
+                  aria-label={texts.edit_registration_settings}
+                >
+                  {texts.edit_registration_settings}
+                </Button>
+                {project.registration_config?.is_draft && (
+                  <Typography variant="body2" color="warning.main" sx={{ mt: 0.5 }}>
+                    {texts.registration_config_still_draft_warning}
+                  </Typography>
+                )}
+              </Box>
             )}
           </Box>
         )}
@@ -263,6 +347,18 @@ export default function EditProjectContent({
           eventRegistration={project.registration_config}
         />
       )}
+      <Dialog open={confirmDisableOpen} onClose={() => setConfirmDisableOpen(false)}>
+        <DialogTitle>{texts.online_registration}</DialogTitle>
+        <DialogContent>
+          <Typography>{texts.disable_registration_confirm}</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmDisableOpen(false)}>{texts.cancel}</Button>
+          <Button onClick={doDisableRegistration} color="error" variant="contained">
+            {texts.disable_registration}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/components/editProject/EditProjectRoot.tsx
+++ b/frontend/src/components/editProject/EditProjectRoot.tsx
@@ -158,6 +158,19 @@ export default function EditProjectRoot({
       }
     }
 
+    if (!isDraft && project.project_type?.type_id === "event" && project.registration_config) {
+      const rc = project.registration_config;
+      if (!rc.is_draft && rc.registration_end_date && project.end_date) {
+        if (new Date(rc.registration_end_date) > new Date(project.end_date)) {
+          setErrors({
+            ...errors,
+            end_date: texts.registration_end_date_must_be_before_event_end_date,
+          });
+          return false;
+        }
+      }
+    }
+
     return true;
   };
 
@@ -397,6 +410,7 @@ export default function EditProjectRoot({
             errors={errors}
             contentRef={contentRef}
             projectTypeOptions={projectTypeOptions}
+            savedIsEventType={oldProject?.project_type?.type_id === "event"}
           />
           <Divider className={classes.divider} />
           <NavigationButtons

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -38,6 +38,8 @@ export type EventRegistrationData = {
   notify_admins: boolean;
   /** When true, the registration configuration is incomplete and not visible to visitors. */
   is_draft: boolean;
+  /** When false, registration features are hidden. Config preserved for re-enable. */
+  registration_enabled: boolean;
   /** Custom registration fields configured by the organiser (Phase 4a). */
   fields?: RegistrationField[];
 };


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Implementation for #2001 
