### PR TITLE
Bug event registration confirmation email with time slot answer shows the time in utc

### DIFF
--- a/backend/organization/tests/test_email_field_answers.py
+++ b/backend/organization/tests/test_email_field_answers.py
@@ -13,7 +13,8 @@ Covers spec test cases:
   9. Register with mix of answered and unanswered optional fields → only answered shown
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 from django.contrib.auth.models import User
 from django.test import TestCase, tag
@@ -32,6 +33,8 @@ from organization.models.registration_field import (
 )
 from organization.models import Project, ProjectStatus
 from organization.utility.email import _build_field_answers_html
+
+_UTC = ZoneInfo("UTC")
 
 
 class TestBuildFieldAnswersHtml(TestCase):
@@ -117,7 +120,7 @@ class TestBuildFieldAnswersHtml(TestCase):
         )
         self._create_answer(field, value_boolean=True)
 
-        html = _build_field_answers_html(self.registration, "en")
+        html = _build_field_answers_html(self.registration, "en", _UTC)
         self.assertIn("✓", html)
         self.assertIn("I agree to the terms", html)
         self.assertNotIn("<p>", html)  # HTML stripped
@@ -135,7 +138,7 @@ class TestBuildFieldAnswersHtml(TestCase):
         )
         self._create_answer(field, value_boolean=False)
 
-        html = _build_field_answers_html(self.registration, "en")
+        html = _build_field_answers_html(self.registration, "en", _UTC)
         self.assertEqual(html, "")
 
     # ── Test 3: Option select → title + option title ─────────────────────────
@@ -152,7 +155,7 @@ class TestBuildFieldAnswersHtml(TestCase):
         option = self._create_option(field, "Solar panel installation", 0)
         self._create_answer(field, value_option=option)
 
-        html = _build_field_answers_html(self.registration, "en")
+        html = _build_field_answers_html(self.registration, "en", _UTC)
         self.assertIn("Preferred workshop", html)
         self.assertIn("Solar panel installation", html)
 
@@ -170,7 +173,7 @@ class TestBuildFieldAnswersHtml(TestCase):
         option = self._create_option(field, "Vegetarian", 0)
         self._create_answer(field, value_option=option, value_number=2)
 
-        html = _build_field_answers_html(self.registration, "en")
+        html = _build_field_answers_html(self.registration, "en", _UTC)
         self.assertIn("Meal preference", html)
         self.assertIn("Vegetarian × 2", html)
 
@@ -178,7 +181,7 @@ class TestBuildFieldAnswersHtml(TestCase):
 
     @tag("field_answers_email")
     def test_time_slot_included(self):
-        """Time slot shows field title and formatted time range."""
+        """Time slot shows field title and formatted time range with timezone."""
         field = self._create_field(
             RegistrationFieldType.TIME_SLOT_SELECT,
             0,
@@ -196,9 +199,64 @@ class TestBuildFieldAnswersHtml(TestCase):
         )
         self._create_answer(field, value_option=option)
 
-        html = _build_field_answers_html(self.registration, "en")
+        html = _build_field_answers_html(self.registration, "en", _UTC)
         self.assertIn("Pickup slot", html)
         self.assertIn("–", html)  # time range separator
+        self.assertIn("(UTC)", html)  # timezone abbreviation present
+
+    @tag("field_answers_email")
+    def test_time_slot_converts_to_resolved_timezone(self):
+        """Time slot times are converted from UTC to the supplied timezone."""
+        berlin_tz = ZoneInfo("Europe/Berlin")
+        field = self._create_field(
+            RegistrationFieldType.TIME_SLOT_SELECT,
+            0,
+            "Pickup",
+            {"title": "Pickup slot"},
+        )
+        # 2024-06-01 12:00 UTC = 14:00 CEST (Berlin summer time)
+        start = datetime(2024, 6, 1, 12, 0, tzinfo=_UTC)
+        end = start + timedelta(hours=2)
+        option = self._create_option(
+            field,
+            "",
+            0,
+            start_time=start,
+            end_time=end,
+        )
+        self._create_answer(field, value_option=option)
+
+        html = _build_field_answers_html(self.registration, "en", berlin_tz)
+        # The back-end should render 14:00–16:00 in CEST, not 12:00–14:00 UTC
+        self.assertIn("14:00", html)
+        self.assertIn("16:00", html)
+        self.assertIn("(CEST)", html)
+
+    @tag("field_answers_email")
+    def test_time_slot_german_locale_uses_de_tz_abbrev(self):
+        """German locale translates CET/CEST abbreviations."""
+        berlin_tz = ZoneInfo("Europe/Berlin")
+        field = self._create_field(
+            RegistrationFieldType.TIME_SLOT_SELECT,
+            0,
+            "Abholung",
+            {"title": "Abholzeit"},
+        )
+        start = datetime(2024, 6, 1, 12, 0, tzinfo=_UTC)
+        end = start + timedelta(hours=2)
+        option = self._create_option(
+            field,
+            "",
+            0,
+            start_time=start,
+            end_time=end,
+        )
+        self._create_answer(field, value_option=option)
+
+        html = _build_field_answers_html(self.registration, "de", berlin_tz)
+        self.assertIn("14:00", html)
+        self.assertIn("16:00", html)
+        self.assertIn("(MESZ)", html)
 
     # ── Test 6: Multiple fields → ordered by field.order ─────────────────────
 
