### PR TITLE
Add ical attachments to confirmation email

### DIFF
--- a/backend/organization/tests/test_ics_attachment.py
+++ b/backend/organization/tests/test_ics_attachment.py
@@ -32,6 +32,7 @@ from organization.models.registration_field import (
 from organization.utility.email import (
     _build_field_answers_text,
     generate_event_ics_attachment,
+    generate_timeslot_ics_attachments,
 )
 
 _UTC = ZoneInfo("UTC")
@@ -679,3 +680,433 @@ class TestIcsDescriptionWithFieldAnswers(TestCase):
         self.assertGreater(event_desc_pos, -1)
         self.assertGreater(answers_pos, event_desc_pos)
         self.assertGreater(url_pos, answers_pos)
+
+
+class TestTimeslotIcsAttachments(TestCase):
+    """Tests for per-timeslot .ics attachments."""
+
+    def setUp(self):
+        self.project_status, _ = ProjectStatus.objects.update_or_create(
+            id=2,
+            defaults={
+                "name": "active_timeslot_ics",
+                "has_end_date": True,
+                "has_start_date": True,
+            },
+        )
+        self.language, _ = Language.objects.get_or_create(
+            language_code="en",
+            defaults={"name": "English", "native_name": "English"},
+        )
+        self.project = Project.objects.create(
+            name="Workshop Day",
+            url_slug="workshop-day",
+            is_active=True,
+            is_draft=False,
+            status=self.project_status,
+            language=self.language,
+            project_type="EV",
+            start_date=datetime(2026, 10, 1, 9, 0, tzinfo=_UTC),
+            end_date=datetime(2026, 10, 1, 17, 0, tzinfo=_UTC),
+        )
+        self.config = EventRegistrationConfig.objects.create(
+            project=self.project,
+            max_participants=100,
+            registration_end_date=django_timezone.now() + timedelta(days=30),
+            status=RegistrationStatus.OPEN,
+        )
+        self.user = User.objects.create_user(
+            username="timeslot_user", password="testpassword"
+        )
+        self.registration = EventRegistration.objects.create(
+            user=self.user,
+            registration_config=self.config,
+        )
+
+    def _parse_ics(self, attachment):
+        ics_bytes = base64.b64decode(attachment["Base64Content"])
+        return Calendar.from_ical(ics_bytes)
+
+    @tag("ics_attachment")
+    def test_no_timeslots_returns_empty(self):
+        """No timeslot answers returns an empty list."""
+        result = generate_timeslot_ics_attachments(
+            self.project, "en", self.registration
+        )
+        self.assertEqual(result, [])
+
+    @tag("ics_attachment")
+    def test_single_timeslot_generates_one_ics(self):
+        """A single timeslot answer generates one .ics attachment."""
+        field = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=0,
+            label="Workshop",
+            settings={"title": "Workshop"},
+        )
+        option = RegistrationFieldOption.objects.create(
+            field=field,
+            title="Morning",
+            order=0,
+            start_time=datetime(2026, 10, 1, 10, 0, tzinfo=_UTC),
+            end_time=datetime(2026, 10, 1, 12, 0, tzinfo=_UTC),
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option,
+        )
+        attachments = generate_timeslot_ics_attachments(
+            self.project, "en", self.registration
+        )
+        self.assertEqual(len(attachments), 1)
+
+    @tag("ics_attachment")
+    def test_multiple_timeslots_generates_multiple_ics(self):
+        """Multiple timeslot fields each generate a separate .ics file."""
+        field1 = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=0,
+            label="Morning",
+            settings={"title": "Morning"},
+        )
+        field2 = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=1,
+            label="Afternoon",
+            settings={"title": "Afternoon"},
+        )
+        option1 = RegistrationFieldOption.objects.create(
+            field=field1,
+            title="Morning",
+            order=0,
+            start_time=datetime(2026, 10, 1, 10, 0, tzinfo=_UTC),
+            end_time=datetime(2026, 10, 1, 12, 0, tzinfo=_UTC),
+        )
+        option2 = RegistrationFieldOption.objects.create(
+            field=field2,
+            title="Afternoon",
+            order=0,
+            start_time=datetime(2026, 10, 1, 14, 0, tzinfo=_UTC),
+            end_time=datetime(2026, 10, 1, 16, 0, tzinfo=_UTC),
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field1,
+            value_option=option1,
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field2,
+            value_option=option2,
+        )
+        attachments = generate_timeslot_ics_attachments(
+            self.project, "en", self.registration
+        )
+        self.assertEqual(len(attachments), 2)
+
+    @tag("ics_attachment")
+    def test_timeslot_summary_format(self):
+        """Timeslot SUMMARY uses 'My timeslot at {event name}'."""
+        field = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=0,
+            label="Session",
+            settings={"title": "Session"},
+        )
+        option = RegistrationFieldOption.objects.create(
+            field=field,
+            title="Morning",
+            order=0,
+            start_time=datetime(2026, 10, 1, 10, 0, tzinfo=_UTC),
+            end_time=datetime(2026, 10, 1, 12, 0, tzinfo=_UTC),
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option,
+        )
+        attachments = generate_timeslot_ics_attachments(
+            self.project, "en", self.registration
+        )
+        cal = self._parse_ics(attachments[0])
+        event = cal.walk("VEVENT")[0]
+        self.assertEqual(str(event.get("summary")), "My timeslot at Workshop Day")
+
+    @tag("ics_attachment")
+    def test_timeslot_summary_german(self):
+        """German timeslot SUMMARY uses 'Mein Zeitfester bei {event name}'."""
+        field = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=0,
+            label="Session",
+            settings={"title": "Session"},
+        )
+        option = RegistrationFieldOption.objects.create(
+            field=field,
+            title="Morning",
+            order=0,
+            start_time=datetime(2026, 10, 1, 10, 0, tzinfo=_UTC),
+            end_time=datetime(2026, 10, 1, 12, 0, tzinfo=_UTC),
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option,
+        )
+        attachments = generate_timeslot_ics_attachments(
+            self.project, "de", self.registration
+        )
+        cal = self._parse_ics(attachments[0])
+        event = cal.walk("VEVENT")[0]
+        self.assertEqual(str(event.get("summary")), "Mein Zeitfester bei Workshop Day")
+
+    @tag("ics_attachment")
+    def test_timeslot_dtstart_dtend(self):
+        """Timeslot DTSTART/DTEND match the option's start_time/end_time."""
+        field = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=0,
+            label="Session",
+            settings={"title": "Session"},
+        )
+        option = RegistrationFieldOption.objects.create(
+            field=field,
+            title="Morning",
+            order=0,
+            start_time=datetime(2026, 10, 1, 10, 0, tzinfo=_UTC),
+            end_time=datetime(2026, 10, 1, 12, 0, tzinfo=_UTC),
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option,
+        )
+        attachments = generate_timeslot_ics_attachments(
+            self.project, "en", self.registration
+        )
+        cal = self._parse_ics(attachments[0])
+        event = cal.walk("VEVENT")[0]
+        self.assertEqual(event.get("dtstart").dt.hour, 10)
+        self.assertEqual(event.get("dtend").dt.hour, 12)
+
+    @tag("ics_attachment")
+    def test_timeslot_uid(self):
+        """Timeslot UID uses registration_id and field_id."""
+        field = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=0,
+            label="Session",
+            settings={"title": "Session"},
+        )
+        option = RegistrationFieldOption.objects.create(
+            field=field,
+            title="Morning",
+            order=0,
+            start_time=datetime(2026, 10, 1, 10, 0, tzinfo=_UTC),
+            end_time=datetime(2026, 10, 1, 12, 0, tzinfo=_UTC),
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option,
+        )
+        attachments = generate_timeslot_ics_attachments(
+            self.project, "en", self.registration
+        )
+        cal = self._parse_ics(attachments[0])
+        event = cal.walk("VEVENT")[0]
+        expected_uid = f"{self.registration.id}_{field.id}@climateconnect.earth"
+        self.assertEqual(str(event.get("uid")), expected_uid)
+
+    @tag("ics_attachment")
+    def test_timeslot_description_only_has_cta(self):
+        """Timeslot DESCRIPTION contains only CTA + event URL (no field answers)."""
+        field = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=0,
+            label="Session",
+            settings={"title": "Session"},
+        )
+        option = RegistrationFieldOption.objects.create(
+            field=field,
+            title="Morning",
+            order=0,
+            start_time=datetime(2026, 10, 1, 10, 0, tzinfo=_UTC),
+            end_time=datetime(2026, 10, 1, 12, 0, tzinfo=_UTC),
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option,
+        )
+        attachments = generate_timeslot_ics_attachments(
+            self.project, "en", self.registration
+        )
+        cal = self._parse_ics(attachments[0])
+        event = cal.walk("VEVENT")[0]
+        description = str(event.get("description"))
+        self.assertIn("http://localhost:3000/projects/workshop-day", description)
+        self.assertNotIn("registration answers", description.lower())
+
+    @tag("ics_attachment")
+    def test_timeslot_filename(self):
+        """Timeslot filename uses event slug and option title."""
+        field = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=0,
+            label="Session",
+            settings={"title": "Session"},
+        )
+        option = RegistrationFieldOption.objects.create(
+            field=field,
+            title="Morning Session",
+            order=0,
+            start_time=datetime(2026, 10, 1, 10, 0, tzinfo=_UTC),
+            end_time=datetime(2026, 10, 1, 12, 0, tzinfo=_UTC),
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option,
+        )
+        attachments = generate_timeslot_ics_attachments(
+            self.project, "en", self.registration
+        )
+        self.assertEqual(attachments[0]["Filename"], "workshop-day_morning-session.ics")
+
+    @tag("ics_attachment")
+    def test_online_event_timeslot_uses_website_url(self):
+        """Online event timeslot .ics uses website URL."""
+        self.project.is_online = True
+        self.project.website = "https://zoom.us/j/999"
+        self.project.save()
+        field = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=0,
+            label="Session",
+            settings={"title": "Session"},
+        )
+        option = RegistrationFieldOption.objects.create(
+            field=field,
+            title="Morning",
+            order=0,
+            start_time=datetime(2026, 10, 1, 10, 0, tzinfo=_UTC),
+            end_time=datetime(2026, 10, 1, 12, 0, tzinfo=_UTC),
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option,
+        )
+        attachments = generate_timeslot_ics_attachments(
+            self.project, "en", self.registration
+        )
+        cal = self._parse_ics(attachments[0])
+        event = cal.walk("VEVENT")[0]
+        self.assertEqual(str(event.get("url")), "https://zoom.us/j/999")
+
+    @tag("ics_attachment")
+    def test_non_timeslot_fields_ignored(self):
+        """Non-timeslot fields are not included in timeslot attachments."""
+        field = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.OPTION_SELECT,
+            order=0,
+            label="T-shirt",
+            settings={"title": "T-shirt size"},
+        )
+        option = RegistrationFieldOption.objects.create(
+            field=field, title="Medium", order=0
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option,
+        )
+        attachments = generate_timeslot_ics_attachments(
+            self.project, "en", self.registration
+        )
+        self.assertEqual(attachments, [])
+
+    @tag("ics_attachment")
+    def test_timeslot_without_times_skipped(self):
+        """Timeslot option without start_time/end_time is skipped."""
+        field = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=0,
+            label="Session",
+            settings={"title": "Session"},
+        )
+        option = RegistrationFieldOption.objects.create(
+            field=field, title="TBD", order=0
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field,
+            value_option=option,
+        )
+        attachments = generate_timeslot_ics_attachments(
+            self.project, "en", self.registration
+        )
+        self.assertEqual(attachments, [])
+
+    @tag("ics_attachment")
+    def test_two_timeslot_fields_each_generate_ics(self):
+        """Two separate timeslot fields each produce their own .ics files."""
+        field1 = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=0,
+            label="Day 1",
+            settings={"title": "Day 1"},
+        )
+        field2 = RegistrationField.objects.create(
+            registration_config=self.config,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=1,
+            label="Day 2",
+            settings={"title": "Day 2"},
+        )
+        opt1 = RegistrationFieldOption.objects.create(
+            field=field1,
+            title="Morning Day 1",
+            order=0,
+            start_time=datetime(2026, 10, 1, 10, 0, tzinfo=_UTC),
+            end_time=datetime(2026, 10, 1, 12, 0, tzinfo=_UTC),
+        )
+        opt2 = RegistrationFieldOption.objects.create(
+            field=field2,
+            title="Morning Day 2",
+            order=0,
+            start_time=datetime(2026, 10, 2, 10, 0, tzinfo=_UTC),
+            end_time=datetime(2026, 10, 2, 12, 0, tzinfo=_UTC),
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field1,
+            value_option=opt1,
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=self.registration,
+            field=field2,
+            value_option=opt2,
+        )
+        attachments = generate_timeslot_ics_attachments(
+            self.project, "en", self.registration
+        )
+        self.assertEqual(len(attachments), 2)
+        filenames = {a["Filename"] for a in attachments}
+        self.assertIn("workshop-day_morning-day-1.ics", filenames)
+        self.assertIn("workshop-day_morning-day-2.ics", filenames)