@@ -222,7 +280,7 @@ class TestBuildFieldAnswersHtml(TestCase):
         self._create_answer(field_b, value_option=option_b)
         self._create_answer(field_a, value_option=option_a)
 
-        html = _build_field_answers_html(self.registration, "en")
+        html = _build_field_answers_html(self.registration, "en", _UTC)
         # Both fields present
         self.assertIn("First field", html)
         self.assertIn("Second field", html)
@@ -236,7 +294,7 @@ class TestBuildFieldAnswersHtml(TestCase):
     @tag("field_answers_email")
     def test_no_custom_fields_returns_empty(self):
         """Registration with no custom fields returns empty string."""
-        html = _build_field_answers_html(self.registration, "en")
+        html = _build_field_answers_html(self.registration, "en", _UTC)
         self.assertEqual(html, "")
 
     # ── Test 8: Optional fields, no answers → empty string ───────────────────
@@ -252,7 +310,7 @@ class TestBuildFieldAnswersHtml(TestCase):
             is_required=False,
         )
         # No answer created
-        html = _build_field_answers_html(self.registration, "en")
+        html = _build_field_answers_html(self.registration, "en", _UTC)
         self.assertEqual(html, "")
 
     # ── Test 9: Mix of answered and unanswered → only answered shown ─────────
@@ -278,7 +336,7 @@ class TestBuildFieldAnswersHtml(TestCase):
         self._create_answer(field_a, value_option=option_a)
         # No answer for field_b
 
-        html = _build_field_answers_html(self.registration, "en")
+        html = _build_field_answers_html(self.registration, "en", _UTC)
         self.assertIn("Answered field", html)
         self.assertNotIn("Unanswered field", html)
 
@@ -296,5 +354,5 @@ class TestBuildFieldAnswersHtml(TestCase):
         option = self._create_option(field, "Solar", 0)
         self._create_answer(field, value_option=option)
 
-        html = _build_field_answers_html(self.registration, "de")
+        html = _build_field_answers_html(self.registration, "de", _UTC)
         self.assertIn("Deine Anmeldeantworten", html)

--- a/backend/organization/utility/email.py
+++ b/backend/organization/utility/email.py
@@ -585,26 +585,35 @@ _DE_MONTHS_SHORT = {
 }
 
 
-def _format_time_range_localized(start, end, lang_code):
+def _format_time_range_localized(start, end, lang_code, tz):
     """
     Format a start/end datetime pair as a localised time-range string.
 
-    English: "Mon, Jan 1, 10:00 – 12:00"
-    German:  "Mo, 1. Jan, 10:00 – 12:00"
+    Both datetimes are converted to ``tz`` before formatting so that
+    timezone-aware output is produced regardless of the stored timezone.
+
+    English: "Mon, Jan 1, 10:00 – 12:00 (CET)"
+    German:  "Mo, 1. Jan, 10:00 – 12:00 Uhr (MEZ)"
     """
+    from climateconnect_api.utility.timezone_utils import _DE_TZ_ABBREVS
+
+    start = start.astimezone(tz)
+    end = end.astimezone(tz)
     start_day_en = start.strftime("%a")
     start_month = start.month
     start_day_num = start.day
     start_time = start.strftime("%H:%M")
     end_time = end.strftime("%H:%M")
+    tz_abbrev = start.strftime("%Z")
 
     if lang_code == "de":