--- a/backend/organization/tests/test_ics_attachment.py
+++ b/backend/organization/tests/test_ics_attachment.py
@@ -959,7 +959,7 @@ class TestTimeslotIcsAttachments(TestCase):
 
     @tag("ics_attachment")
     def test_timeslot_filename(self):
-        """Timeslot filename uses event slug and option title."""
+        """Timeslot filename uses event slug and sequence number."""
         field = RegistrationField.objects.create(
             registration_config=self.config,
             field_type=RegistrationFieldType.TIME_SLOT_SELECT,
@@ -982,7 +982,7 @@ class TestTimeslotIcsAttachments(TestCase):
         attachments = generate_timeslot_ics_attachments(
             self.project, "en", self.registration
         )
-        self.assertEqual(attachments[0]["Filename"], "workshop-day_morning-session.ics")
+        self.assertEqual(attachments[0]["Filename"], "workshop-day_timeslot_1.ics")
 
     @tag("ics_attachment")
     def test_online_event_timeslot_uses_website_url(self):
@@ -1108,5 +1108,5 @@ class TestTimeslotIcsAttachments(TestCase):
         )
         self.assertEqual(len(attachments), 2)
         filenames = {a["Filename"] for a in attachments}
-        self.assertIn("workshop-day_morning-day-1.ics", filenames)
-        self.assertIn("workshop-day_morning-day-2.ics", filenames)
+        self.assertIn("workshop-day_timeslot_1.ics", filenames)
+        self.assertIn("workshop-day_timeslot_2.ics", filenames)

--- a/backend/organization/tests/test_ics_attachment.py
+++ b/backend/organization/tests/test_ics_attachment.py
@@ -11,6 +11,7 @@ import base64
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase, tag
 from django.utils import timezone as django_timezone
@@ -129,7 +130,7 @@ class TestGenerateEventIcsAttachment(TestCase):
         attachment = generate_event_ics_attachment(self.project, "en")
         cal = self._parse_ics(attachment)
         event = cal.walk("VEVENT")[0]
-        expected_url = f"http://localhost:3000/projects/{self.project.url_slug}"
+        expected_url = f"{settings.FRONTEND_URL}/projects/{self.project.url_slug}"
         self.assertEqual(str(event.get("url")), expected_url)
 
     @tag("ics_attachment")
@@ -140,7 +141,7 @@ class TestGenerateEventIcsAttachment(TestCase):
         event = cal.walk("VEVENT")[0]
         description = str(event.get("description"))
         self.assertIn(
-            f"http://localhost:3000/projects/{self.project.url_slug}",
+            f"{settings.FRONTEND_URL}/projects/{self.project.url_slug}",
             description,
         )
 
@@ -198,7 +199,7 @@ class TestGenerateEventIcsAttachment(TestCase):
         event = cal.walk("VEVENT")[0]
         self.assertEqual(
             str(event.get("url")),
-            f"http://localhost:3000/projects/{self.project.url_slug}",
+            f"{settings.FRONTEND_URL}/projects/{self.project.url_slug}",
         )
 
     @tag("ics_attachment")