+        de_abbrev = _DE_TZ_ABBREVS.get(tz_abbrev, tz_abbrev)
         day_str = _DE_DAYS.get(start_day_en, start_day_en)
         month_str = _DE_MONTHS_SHORT.get(start_month, start.strftime("%b"))
-        return f"{day_str}, {start_day_num}. {month_str}, {start_time} – {end_time}"
+        return f"{day_str}, {start_day_num}. {month_str}, {start_time} – {end_time} Uhr ({de_abbrev})"
 
     month_str = start.strftime("%b")
-    return f"{start_day_en}, {month_str} {start_day_num}, {start_time} – {end_time}"
+    return f"{start_day_en}, {month_str} {start_day_num}, {start_time} – {end_time} ({tz_abbrev})"
 
 
 _FIELD_CELL_STYLE = (
@@ -612,7 +621,7 @@ _FIELD_CELL_STYLE = (
 )
 
 
-def _build_field_answers_html(registration, lang_code):
+def _build_field_answers_html(registration, lang_code, tz):
     """
     Build an HTML snippet of the guest's registration field answers for the
     confirmation email.
@@ -624,6 +633,7 @@ def _build_field_answers_html(registration, lang_code):
         registration: EventRegistration instance with prefetched field_answers,
             field, value_option, and field.options.
         lang_code: User's language code ("en" or "de").
+        tz: The :class:`~zoneinfo.ZoneInfo` timezone to display times in.
 
     Returns:
         str: HTML snippet or empty string.
@@ -694,7 +704,7 @@ def _build_field_answers_html(registration, lang_code):
             option = answer.value_option
             if option and option.start_time and option.end_time:
                 answer_text = _format_time_range_localized(
-                    option.start_time, option.end_time, lang_code
+                    option.start_time, option.end_time, lang_code, tz
                 )
             elif option:
                 answer_text = option.title
@@ -765,7 +775,7 @@ def send_event_registration_confirmation_to_user(user, project, registration):
         "de": f"Du bist für {get_project_name(project, 'de')} angemeldet!",
     }
 
-    field_answers_html = _build_field_answers_html(registration, lang_code)
+    field_answers_html = _build_field_answers_html(registration, lang_code, display_tz)
 
     variables = {
         "FirstName": user.first_name or user.username,

--- a/doc/spec/20260602_1600_calendar_integration_for_events.md
+++ b/doc/spec/20260602_1600_calendar_integration_for_events.md
@@ -1,0 +1,203 @@
+# Calendar Integration for Events
+
+**Date**: 2026-06-02  
+**Status**: DRAFT  
+**Epic**: [Event Registration](./EPIC_event_registration.md) (Phase 5 — iCal support for events)  
+**GitHub Issue**: —
+
+---
+
+## Problem Statement
+
+When a visitor views a Climate Connect event, they have no way to add it to their personal calendar. Guests must manually copy event details into Google Calendar, Apple Calendar, Outlook, or another calendar app. This is a friction point that risks guests forgetting about the event or entering incorrect details.
+
+This applies to all events — whether they have registration enabled or not. The feature is also useful in registration confirmation emails, where the guest already has a clear intent to attend.
+
+### Why it matters
+
+- **Reduces no-shows**: Calendar reminders are the most reliable way to ensure guests attend.
+- **Improves UX**: Every major event platform (Eventbrite, Luma, Meetup, Lu.ma) offers calendar integration. Its absence feels like a missing feature.
+- **Timeslot personalisation** (future): Events with time slot fields (Phase 4c) have per-guest schedules. A generic event .ics file uses overall event times — the guest's *specific* timeslot could be included via a token-based personalised URL (out of scope for this iteration).
+
+### Current state
+
+- No calendar-related features exist anywhere in the codebase.
+- The EPIC already lists "iCal support for events" as a Phase 5 nice-to-have.
+- Email templates are Mailjet transactional templates with variable injection — calendar links can be added as new template variables.
+- All event data needed for calendar generation is available in the Django models: `Project.name`, `start_date`, `end_date`, `Location` (with coordinates), `is_online`, `additional_loc_info`, and `RegistrationFieldOption.start_time` / `.end_time` for timeslots.
+
+---
+
+## Scope
+
+### In scope
+
+1. **Calendar links on the event page** — visible to all visitors on all events (project type `EV`).
+2. **Public `.ical` web endpoint** — a Next.js page at `/projects/{slug}.ical` that returns a valid iCalendar file for the event, using the event's overall start/end times.
+3. **Google Calendar and Outlook redirect endpoints** — Next.js pages at `/projects/{slug}/add-to-google-calendar` and `/projects/{slug}/add-to-outlook` that redirect to the provider URL scheme with pre-filled event details.
+4. **Calendar links in registration confirmation email** — the same three links (Google, Apple, Outlook) added to the existing confirmation email template.
+
+### Out of scope (for now)
+
+- **Personalised .ics with timeslot data** — requires per-user authentication or a signed token URL. Possible future enhancement: unique-token URLs like `/projects/{slug}?token={unguessable_token}.ical` that embed the user's timeslot selection in the `DESCRIPTION` and adjust `DTSTART`/`DTEND` to the slot times.
+- Calendar subscription feeds (recurring .ics feeds for all events an org hosts).
+- .ics file attachments in emails (links only, as requested).
+- Two-way calendar sync (e.g. Google Calendar API integration).
+
+---
+
+## Acceptance Criteria
+
+### AC-1: Calendar links in confirmation email
+
+When a guest registers for an event, the confirmation email contains three clickable links:
+- **"Add to Google Calendar"** — links to `FRONTEND_URL/projects/{slug}/add-to-google-calendar`. A Next.js page that fetches event data and redirects (302) to the Google Calendar URL scheme with pre-filled event details.
+- **"Add to Apple Calendar"** — links to `FRONTEND_URL/projects/{slug}.ical`. Serves the `.ics` file directly. On iOS/macOS this triggers the native calendar app; on other platforms it downloads the file.
+- **"Add to Outlook"** — links to `FRONTEND_URL/projects/{slug}/add-to-outlook`. A Next.js page that fetches event data and redirects (302) to the Outlook URL scheme with pre-filled event details.
+
+All three links are short, clean frontend URLs — no query params, no URL-encoded event data. The actual provider URL construction happens at redirect time in Next.js `getServerSideProps`, which already has the event data from the Django API. This keeps the email text version clean and avoids stale links if event details change after the email is sent.
+
+The links are plain HTML `<a>` tags — no JavaScript required. They work in all email clients.
+
+### AC-2: Calendar links on event page
+
+On every event detail page, all visitors see a minimalistic "Add to Calendar" control near the event date/time display. The control is a small dropdown/select (calendar icon in an outline button) with three options: Google Calendar, Apple Calendar, Outlook. Keeps the UI compact — the page already has many buttons.
+
+**Priority**: The event page UI is a bonus. The primary deliverable is the calendar links in the confirmation email (AC-1) and the `.ical` / redirect endpoints (AC-3). The event page UI can be iterated on after the email integration ships.
+
+### AC-3: Public .ical endpoint (Next.js)
+
+Next.js serves the `.ical` content directly via a page with `getServerSideProps`. The page fetches event data from the Django API and generates the iCal response using the `ical-generator` library.
+
+**URL patterns:**
+- `GET /projects/{slug}.ical` — returns a valid iCalendar file for the event.
+- `GET /de/projects/{slug}.ical` — same, with German-language `SUMMARY` and `DESCRIPTION` (locale-aware content).
+- Accessible to anyone, no authentication required.
+- Used in confirmation emails and on the event page for all visitors.
+
+**Response:**
+- `Content-Type: text/calendar; charset=utf-8`
+- `Content-Disposition: attachment; filename="{slug}.ics"`
+
+**iCal content:**
+- `VCALENDAR` with `PRODID` and `VERSION`
+- `VEVENT` with `SUMMARY` (event name), `DTSTART`, `DTEND`, `LOCATION`, `DESCRIPTION`, `URL`
+- `DTSTART`/`DTEND` use the event's overall `start_date`/`end_date` in UTC (ISO 8601)
+- `LOCATION` formatted as: `{place_name}, {exact_address}, {city}, {country}` (or "Online" for online events)
+- `DESCRIPTION` includes the event description and a link back to the event page
+
+**Routing**: Next.js already has `.xml` extension routes for sitemaps (`pages/sitemapindex.xml.tsx`, `pages/sitemap/[language_code_dot_xml].tsx`). The same pattern applies for `.ical`. Next.js built-in i18n locale prefix routing handles `/de/projects/{slug}.ical` automatically.
+
+**Data flow**: `getServerSideProps` → `apiRequest()` to Django (`GET /api/projects/{slug}/`) → build iCal object with `ical-generator` → write to `res` with `text/calendar` content type.
+
+### AC-4: Edge cases
+
+- Event with no `start_date` or `end_date`: calendar links are not shown (no valid date to put in calendar).
+- Online event with no physical location: `LOCATION` field is omitted or set to "Online".
+- Event with `is_online=True` and a `website` URL: the event URL is included in the `DESCRIPTION` field.
+- Draft event: calendar endpoints return 404.
+- Non-event project types (projects, ideas): calendar links are not shown.
+
+---
+
+## Constraints
+
+- **No .ics attachments in emails** — links only. All calendar links are short Next.js frontend URLs.
+- **Email links must work without JavaScript** — plain `<a>` tags with `href` attributes. Google/Outlook links go through Next.js redirect pages; the `.ical` link serves the file directly.
+- **Calendar URL construction in Next.js** — Google Calendar and Outlook URL schemes are built at redirect time in `getServerSideProps`, not in the email. The email only contains short frontend URLs.
+- **.ics generation in Next.js** — uses `ical-generator` (Node.js). The page's `getServerSideProps` fetches event data from Django API and generates the iCal response.
+- **Feature toggle** — calendar UI does NOT require the `EVENT_REGISTRATION` toggle. It applies to all events regardless of registration status. No toggle check needed.
+- **i18n** — calendar UI strings ("Add to Calendar", "Add to Google Calendar", etc.) must support English and German. The `.ical` content uses the locale from the URL prefix (`/de/` for German).
+- **Performance** — .ics generation happens in `getServerSideProps` (same as existing project page). The data needed is a single Django API call — no additional queries.
+
+---
+
+## Domain Context
+
+### How timeslots work (Phase 4c) — future personalisation
+
+Timeslots are implemented as a field type within the registration field system. A `RegistrationField` with `field_type="time_slot_select"` contains `RegistrationFieldOption` records, each with:
+- `start_time` (DateTimeField, nullable)
+- `end_time` (DateTimeField, nullable)
+- `title` (CharField)
+
+When a guest registers and selects a timeslot, a `RegistrationFieldAnswer` is created with `value_option` pointing to the chosen `RegistrationFieldOption`.
+
+**Future enhancement**: A personalised `.ical` URL (with a unique, unguessable token) could embed the guest's selected timeslot in the `DESCRIPTION` field and adjust `DTSTART`/`DTEND` to the slot times. The iCal `DESCRIPTION` field (RFC 5545) supports plain text with `\n` newlines — timeslot details can be formatted as:
+```
+Your selected time slot:\nMorning — Sat, Jun 20, 09:00 – 12:00\n\nEvent details:\n...
+```
+This is deferred because it requires either per-user authentication or a signed-token URL mechanism.
+
+### How emails are sent
+
+Emails are sent from Django via Mailjet transactional templates. The Python code builds a dictionary of template variables and passes them to the Mailjet API. Calendar links are added as new template variables:
+
+- `GoogleCalendarUrl` — `FRONTEND_URL/projects/{url_slug}/add-to-google-calendar`
+- `OutlookCalendarUrl` — `FRONTEND_URL/projects/{url_slug}/add-to-outlook`
+- `IcsDownloadUrl` — `FRONTEND_URL/projects/{url_slug}.ical`
+
+All three are short, static URLs — the Celery task only needs `FRONTEND_URL` and `url_slug`. No event data is URL-encoded in the email. The actual provider URL construction happens at redirect time in Next.js.
+
+The email sending happens in a Celery task (`send_event_registration_confirmation_email`) dispatched via `transaction.on_commit`. The task fetches the event data and builds template variables.
+
+### Location data structure
+
+The `Location` model has: `name`, `place_name`, `exact_address`, `display_name`, `city`, `state`, `country`, `centre_point` (PostGIS PointField with lat/lon). The `additional_loc_info` field on `Project` stores room numbers or directions.
+
+### Event URL pattern
+
+Event pages are at `FRONTEND_URL/projects/{url_slug}`. The `url_slug` is unique and stable.
+
+Calendar URLs — all served by Next.js:
+- `.ical` file: `FRONTEND_URL/projects/{url_slug}.ical` (serves .ics content via `ical-generator`)
+- Google Calendar redirect: `FRONTEND_URL/projects/{url_slug}/add-to-google-calendar` (302 → Google Calendar URL scheme)
+- Outlook redirect: `FRONTEND_URL/projects/{url_slug}/add-to-outlook` (302 → Outlook URL scheme)
+
+Localized variants (Next.js i18n prefix):
+- `FRONTEND_URL/de/projects/{url_slug}.ical`
+- `FRONTEND_URL/de/projects/{url_slug}/add-to-google-calendar`
+- `FRONTEND_URL/de/projects/{url_slug}/add-to-outlook`
+
+---
+
+## Open Questions
+
+~~1. **Where does the "Add to Calendar" UI live on the event page?**~~ Resolved: near the event date/time display, as a minimalistic calendar icon dropdown.
+
+~~2. **Should we use `add-to-calendar-button-react` for the frontend UI?**~~ Resolved: custom minimalistic UI (calendar icon outline button with dropdown). No new dependency. Can revisit `add-to-calendar-button-react` later if more polish is needed.
+
+---
+
+## Research Notes
+
+### Solutions evaluated
+
+**add-to-calendar-button-react** (`add-to-calendar-button-react` on npm)
+- React wrapper around a web component. Renders a dropdown with Apple/Google/Outlook/Yahoo options.
+- Client-side only (`'use client'` required). Generates .ics content in the browser.
+- Verdict: Optional — for polished event page UI only. Does not solve the email link use case (email links point to Next.js `.ical` URL or Google/Outlook URL schemes directly).
+
+**ical-generator** (`ical-generator` on npm, v10.2.0, 847 stars)
+- Node.js library for generating iCalendar (.ics) files. Full control over all iCal properties.
+- Works in Node.js (`getServerSideProps`, API routes) and browser. TypeScript support. Zero dependencies.
+- Verdict: **Selected** — .ics generation in Next.js `getServerSideProps`. Fetches event data from Django API, builds iCal object, writes to response.
+
+**Python `icalendar` library** (not used)
+- Python equivalent of `ical-generator`. Would work in Django directly.
+- Not needed — Next.js handles .ics serving. Django only needs to construct the frontend URL for email template variables.
+
+**Direct URL construction** (no library needed)
+- Google Calendar: `https://calendar.google.com/calendar/render?action=TEMPLATE&text=...&dates=.../...&details=...&location=...`
+- Outlook: `https://outlook.live.com/calendar/0/action/compose?subject=...&startdt=...&enddt=...&body=...&location=...`
+- Apple Calendar: `.ics` download link (points to the Next.js `.ical` URL)
+- Verdict: Google/Outlook URLs are constructed at redirect time in Next.js `getServerSideProps`. Not embedded in email — email contains short frontend URLs that redirect.
+
+### Recommendation summary
+
+| Layer | Solution | Rationale |
+|-------|----------|-----------|
+| .ics generation | `ical-generator` in Next.js `getServerSideProps` | Fetches event data from Django API, generates .ics, writes to response. |
+| Google Calendar / Outlook redirect | Next.js `getServerSideProps` redirect pages | Fetches event data, constructs provider URL, issues 302. Keeps email URLs short and always up-to-date. |
+| Email template variables | Short frontend URLs only | Celery task uses `FRONTEND_URL` + `url_slug`. No event data in URLs. |
+| Event page UI | Custom buttons (MUI) with direct links | Fewer dependencies; consistent with existing UI patterns. Can upgrade to `add-to-calendar-button-react` later. |

--- a/doc/spec/20260603_0835_fix_timeslot_email_timezone.md
+++ b/doc/spec/20260603_0835_fix_timeslot_email_timezone.md
@@ -1,0 +1,186 @@
+# Fix: Time-slot Times in Confirmation Email Shown in UTC
+
+**Status**: DRAFT
+**Type**: Bug Fix
+**Date and time created**: 2026-06-03 08:35
+**GitHub Issue**: [#2027](https://github.com/climateconnect/climateconnect/issues/2027)
+**Epic**: [`EPIC_event_registration.md`](./EPIC_event_registration.md)
+**Related Specs**:
+- [`20260601_1031_include_field_answers_in_registration_email.md`](./20260601_1031_include_field_answers_in_registration_email.md) ← introduced field answers in email (including time-slot formatting)
+- [`20260526_1100_time_slot_field_type_event_registration.md`](./20260526_1100_time_slot_field_type_event_registration.md) ← time-slot field type definition
+
+---
+
+## Problem Statement
+
+When an event registration includes a time-slot field, the confirmation email displays the time-slot times in UTC instead of the user's local timezone. The frontend correctly converts UTC datetimes to the user's browser/OS timezone, but the backend email sends raw UTC times.
+
+**Root cause**: The `_format_time_range_localized()` helper in `backend/organization/utility/email.py` (line 588) formats `start_time` and `end_time` directly with `strftime()` without any timezone conversion. The datetimes are stored in UTC in the database, so the email renders UTC times.
+
+Meanwhile, the event's `StartDate` in the same email is correctly timezone-converted — `send_event_registration_confirmation_to_user()` computes `display_tz` via `get_event_display_timezone(user, project)` and passes it to `format_datetime_localized()`, which calls `dt.astimezone(tz)` before formatting. The time-slot path simply doesn't use this timezone.
+
+**Core Requirements:**
+
+1. Time-slot times in the confirmation email must be displayed in the same timezone as the event start date in the same email.
+2. The timezone resolution must follow the same priority as the event start date: user location → event location → UTC fallback.
+3. The time range format must include a timezone abbreviation (e.g. "CET", "MESZ") so the user knows which timezone the times refer to.
+
+**Explicitly Out of Scope:**
+
+- Storing user timezone preferences in the database.
+- Changing how the frontend displays time-slots (already correct).
+- Changing the admin notification email or organiser message email.
+- Adding timezone information to other field types (no other field types store datetimes).
+
+---
+
+## System Impact
+
+### Actors
+- **Guest**: sees correct local times in the confirmation email instead of UTC.
+
+### Entities Changed
+- No model changes. No new entities.
+
+### Flows Changed
+- **Registration confirmation email**: time-slot times now timezone-converted.
+
+### Integration Changes
+- Internal function signatures change (not exposed via API).
+
+---
+
+## Software Architecture
+
+### What needs to change
+
+The timezone is already computed in `send_event_registration_confirmation_to_user()` as `display_tz`. It just needs to be threaded through to the time-slot formatting path.
+
+**Current call chain (broken)**:
+```
+send_event_registration_confirmation_to_user()
+  → display_tz = get_event_display_timezone(user, project)  ✓ computed
+  → format_datetime_localized(project.start_date, lang_code, display_tz)  ✓ uses display_tz
+  → _build_field_answers_html(registration, lang_code)  ✗ no display_tz
+      → _format_time_range_localized(start, end, lang_code)  ✗ no tz conversion
+```
+
+**Fixed call chain**:
+```
+send_event_registration_confirmation_to_user()
+  → display_tz = get_event_display_timezone(user, project)
+  → format_datetime_localized(project.start_date, lang_code, display_tz)
+  → _build_field_answers_html(registration, lang_code, display_tz)  ← pass display_tz
+      → _format_time_range_localized(start, end, lang_code, display_tz)  ← pass display_tz
+          → start.astimezone(tz), end.astimezone(tz)  ← convert before formatting
+```
+
+### Function changes
+
+**1. `_format_time_range_localized(start, end, lang_code)` → add `tz` parameter**
+
+Located at `backend/organization/utility/email.py:588`.
+
+Add a `tz: ZoneInfo` parameter. Before formatting, convert both datetimes:
+```python
+def _format_time_range_localized(start, end, lang_code, tz):
+    start = start.astimezone(tz)
+    end = end.astimezone(tz)
+    # ... rest of existing formatting logic unchanged ...
+```
+
+The formatted output should include the timezone abbreviation (e.g. "Mon, Jan 1, 10:00 – 12:00 (CET)") so the user knows the timezone context. This is consistent with `format_datetime_localized()` which already appends `(CET)` / `(MEZ)` to the event start date.
+
+**2. `_build_field_answers_html(registration, lang_code)` → add `tz` parameter**
+
+Located at `backend/organization/utility/email.py:615`.
+
+Add a `tz: ZoneInfo` parameter and pass it to `_format_time_range_localized()`:
+```python
+def _build_field_answers_html(registration, lang_code, tz):
+    # ...
+    elif field_type == RegistrationFieldType.TIME_SLOT_SELECT:
+        # ...
+        answer_text = _format_time_range_localized(
+            option.start_time, option.end_time, lang_code, tz
+        )
+```
+
+**3. `send_event_registration_confirmation_to_user()` → pass `display_tz`**
+
+Located at `backend/organization/utility/email.py:721`.
+
+Change the call to `_build_field_answers_html` to include `display_tz`:
+```python
+field_answers_html = _build_field_answers_html(registration, lang_code, display_tz)
+```
+
+No other changes needed in this function — `display_tz` is already computed on line 758.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Time-slot times in the confirmation email are displayed in the user's resolved timezone (not UTC).
+- [ ] The timezone abbreviation is shown after the time range (e.g. "Mon, Jan 1, 10:00 – 12:00 (CET)").
+- [ ] The timezone resolution follows the same priority as the event start date: user location → event location → UTC.
+- [ ] The event start date in the same email continues to display correctly (no regression).
+- [ ] Other field types (checkbox, option_select, inventory) are unaffected.
+- [ ] The German locale formatting is correct (timezone abbreviation uses German equivalents where applicable, e.g. "MESZ" instead of "CEST").
+- [ ] Existing tests continue to pass.
+
+---
+
+## Test Cases
+
+### Backend Tests
+
+| Scenario | Expected |
+|----------|----------|
+| Time-slot with user in CET timezone | Email shows times in CET with "(CET)" suffix |
+| Time-slot with user in UTC (no location) and event in CET | Email shows times in CET (falls back to event location) |
+| Time-slot with no user location and no event location | Email shows times in UTC with "(UTC)" suffix |
+| Time-slot with German locale | Timezone abbreviation uses German equivalent (e.g. "MESZ") |
+| Event start date in same email | Still correctly timezone-converted (no regression) |
+| Non-time-slot field types | Unaffected by the change |
+
+### Existing Tests
+
+The test at `backend/organization/tests/test_email_field_answers.py:180` (`test_time_slot_included`) creates time-slots using `timezone.now()` which returns UTC. After the fix, this test may need its assertions updated to account for the timezone suffix in the formatted output.
+
+---
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `backend/organization/utility/email.py` | Add `tz` parameter to `_format_time_range_localized()` and `_build_field_answers_html()`; add `astimezone(tz)` conversion; pass `display_tz` from `send_event_registration_confirmation_to_user()` |
+| `backend/organization/tests/test_email_field_answers.py` | Update `test_time_slot_included` assertions to expect timezone abbreviation; add test for timezone conversion |
+
+---
+
+## Dependency Notes
+
+- **Depends on**: `get_event_display_timezone()` and `format_datetime_localized()` in `backend/climateconnect_api/utility/timezone_utils.py` (already exist).
+- **Enables**: Nothing directly — this is a bug fix.
+- **No new migrations required**.
+- **No new API endpoints required**.
+- **No Mailjet template changes required** — the time range string is embedded in `FieldAnswersHtml` which is already rendered.
+
+---
+
+## Log
+
+- 2026-06-03 08:35 — Spec created. Initial draft based on codebase analysis.
+
+---
+
+## Notes and Open Questions
+
+1. **Timezone abbreviation in time range**: The current `_format_time_range_localized()` output does not include a timezone suffix (e.g. "Mon, Jan 1, 10:00 – 12:00"). After the fix, it should include one (e.g. "Mon, Jan 1, 10:00 – 12:00 (CET)") to match the event start date format and make the timezone explicit. This is a minor format change to an existing helper.
+
+2. **German timezone abbreviations**: The `_DE_TZ_ABBREVS` mapping in `timezone_utils.py` already handles CET → MEZ and CEST → MESZ. The `_format_time_range_localized()` function in `email.py` has its own `_DE_MONTHS_SHORT` and `_DE_DAYS` mappings but no timezone abbreviation mapping. The timezone abbreviation should come from `local_dt.strftime("%Z")` (which gives the IANA abbreviation) and then be translated using the existing `_DE_TZ_ABBREVS` mapping if the lang_code is "de". This is consistent with how `format_datetime_localized()` handles it.
+
+3. **Test isolation**: The existing `test_time_slot_included` test creates datetimes with `timezone.now()` (UTC). After adding timezone conversion, the formatted output will depend on the resolved timezone. The test should either: (a) mock `get_event_display_timezone` to return UTC so the output is deterministic, or (b) set up user/project locations to control the timezone. Option (a) is simpler for a unit test of `_build_field_answers_html`.
+
+4. **Same timezone for start and end**: Since `start_time` and `end_time` are converted using the same `tz`, and both are stored in UTC, there's no risk of the start being in one timezone and the end in another. The timezone abbreviation will be the same for both.


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Fix for #2027