@@ -211,7 +212,7 @@ class TestGenerateEventIcsAttachment(TestCase):
         event = cal.walk("VEVENT")[0]
         self.assertEqual(
             str(event.get("url")),
-            f"http://localhost:3000/projects/{self.project.url_slug}",
+            f"{settings.FRONTEND_URL}/projects/{self.project.url_slug}",
         )
 
     @tag("ics_attachment")
@@ -225,7 +226,7 @@ class TestGenerateEventIcsAttachment(TestCase):
         event = cal.walk("VEVENT")[0]
         description = str(event.get("description"))
         self.assertIn(
-            "http://localhost:3000/projects/climate-action-summit", description
+            f"{settings.FRONTEND_URL}/projects/climate-action-summit", description
         )
         self.assertNotIn("zoom.us", description)
 
@@ -616,7 +617,7 @@ class TestIcsDescriptionWithFieldAnswers(TestCase):
         self.assertIn("10:00", description)
         self.assertIn("12:00", description)
         self.assertIn(
-            "http://localhost:3000/projects/answers-test-event",
+            f"{settings.FRONTEND_URL}/projects/answers-test-event",
             description,
         )
 
@@ -673,7 +674,7 @@ class TestIcsDescriptionWithFieldAnswers(TestCase):
         cal = self._parse_ics(attachment)
         event = cal.walk("VEVENT")[0]
         description = str(event.get("description"))
-        event_url = "http://localhost:3000/projects/answers-test-event"
+        event_url = f"{settings.FRONTEND_URL}/projects/answers-test-event"
         event_desc_pos = description.find("An exciting climate event.")
         answers_pos = description.find("Your registration answers:")
         url_pos = description.find(event_url)
@@ -954,7 +955,7 @@ class TestTimeslotIcsAttachments(TestCase):
         cal = self._parse_ics(attachments[0])
         event = cal.walk("VEVENT")[0]
         description = str(event.get("description"))
-        self.assertIn("http://localhost:3000/projects/workshop-day", description)
+        self.assertIn(f"{settings.FRONTEND_URL}/projects/workshop-day", description)
         self.assertNotIn("registration answers", description.lower())
 
     @tag("ics_attachment")

--- a/backend/organization/utility/email.py
+++ b/backend/organization/utility/email.py
@@ -893,6 +893,84 @@ def generate_event_ics_attachment(project, lang_code, registration=None, tz=None
     }
 
 
+def generate_timeslot_ics_attachments(project, lang_code, registration):
+    """
+    Generate a separate .ics attachment for each timeslot field answer.
+
+    Each timeslot the guest selected during registration becomes its own
+    calendar entry so that guests can add individual sessions to their
+    calendar independently of the overall event.
+
+    Returns a list of Mailjet attachment dicts (may be empty if the
+    registration has no timeslot answers).
+
+    Args:
+        project: ``Project`` instance.
+        lang_code: User's language code ("en" or "de").
+        registration: ``EventRegistration`` instance with prefetched
+            ``field_answers__field``, ``field_answers__value_option``.
+    """
+    from organization.models.registration_field import RegistrationFieldType
+
+    event_url = (
+        settings.FRONTEND_URL
+        + get_user_lang_url(lang_code)
+        + "/projects/"
+        + project.url_slug
+    )
+    ical_url = project.website if (project.is_online and project.website) else event_url
+
+    url_cta = (
+        "Visit the following link to see event details or change your registration:"
+        if lang_code == "en"
+        else "Besuche folgenden Link, um die Details der Veranstaltung zu sehen"
+        " oder deine Anmeldung zu ändern:"
+    )
+    description = f"{url_cta}\n{event_url}"
+
+    summary_prefix = "My timeslot at" if lang_code == "en" else "Mein Zeitfester bei"
+    event_name = get_project_name(project, lang_code)
+
+    attachments = []
+    for answer in registration.field_answers.all():
+        if answer.field.field_type != RegistrationFieldType.TIME_SLOT_SELECT:
+            continue
+        option = answer.value_option
+        if not option or not option.start_time or not option.end_time:
+            continue
+
+        cal = Calendar()
+        cal.add("prodid", "-//Climate Connect//EN")
+        cal.add("version", "2.0")
+        cal.add("method", "PUBLISH")
+
+        ical_event = IcalEvent()
+        ical_event.add(
+            "uid", f"{registration.id}_{answer.field.id}@climateconnect.earth"
+        )
+        ical_event.add("summary", f"{summary_prefix} {event_name}")
+        ical_event.add("dtstart", option.start_time)
+        ical_event.add("dtend", option.end_time)
+        ical_event.add("description", description)
+        ical_event.add("url", ical_url)
+
+        cal.add_component(ical_event)
+
+        ics_bytes = cal.to_ical()
+        ics_base64 = base64.b64encode(ics_bytes).decode("ascii")
+
+        slug = re.sub(r"[^a-z0-9]+", "-", option.title.lower()).strip("-")
+        attachments.append(
+            {
+                "ContentType": "text/calendar; method=PUBLISH; charset=utf-8",
+                "Filename": f"{project.url_slug}_{slug}.ics",
+                "Base64Content": ics_base64,
+            }
+        )
+
+    return attachments
+
+
 def send_event_registration_confirmation_to_user(user, project, registration):
     """
     Send a registration confirmation email to a user who just registered for an event.
@@ -963,6 +1041,9 @@ def send_event_registration_confirmation_to_user(user, project, registration):
     )
     if ics_attachment:
         attachments.append(ics_attachment)
+    attachments.extend(
+        generate_timeslot_ics_attachments(project, lang_code, registration)
+    )
 
     send_email(
         user=user,

--- a/backend/organization/utility/email.py
+++ b/backend/organization/utility/email.py
@@ -932,12 +932,15 @@ def generate_timeslot_ics_attachments(project, lang_code, registration):
     event_name = get_project_name(project, lang_code)
 
     attachments = []
+    timeslot_seq = 0
     for answer in registration.field_answers.all():
         if answer.field.field_type != RegistrationFieldType.TIME_SLOT_SELECT:
             continue
         option = answer.value_option
         if not option or not option.start_time or not option.end_time:
             continue
+
+        timeslot_seq += 1
 
         cal = Calendar()
         cal.add("prodid", "-//Climate Connect//EN")
@@ -959,11 +962,10 @@ def generate_timeslot_ics_attachments(project, lang_code, registration):
         ics_bytes = cal.to_ical()
         ics_base64 = base64.b64encode(ics_bytes).decode("ascii")
 
-        slug = re.sub(r"[^a-z0-9]+", "-", option.title.lower()).strip("-")
         attachments.append(
             {
                 "ContentType": "text/calendar; method=PUBLISH; charset=utf-8",
-                "Filename": f"{project.url_slug}_{slug}.ics",
+                "Filename": f"{project.url_slug}_timeslot_{timeslot_seq}.ics",
                 "Base64Content": ics_base64,
             }
         )

--- a/doc/spec/20260611_1131_ics_attachment_in_confirmation_email.md
+++ b/doc/spec/20260611_1131_ics_attachment_in_confirmation_email.md
@@ -252,3 +252,8 @@ ics_base64 = base64.b64encode(ics_bytes).decode("ascii")
 ### Why not generate .ics via the Next.js endpoint?
 
 The Celery task could theoretically call the Next.js `.ical` endpoint to get the .ics content. But this adds an HTTP roundtrip, a dependency on the frontend being available, and complexity for error handling. Generating the .ics directly in Python is simpler, faster, and more reliable. The event data is already available in the task.
+
+### TODO
+- Name attachment for timeslot .ical attachement differently. Maybe event-slug + "_timeslot_" + sequence number + ".ics"
+- Add the additional information field of the event project if set to the description of the even .ical file as it is intended to provide more information
+

--- a/doc/spec/20260611_1131_ics_attachment_in_confirmation_email.md
+++ b/doc/spec/20260611_1131_ics_attachment_in_confirmation_email.md
@@ -36,6 +36,7 @@ When a guest registers for an event, the confirmation email contains no calendar
 3. Extend the `send_email()` helper to support optional attachments (backwards-compatible).
 4. Include the guest's registration field answers (especially timeslots) as plain text in the iCalendar DESCRIPTION.
 5. Use the event's `website` URL as the iCal `URL` property for online events.
+6. Generate separate per-timeslot .ics attachments so guests can add individual sessions to their calendar independently.
 
 ### Out of scope (for now)
 
@@ -66,7 +67,30 @@ When a guest registers for an event, the confirmation email includes an .ics fil
 - `ContentType`: `text/calendar; method=PUBLISH; charset=utf-8`
 - `Base64Content`: Base64-encoded .ics content
 
-### AC-2: Edge cases
+### AC-2: Per-timeslot .ics attachments
+
+When a guest has selected timeslot field answers during registration, a separate .ics file is generated for each timeslot. This allows guests to add individual sessions to their calendar independently of the overall event.
+
+**iCal content (per timeslot):**
+- `VCALENDAR` with `PRODID`, `VERSION`, and `METHOD:PUBLISH`
+- `VEVENT` with:
+  - `UID` — `{registration_id}_{field_id}@climateconnect.earth` (unique per timeslot answer)
+  - `SUMMARY` — localised: "My timeslot at {event name}" (EN) / "Mein Zeitfester bei {event name}" (DE)
+  - `DTSTART` / `DTEND` — the timeslot option's `start_time` / `end_time`
+  - `DESCRIPTION` — localised CTA text + event page URL (no field answers repeated)
+  - `URL` — same logic as the main event .ics (online website or event page)
+
+**Attachment metadata:**
+- Filename: `{event_slug}_{option-title-slug}.ics` (e.g. `workshop-day_morning-session.ics`)
+- `ContentType`: `text/calendar; method=PUBLISH; charset=utf-8`
+- `Base64Content`: Base64-encoded .ics content
+
+**Behaviour:**
+- Multiple timeslot fields each produce their own .ics files (e.g. "Day 1" and "Day 2" → two files).
+- Timeslot options without `start_time` / `end_time` are skipped.
+- Non-timeslot field types (checkbox, option select, inventory) are ignored.
+
+### AC-3: Edge cases
 
 - Online events (`is_online=True`): `LOCATION` is "Online". (Online events do have an associated physical location for hub purposes, but the calendar entry should reflect that the event itself is online.)
 - Online event with `is_online=True` and a `website` URL: the iCal `URL` property uses the `website` value (typically a Zoom/meeting link). The DESCRIPTION CTA always links back to the Climate Connect event page.
@@ -74,16 +98,18 @@ When a guest registers for an event, the confirmation email includes an .ics fil
 - Event with no location: `LOCATION` is omitted from the .ics. (The `get_location_name()` function returns an empty string in this case.)
 - Event with no `start_date` or `end_date`: no .ics attachment is generated (function returns `None`).
 - Project description contains HTML: stripped via `bleach.clean(tags=[], strip=True)` before inclusion in DESCRIPTION.
+- Per-timeslot .ics files: each timeslot option becomes its own calendar entry with a unique UID and filename.
 
 ---
 
 ## Constraints
 
-- **.ics generation in Python** — uses the `icalendar` library (PyPI, `>=5.0.0`). Generates the .ics content in `generate_event_ics_attachment()` in `organization/utility/email.py`, using event data already fetched for the email template variables. No additional database queries.
+- **.ics generation in Python** — uses the `icalendar` library (PyPI, `>=5.0.0`). Generates the .ics content in `generate_event_ics_attachment()` and `generate_timeslot_ics_attachments()` in `organization/utility/email.py`, using event data already fetched for the email template variables. No additional database queries.
 - **Mailjet attachment format** — the `Attachments` field on the message object accepts `[{"ContentType": "...", "Filename": "...", "Base64Content": "<base64>"}]`. Content must be Base64-encoded. Note: Mailjet v3.1 uses `ContentType` and `Base64Content` (not `Content-type` and `Content`).
 - **No multiple calendar formats** — `.ics` (iCalendar / RFC 5545) is the only format. Universally supported by all major calendar apps.
 - **i18n** — `SUMMARY`, `DESCRIPTION` field answers heading, and CTA text use the user's language (via `get_user_lang_code`). `LOCATION` reuses the already-translated `LocationName` template variable. Consistent with existing email localisation.
 - **Performance** — .ics generation uses data already fetched for the email template. No additional database queries. The `icalendar` library is lightweight.
+- **Attachment count** — a registration with N timeslot fields produces 1 (main event) + N (timeslot) attachments. Mailjet supports up to 15 MB total per message; text .ics files are negligible in size.
 
 ---
 
@@ -99,7 +125,7 @@ The `LOCATION` field in the .ics reuses the same `LocationName` value that is al
 
 This is already fetched and computed in the Celery task for the `LocationName` email template variable. The .ics generation reuses the same value — no additional queries or formatting logic needed.
 
-### DESCRIPTION structure
+### DESCRIPTION structure (main event .ics)
 
 The iCalendar `DESCRIPTION` field is composed of up to four sections, separated by `\n\n`:
 
@@ -121,7 +147,38 @@ Besuche folgenden Link, um die Details der Veranstaltung zu sehen oder deine Anm
 https://climateconnect.earth/projects/event-slug
 ```
 
-### Registration field answers in .ics
+### DESCRIPTION structure (per-timeslot .ics)
+
+Per-timeslot .ics files have a simpler DESCRIPTION with only two sections:
+
+1. **Localised CTA text** — same as the main event .ics.
+2. **Event page URL** — always the Climate Connect event page URL.
+
+Field answers are not repeated in the per-timeslot DESCRIPTION since the timeslot itself is the subject of the calendar entry.
+
+### Per-timeslot .ics generation
+
+The `generate_timeslot_ics_attachments()` function produces a separate .ics attachment for each timeslot field answer in the guest's registration. This allows guests to add individual sessions to their calendar independently.
+
+**How it works:**
+1. Iterates through `registration.field_answers.all()`.
+2. Filters to `TIME_SLOT_SELECT` fields only.
+3. Skips answers where the option has no `start_time` or `end_time`.
+4. For each valid timeslot, generates a complete iCalendar file with:
+   - `SUMMARY`: localised "My timeslot at {event name}" / "Mein Zeitfester bei {event name}"
+   - `DTSTART`/`DTEND`: from the option's times
+   - `DESCRIPTION`: CTA + event page URL only
+   - `URL`: online website if applicable, otherwise event page
+   - `UID`: `{registration_id}_{field_id}@climateconnect.earth`
+   - `Filename`: `{event_slug}_{option-title-slug}.ics`
+
+**Example:** A guest registers for "Workshop Day" and selects "Morning Session" (10:00–12:00) from the timeslot field. The email includes:
+- `workshop-day.ics` — the overall event (9:00–17:00)
+- `workshop-day_morning-session.ics` — the individual timeslot (10:00–12:00)
+
+If the event has two timeslot fields (e.g. "Day 1" and "Day 2"), each produces its own .ics file, resulting in 3 attachments total.
+
+### Registration field answers in .ics (main event)
 
 The `_build_field_answers_text()` function produces a plain-text version of the guest's registration field answers for inclusion in the iCalendar DESCRIPTION. It mirrors the logic of `_build_field_answers_html()` (used in the email body) but outputs bullet-point lines instead of HTML table rows.
 
@@ -170,7 +227,7 @@ The `Base64Content` field is a Base64-encoded string. Generated with `base64.b64
 
 Note: Mailjet v3.1 uses `ContentType` and `Base64Content` as the field names (not `Content-type` and `Content` as some documentation suggests).
 
-### .ics content structure
+### .ics content structure (main event)
 
 The .ics file follows RFC 5545:
 
@@ -196,6 +253,30 @@ END:VCALENDAR
 - `LOCATION` reuses the `LocationName` template variable (see "Location formatting" above).
 - `DESCRIPTION` includes the event description text (HTML stripped), plain-text field answers, a localised CTA, and a link back to the event page, separated by `\n\n`.
 - `URL` uses the event's `website` field for online events (`is_online=True` and `website` is set). For all other events, it uses the Climate Connect event page URL.
+
+### .ics content structure (per-timeslot)
+
+```
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Climate Connect//EN
+METHOD:PUBLISH
+BEGIN:VEVENT
+UID:{registration_id}_{field_id}@climateconnect.earth
+SUMMARY:My timeslot at {event name}
+DTSTART:20260620T100000Z
+DTEND:20260620T120000Z
+DESCRIPTION:{CTA text}\n{event page URL}
+URL:{event website URL for online events, or event page URL}
+END:VEVENT
+END:VCALENDAR
+```
+
+- `UID` uses the registration ID + field ID for global uniqueness per timeslot answer.
+- `SUMMARY` is localised: "My timeslot at {event name}" (EN) / "Mein Zeitfester bei {event name}" (DE).
+- `DTSTART`/`DTEND` come from the timeslot option's `start_time`/`end_time`.
+- `DESCRIPTION` contains only the CTA text and event page URL (field answers are not repeated).
+- `URL` follows the same logic as the main event .ics.
 
 ### Confirmation email Celery task
 
@@ -253,7 +334,10 @@ ics_base64 = base64.b64encode(ics_bytes).decode("ascii")
 
 The Celery task could theoretically call the Next.js `.ical` endpoint to get the .ics content. But this adds an HTTP roundtrip, a dependency on the frontend being available, and complexity for error handling. Generating the .ics directly in Python is simpler, faster, and more reliable. The event data is already available in the task.
 
+### Google Calendar compatibility
+
+The per-timeslot .ics feature was designed with Google Calendar in mind. Google Calendar handles multiple .ics attachments in a single email by surfacing each as a separate "Add to Calendar" action, allowing the guest to selectively add the overall event and/or individual timeslots. Each .ics file has a unique UID so calendar apps treat them as distinct events even if imported together.
+
 ### TODO
 - Name attachment for timeslot .ical attachement differently. Maybe event-slug + "_timeslot_" + sequence number + ".ics"
 - Add the additional information field of the event project if set to the description of the even .ical file as it is intended to provide more information
-

--- a/doc/spec/20260611_1131_ics_attachment_in_confirmation_email.md
+++ b/doc/spec/20260611_1131_ics_attachment_in_confirmation_email.md
@@ -81,7 +81,7 @@ When a guest has selected timeslot field answers during registration, a separate
   - `URL` — same logic as the main event .ics (online website or event page)
 
 **Attachment metadata:**
-- Filename: `{event_slug}_{option-title-slug}.ics` (e.g. `workshop-day_morning-session.ics`)
+- Filename: `{event_slug}_timeslot_{sequence_number}.ics` (e.g. `workshop-day_timeslot_1.ics`)
 - `ContentType`: `text/calendar; method=PUBLISH; charset=utf-8`
 - `Base64Content`: Base64-encoded .ics content
 
@@ -170,11 +170,11 @@ The `generate_timeslot_ics_attachments()` function produces a separate .ics atta
    - `DESCRIPTION`: CTA + event page URL only
    - `URL`: online website if applicable, otherwise event page
    - `UID`: `{registration_id}_{field_id}@climateconnect.earth`
-   - `Filename`: `{event_slug}_{option-title-slug}.ics`
+   - `Filename`: `{event_slug}_timeslot_{sequence_number}.ics`
 
 **Example:** A guest registers for "Workshop Day" and selects "Morning Session" (10:00–12:00) from the timeslot field. The email includes:
 - `workshop-day.ics` — the overall event (9:00–17:00)
-- `workshop-day_morning-session.ics` — the individual timeslot (10:00–12:00)
+- `workshop-day_timeslot_1.ics` — the individual timeslot (10:00–12:00)
 
 If the event has two timeslot fields (e.g. "Day 1" and "Day 2"), each produces its own .ics file, resulting in 3 attachments total.
 
@@ -339,5 +339,5 @@ The Celery task could theoretically call the Next.js `.ical` endpoint to get the
 The per-timeslot .ics feature was designed with Google Calendar in mind. Google Calendar handles multiple .ics attachments in a single email by surfacing each as a separate "Add to Calendar" action, allowing the guest to selectively add the overall event and/or individual timeslots. Each .ics file has a unique UID so calendar apps treat them as distinct events even if imported together.
 
 ### TODO
-- Name attachment for timeslot .ical attachement differently. Maybe event-slug + "_timeslot_" + sequence number + ".ics"
+- ~~Name attachment for timeslot .ical attachement differently.~~ DONE — uses `{event_slug}_timeslot_{sequence_number}.ics`
 - Add the additional information field of the event project if set to the description of the even .ical file as it is intended to provide more information


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
