### PR TITLE
Implement event status based on capacity fields

### DIFF
--- a/backend/organization/serializers/event_registration.py
+++ b/backend/organization/serializers/event_registration.py
@@ -14,6 +14,7 @@ from organization.serializers.registration_field import (
     create_fields,
     sync_fields,
 )
+from organization.utility.event_registration import evaluate_registration_status
 
 
 def _compute_effective_status(obj: EventRegistrationConfig) -> str:
@@ -766,29 +767,16 @@ class EditEventRegistrationConfigSerializer(EventRegistrationConfigBaseSerialize
 
         explicit_status = validated_data.get("status")
 
-        if "max_participants" in validated_data and explicit_status is None:
-            new_max = validated_data["max_participants"]
-            if new_max is None:
-                # Switching to unlimited capacity — always re-opens a full event.
-                if instance.status == RegistrationStatus.FULL:
-                    instance.status = RegistrationStatus.OPEN
-            else:
-                current_count = EventRegistration.objects.filter(
-                    registration_config=instance,
-                    cancelled_at__isnull=True,
-                ).count()
-                if (
-                    instance.status == RegistrationStatus.FULL
-                    and new_max > current_count
-                ):
-                    # Capacity raised above filled seats → re-open.
-                    instance.status = RegistrationStatus.OPEN
-                elif (
-                    instance.status == RegistrationStatus.OPEN
-                    and new_max <= current_count
-                ):
-                    # Capacity set to match filled seats (< is blocked by validate) → close.
-                    instance.status = RegistrationStatus.FULL
+        if explicit_status is None and instance.status in (
+            RegistrationStatus.OPEN,
+            RegistrationStatus.FULL,
+        ):
+            # Auto-adjust: temporarily apply new max_participants so the
+            # utility evaluates with the proposed value.
+            if "max_participants" in validated_data:
+                instance.max_participants = validated_data["max_participants"]
+            suggested = evaluate_registration_status(instance)
+            instance.status = suggested
         result = super().update(instance, validated_data)
 
         if fields_data is not None:

--- a/backend/organization/serializers/event_registration.py
+++ b/backend/organization/serializers/event_registration.py
@@ -752,11 +752,16 @@ class EditEventRegistrationConfigSerializer(EventRegistrationConfigBaseSerialize
     def update(self, instance, validated_data):
         """
         Save updated config fields, sync custom registration fields, and
-        auto-adjust status when max_participants changes.
+        auto-adjust status when capacity conditions change.
 
-        Auto-adjustment is skipped when ``status`` is explicitly present in the
-        request body — the organiser's explicit intent takes priority over the
-        capacity-driven heuristic.
+        The organiser may explicitly set status to "open" or "closed".
+        After applying the organiser's intent, the capacity check always
+        runs on the *resulting* status — if the resulting status is
+        auto-managed (OPEN or FULL), the check may override it.  Only
+        CLOSED (an organiser-set terminal state) is never overridden.
+
+        The status evaluation MUST run after ``sync_fields`` so that field
+        option capacity changes (e.g. ``available_amount``) are visible.
         """
         fields_data = validated_data.pop("fields", None)
         new_is_draft = validated_data.pop("is_draft", None)
@@ -765,22 +770,22 @@ class EditEventRegistrationConfigSerializer(EventRegistrationConfigBaseSerialize
         if new_is_draft is not None and not new_is_draft and instance.is_draft:
             instance.is_draft = False
 
-        explicit_status = validated_data.get("status")
-
-        if explicit_status is None and instance.status in (
-            RegistrationStatus.OPEN,
-            RegistrationStatus.FULL,
-        ):
-            # Auto-adjust: temporarily apply new max_participants so the
-            # utility evaluates with the proposed value.
-            if "max_participants" in validated_data:
-                instance.max_participants = validated_data["max_participants"]
-            suggested = evaluate_registration_status(instance)
-            instance.status = suggested
         result = super().update(instance, validated_data)
 
         if fields_data is not None:
             sync_fields(instance, fields_data)
+
+        # Auto-adjust status AFTER all other changes are persisted so that
+        # max_participants AND field option capacity (available_amount) are
+        # both visible to the evaluation.
+        # Only CLOSED is exempt — it is an organiser-set terminal state.
+        # Both OPEN and FULL are auto-managed and subject to the capacity
+        # check regardless of whether status was in the PATCH payload.
+        if instance.status in (RegistrationStatus.OPEN, RegistrationStatus.FULL):
+            suggested = evaluate_registration_status(instance)
+            if suggested != instance.status:
+                instance.status = suggested
+                instance.save(update_fields=["status", "updated_at"])
 
         return result
 

--- a/backend/organization/tests/test_event_registration_sold_out.py
+++ b/backend/organization/tests/test_event_registration_sold_out.py
@@ -1,0 +1,798 @@
+"""
+Tests for the capacity-limited field sold-out detection feature.
+
+Covers:
+  - evaluate_registration_status() unit tests (AC-1, AC-2, AC-4)
+  - Integration tests: registration triggers sold-out (AC-1)
+  - Integration tests: cancellation reverts sold-out (AC-2)
+  - Integration tests: config PATCH respects sold-out (AC-3)
+  - Edge cases: no fields, no options, unlimited, non-required (AC-4)
+"""
+
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import TestCase, tag
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from climateconnect_api.models import Language, Role
+from organization.models import Project, ProjectMember, ProjectStatus
+from organization.models.event_registration import (
+    EventRegistration,
+    EventRegistrationConfig,
+    RegistrationFieldAnswer,
+    RegistrationStatus,
+)
+from organization.models.registration_field import (
+    RegistrationField,
+    RegistrationFieldOption,
+    RegistrationFieldType,
+)
+from organization.utility.event_registration import (
+    evaluate_registration_status,
+)
+
+# ---------------------------------------------------------------------------
+# Shared base for unit tests
+# ---------------------------------------------------------------------------
+
+
+class _EventRegistrationUnitBase(TestCase):
+    """Creates a minimal event + config for unit-testing the utility."""
+
+    def setUp(self):
+        self.project_status, _ = ProjectStatus.objects.update_or_create(
+            id=2,
+            defaults={
+                "name": "active_soldout",
+                "name_de_translation": "aktiv",
+                "has_end_date": True,
+                "has_start_date": True,
+            },
+        )
+        self.default_language, _ = Language.objects.get_or_create(
+            language_code="en",
+            defaults={"name": "English", "native_name": "English"},
+        )
+        self.event = Project.objects.create(
+            name="Sold Out Test Event",
+            url_slug="sold-out-test-event",
+            is_active=True,
+            is_draft=False,
+            status=self.project_status,
+            language=self.default_language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=30),
+            end_date=timezone.now() + timedelta(days=90),
+        )
+        self.rc = EventRegistrationConfig.objects.create(
+            project=self.event,
+            max_participants=10,
+            registration_end_date=timezone.now() + timedelta(days=60),
+            status=RegistrationStatus.OPEN,
+        )
+        self.user_counter = 0
+
+    def _make_user(self):
+        self.user_counter += 1
+        return User.objects.create_user(
+            username=f"soldout_user_{self.user_counter}",
+            password="testpassword",
+        )
+
+    def _register(self):
+        user = self._make_user()
+        return EventRegistration.objects.create(user=user, registration_config=self.rc)
+
+    def _create_inventory_field(self, is_required=True, order=0, label=None):
+        if label is None:
+            label = f"Inventory {order}"
+        field = RegistrationField.objects.create(
+            registration_config=self.rc,
+            field_type=RegistrationFieldType.INVENTORY,
+            order=order,
+            is_required=is_required,
+            label=label,
+            settings={"title": "T-shirts"},
+        )
+        return field
+
+    def _create_timeslot_field(self, is_required=True, order=0, label=None):
+        if label is None:
+            label = f"TimeSlot {order}"
+        field = RegistrationField.objects.create(
+            registration_config=self.rc,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=order,
+            is_required=is_required,
+            label=label,
+            settings={"title": "Pick your slot"},
+        )
+        return field
+
+    def _create_option(self, field, available_amount, order=0, title=None):
+        if title is None:
+            title = f"Option {order}"
+        return RegistrationFieldOption.objects.create(
+            field=field,
+            title=title,
+            order=order,
+            available_amount=available_amount,
+        )
+
+
+# ===========================================================================
+# Unit tests for evaluate_registration_status
+# ===========================================================================
+
+
+@tag("soldout", "unit")
+class TestEvaluateRegistrationStatusUnit(_EventRegistrationUnitBase):
+    """
+    Spec test cases 1–17 for evaluate_registration_status().
+    """
+
+    # ── 1: No max_participants, no required fields → OPEN ─────────────────
+
+    def test_no_max_no_fields_returns_open(self):
+        self.rc.max_participants = None
+        self.rc.save(update_fields=["max_participants"])
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.OPEN)
+
+    # ── 2: max_participants=10, 5 active → OPEN ───────────────────────────
+
+    def test_max_participants_not_reached_returns_open(self):
+        for _ in range(5):
+            self._register()
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.OPEN)
+
+    # ── 3: max_participants=10, 10 active → FULL ──────────────────────────
+
+    def test_max_participants_reached_returns_full(self):
+        for _ in range(10):
+            self._register()
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.FULL)
+
+    # ── 4: Required inventory field, all options have stock → OPEN ─────────
+
+    def test_required_inventory_with_stock_returns_open(self):
+        field = self._create_inventory_field()
+        self._create_option(field, available_amount=5, order=0)
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.OPEN)
+
+    # ── 5: Required inventory field, all options sold out → FULL ───────────
+
+    def test_required_inventory_all_sold_out_returns_full(self):
+        field = self._create_inventory_field()
+        opt = self._create_option(field, available_amount=2, order=0)
+        reg1 = self._register()
+        reg2 = self._register()
+        RegistrationFieldAnswer.objects.create(
+            registration=reg1, field=field, value_option=opt, value_number=1
+        )
+        RegistrationFieldAnswer.objects.create(
+            registration=reg2, field=field, value_option=opt, value_number=1
+        )
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.FULL)
+
+    # ── 6: Two required inventory fields, one sold out, one with stock → OPEN
+
+    def test_two_required_fields_one_with_stock_returns_open(self):
+        field_a = self._create_inventory_field(order=0, label="Inv A")
+        opt_a = self._create_option(field_a, available_amount=1, order=0, title="A1")
+        reg = self._register()
+        RegistrationFieldAnswer.objects.create(
+            registration=reg, field=field_a, value_option=opt_a, value_number=1
+        )
+        field_b = self._create_inventory_field(order=1, label="Inv B")
+        self._create_option(field_b, available_amount=5, order=0, title="B1")
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.OPEN)
+
+    # ── 7: Required inventory field with null option → OPEN (unlimited) ────
+
+    def test_required_inventory_unlimited_option_returns_open(self):
+        field = self._create_inventory_field()
+        self._create_option(field, available_amount=None, order=0)
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.OPEN)
+
+    # ── 8: Required inventory field with zero options → OPEN ───────────────
+
+    def test_required_inventory_no_options_returns_open(self):
+        self._create_inventory_field()
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.OPEN)
+
+    # ── 9: Non-required inventory field, all sold out → OPEN ───────────────
+
+    def test_non_required_inventory_sold_out_returns_open(self):
+        field = self._create_inventory_field(is_required=False)
+        opt = self._create_option(field, available_amount=1, order=0)
+        reg = self._register()
+        RegistrationFieldAnswer.objects.create(
+            registration=reg, field=field, value_option=opt, value_number=1
+        )
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.OPEN)
+
+    # ── 10: max_participants at capacity AND inventory sold out → FULL ─────
+
+    def test_max_full_and_inventory_full_returns_full(self):
+        for _ in range(10):
+            self._register()
+        field = self._create_inventory_field()
+        self._create_option(field, available_amount=5, order=0)
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.FULL)
+
+    # ── 11: max_participants at capacity but inventory has stock → FULL ─────
+
+    def test_max_full_inventory_has_stock_returns_full(self):
+        for _ in range(10):
+            self._register()
+        field = self._create_inventory_field()
+        self._create_option(field, available_amount=5, order=0)
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.FULL)
+
+    # ── 12: Required time slot field, all options sold out → FULL ──────────
+
+    def test_required_timeslot_all_sold_out_returns_full(self):
+        field = self._create_timeslot_field()
+        opt = self._create_option(field, available_amount=1, order=0)
+        reg = self._register()
+        RegistrationFieldAnswer.objects.create(
+            registration=reg, field=field, value_option=opt
+        )
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.FULL)
+
+    # ── 13: Required time slot, one option has remaining seats → OPEN ──────
+
+    def test_required_timeslot_one_with_stock_returns_open(self):
+        field = self._create_timeslot_field()
+        opt_sold = self._create_option(field, available_amount=1, order=0, title="Sold")
+        self._create_option(field, available_amount=5, order=1, title="Open")
+        reg = self._register()
+        RegistrationFieldAnswer.objects.create(
+            registration=reg, field=field, value_option=opt_sold
+        )
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.OPEN)
+
+    # ── 14: Required time slot with null option → OPEN ────────────────────
+
+    def test_required_timeslot_unlimited_option_returns_open(self):
+        field = self._create_timeslot_field()
+        self._create_option(field, available_amount=None, order=0)
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.OPEN)
+
+    # ── 15: Non-required time slot, all sold out → OPEN ────────────────────
+
+    def test_non_required_timeslot_sold_out_returns_open(self):
+        field = self._create_timeslot_field(is_required=False)
+        opt = self._create_option(field, available_amount=1, order=0)
+        reg = self._register()
+        RegistrationFieldAnswer.objects.create(
+            registration=reg, field=field, value_option=opt
+        )
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.OPEN)
+
+    # ── 16: Inv sold out but time slots available → FULL (OR logic) ─────────
+
+    def test_inv_sold_out_timeslot_available_returns_full(self):
+        """When ALL required inventory options are sold out, the event is FULL
+        regardless of time-slot availability (AC-1 OR logic)."""
+        inv_field = self._create_inventory_field(order=0, label="Inv")
+        inv_opt = self._create_option(
+            inv_field, available_amount=1, order=0, title="Inv1"
+        )
+        reg = self._register()
+        RegistrationFieldAnswer.objects.create(
+            registration=reg, field=inv_field, value_option=inv_opt, value_number=1
+        )
+        ts_field = self._create_timeslot_field(order=1, label="TS")
+        self._create_option(ts_field, available_amount=5, order=0, title="TS1")
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.FULL)
+
+    # ── 17: Both sold out → FULL ──────────────────────────────────────────
+
+    def test_both_inv_and_timeslot_sold_out_returns_full(self):
+        inv_field = self._create_inventory_field(order=0, label="Inv")
+        inv_opt = self._create_option(
+            inv_field, available_amount=1, order=0, title="Inv1"
+        )
+        reg = self._register()
+        RegistrationFieldAnswer.objects.create(
+            registration=reg, field=inv_field, value_option=inv_opt, value_number=1
+        )
+        ts_field = self._create_timeslot_field(order=1, label="TS")
+        ts_opt = self._create_option(ts_field, available_amount=1, order=0, title="TS1")
+        RegistrationFieldAnswer.objects.create(
+            registration=reg, field=ts_field, value_option=ts_opt
+        )
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.FULL)
+
+
+# ===========================================================================
+# Integration tests — registration triggers sold-out
+# ===========================================================================
+
+
+class _IntegrationBase(APITestCase):
+    """Shared setUp for integration tests."""
+
+    def setUp(self):
+        self.project_status, _ = ProjectStatus.objects.update_or_create(
+            id=2,
+            defaults={
+                "name": "active_integ",
+                "name_de_translation": "aktiv",
+                "has_end_date": True,
+                "has_start_date": True,
+            },
+        )
+        self.default_language, _ = Language.objects.get_or_create(
+            language_code="en",
+            defaults={"name": "English", "native_name": "English"},
+        )
+        self.organiser = User.objects.create_user(
+            username="organiser_integ", password="testpassword"
+        )
+        self.admin_role = Role.objects.create(
+            name="Admin_integ", role_type=Role.ALL_TYPE
+        )
+        self.event = Project.objects.create(
+            name="Integration Test Event",
+            url_slug="integ-test-event",
+            is_active=True,
+            is_draft=False,
+            status=self.project_status,
+            language=self.default_language,
+            project_type="EV",
+            start_date=timezone.now() + timedelta(days=30),
+            end_date=timezone.now() + timedelta(days=90),
+        )
+        self.rc = EventRegistrationConfig.objects.create(
+            project=self.event,
+            max_participants=10,
+            registration_end_date=timezone.now() + timedelta(days=60),
+            status=RegistrationStatus.OPEN,
+        )
+        ProjectMember.objects.create(
+            user=self.organiser, project=self.event, role=self.admin_role
+        )
+        self.register_url = reverse(
+            "organization:event-registrations",
+            kwargs={"url_slug": self.event.url_slug},
+        )
+        self.config_patch_url = reverse(
+            "organization:edit-registration-config",
+            kwargs={"url_slug": self.event.url_slug},
+        )
+        self.user_counter = 0
+
+    def _make_user(self):
+        self.user_counter += 1
+        u = User.objects.create_user(
+            username=f"integ_user_{self.user_counter}",
+            password="testpassword",
+        )
+        return u
+
+    def _register_user(self, user):
+        return EventRegistration.objects.create(user=user, registration_config=self.rc)
+
+    def _cancel_registration(self, reg, by_user):
+        reg.cancelled_at = timezone.now()
+        reg.cancelled_by = by_user
+        reg.save(update_fields=["cancelled_at", "cancelled_by"])
+
+    def _create_inventory_field(self, is_required=True, order=0, label=None):
+        if label is None:
+            label = f"Inv {order}"
+        field = RegistrationField.objects.create(
+            registration_config=self.rc,
+            field_type=RegistrationFieldType.INVENTORY,
+            order=order,
+            is_required=is_required,
+            label=label,
+            settings={"title": "Shirts"},
+        )
+        return field
+
+    def _create_timeslot_field(self, is_required=True, order=0, label=None):
+        if label is None:
+            label = f"TS {order}"
+        field = RegistrationField.objects.create(
+            registration_config=self.rc,
+            field_type=RegistrationFieldType.TIME_SLOT_SELECT,
+            order=order,
+            is_required=is_required,
+            label=label,
+            settings={"title": "Slot"},
+        )
+        return field
+
+    def _create_option(self, field, available_amount, order=0, title=None):
+        if title is None:
+            title = f"Opt {order}"
+        return RegistrationFieldOption.objects.create(
+            field=field,
+            title=title,
+            order=order,
+            available_amount=available_amount,
+        )
+
+
+@tag("soldout", "integration")
+class TestRegistrationTriggersCapacitySoldOut(_IntegrationBase):
+    """AC-1 integration tests: registration triggers sold-out status."""
+
+    # ── 18: Registration fills last required inventory item → FULL ─────────
+
+    def test_registration_fills_last_inventory_item_sets_full(self):
+        field = self._create_inventory_field()
+        opt = self._create_option(field, available_amount=3, order=0)
+        user1 = self._make_user()
+        reg1 = self._register_user(user1)
+        RegistrationFieldAnswer.objects.create(
+            registration=reg1, field=field, value_option=opt, value_number=1
+        )
+        user2 = self._make_user()
+        reg2 = self._register_user(user2)
+        RegistrationFieldAnswer.objects.create(
+            registration=reg2, field=field, value_option=opt, value_number=1
+        )
+        # 2 booked out of 3 — still 1 remaining
+
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.OPEN)
+
+        user3 = self._make_user()
+        self.client.login(username=user3.username, password="testpassword")
+        response = self.client.post(
+            self.register_url,
+            {
+                "answers": [
+                    {
+                        "field": field.id,
+                        "value_option": opt.id,
+                        "value_number": 1,
+                    }
+                ]
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.FULL)
+
+    # ── 19: Registration fills last required time slot → FULL ─────────────
+
+    def test_registration_fills_last_timeslot_sets_full(self):
+        field = self._create_timeslot_field()
+        opt = self._create_option(field, available_amount=1, order=0)
+
+        user1 = self._make_user()
+        self.client.login(username=user1.username, password="testpassword")
+        response = self.client.post(
+            self.register_url,
+            {
+                "answers": [
+                    {
+                        "field": field.id,
+                        "value_option": opt.id,
+                    }
+                ]
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.FULL)
+
+    # ── 20: max_participants not reached but inventory sold out → FULL ─────
+
+    def test_inventory_sold_out_before_max_participants_sets_full(self):
+        self.rc.max_participants = 100
+        self.rc.save(update_fields=["max_participants"])
+        field = self._create_inventory_field()
+        opt = self._create_option(field, available_amount=1, order=0)
+
+        user1 = self._make_user()
+        self.client.login(username=user1.username, password="testpassword")
+        response = self.client.post(
+            self.register_url,
+            {
+                "answers": [
+                    {
+                        "field": field.id,
+                        "value_option": opt.id,
+                        "value_number": 1,
+                    }
+                ]
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.FULL)
+
+    # ── 20b: Registration rejected when inventory already sold out ─────────
+
+    def test_registration_rejected_when_inventory_already_sold_out(self):
+        self.rc.max_participants = 100
+        self.rc.save(update_fields=["max_participants"])
+        field = self._create_inventory_field()
+        opt = self._create_option(field, available_amount=1, order=0)
+        user1 = self._make_user()
+        reg1 = self._register_user(user1)
+        RegistrationFieldAnswer.objects.create(
+            registration=reg1, field=field, value_option=opt, value_number=1
+        )
+
+        user2 = self._make_user()
+        self.client.login(username=user2.username, password="testpassword")
+        response = self.client.post(
+            self.register_url,
+            {
+                "answers": [
+                    {
+                        "field": field.id,
+                        "value_option": opt.id,
+                        "value_number": 1,
+                    }
+                ]
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.FULL)
+
+    # ── 24: Stale OPEN status but inventory sold out → error + sets FULL ───
+
+    def test_registration_when_stale_open_but_sold_out_returns_error(self):
+        field = self._create_inventory_field()
+        opt = self._create_option(field, available_amount=1, order=0)
+        user1 = self._make_user()
+        reg1 = self._register_user(user1)
+        RegistrationFieldAnswer.objects.create(
+            registration=reg1, field=field, value_option=opt, value_number=1
+        )
+        # Status is still OPEN (stale)
+        self.assertEqual(self.rc.status, RegistrationStatus.OPEN)
+
+        user2 = self._make_user()
+        self.client.login(username=user2.username, password="testpassword")
+        response = self.client.post(
+            self.register_url,
+            {
+                "answers": [
+                    {
+                        "field": field.id,
+                        "value_option": opt.id,
+                        "value_number": 1,
+                    }
+                ]
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.FULL)
+
+
+@tag("soldout", "integration")
+class TestCancellationRevertsCapacitySoldOut(_IntegrationBase):
+    """AC-2 integration tests: cancellation reverts sold-out status."""
+
+    # ── 21: Cancellation frees inventory item → reverts to OPEN ────────────
+
+    def test_cancellation_frees_inventory_reverts_to_open(self):
+        self.rc.max_participants = 100
+        self.rc.save(update_fields=["max_participants"])
+        field = self._create_inventory_field()
+        opt = self._create_option(field, available_amount=1, order=0)
+        user1 = self._make_user()
+        self._register_user(user1)
+        RegistrationFieldAnswer.objects.create(
+            registration=user1.event_registrations.first(),
+            field=field,
+            value_option=opt,
+            value_number=1,
+        )
+        self.rc.status = RegistrationStatus.FULL
+        self.rc.save(update_fields=["status"])
+
+        self.client.login(username=user1.username, password="testpassword")
+        response = self.client.delete(self.register_url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.OPEN)
+
+    # ── 22: Cancellation frees time slot → reverts to OPEN ────────────────
+
+    def test_cancellation_frees_timeslot_reverts_to_open(self):
+        self.rc.max_participants = 100
+        self.rc.save(update_fields=["max_participants"])
+        field = self._create_timeslot_field()
+        opt = self._create_option(field, available_amount=1, order=0)
+        user1 = self._make_user()
+        self._register_user(user1)
+        RegistrationFieldAnswer.objects.create(
+            registration=user1.event_registrations.first(),
+            field=field,
+            value_option=opt,
+        )
+        self.rc.status = RegistrationStatus.FULL
+        self.rc.save(update_fields=["status"])
+
+        self.client.login(username=user1.username, password="testpassword")
+        response = self.client.delete(self.register_url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.OPEN)
+
+    # ── 23: Cancellation frees inventory but max_participants still full → FULL
+
+    def test_cancellation_frees_inventory_but_max_still_full_stays_full(self):
+        for _ in range(10):
+            self._make_user()
+        users = list(
+            User.objects.filter(username__startswith="integ_user_").order_by("id")
+        )
+        for u in users:
+            self._register_user(u)
+
+        field = self._create_inventory_field()
+        opt = self._create_option(field, available_amount=1, order=0)
+        RegistrationFieldAnswer.objects.create(
+            registration=users[0].event_registrations.first(),
+            field=field,
+            value_option=opt,
+            value_number=1,
+        )
+
+        self.rc.status = RegistrationStatus.FULL
+        self.rc.save(update_fields=["status"])
+
+        # Cancel the user who booked the inventory — inventory frees up,
+        # but max_participants is still at 10.
+        self._cancel_registration(
+            users[0].event_registrations.first(), by_user=users[0]
+        )
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.FULL)
+
+    # ── Admin cancellation frees inventory → reverts to OPEN ───────────────
+
+    def test_admin_cancel_frees_inventory_reverts_to_open(self):
+        self.rc.max_participants = 100
+        self.rc.save(update_fields=["max_participants"])
+        field = self._create_inventory_field()
+        opt = self._create_option(field, available_amount=1, order=0)
+        user1 = self._make_user()
+        reg1 = self._register_user(user1)
+        RegistrationFieldAnswer.objects.create(
+            registration=reg1, field=field, value_option=opt, value_number=1
+        )
+        self.rc.status = RegistrationStatus.FULL
+        self.rc.save(update_fields=["status"])
+
+        admin_cancel_url = reverse(
+            "organization:admin-cancel-guest-registration",
+            kwargs={
+                "url_slug": self.event.url_slug,
+                "registration_id": reg1.id,
+            },
+        )
+        self.client.login(username="organiser_integ", password="testpassword")
+        response = self.client.patch(admin_cancel_url, format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.OPEN)
+
+
+@tag("soldout", "integration")
+class TestConfigPatchRespectsCapacitySoldOut(_IntegrationBase):
+    """AC-3 integration tests: config PATCH respects capacity sold-out."""
+
+    # ── 25: PATCH raises max_participants, but inventory sold out → FULL ────
+
+    def test_patch_raises_max_but_inventory_sold_out_stays_full(self):
+        field = self._create_inventory_field()
+        opt = self._create_option(field, available_amount=1, order=0)
+        user1 = self._make_user()
+        reg1 = self._register_user(user1)
+        RegistrationFieldAnswer.objects.create(
+            registration=reg1, field=field, value_option=opt, value_number=1
+        )
+        self.rc.status = RegistrationStatus.FULL
+        self.rc.save(update_fields=["status"])
+
+        self.client.login(username="organiser_integ", password="testpassword")
+        response = self.client.patch(
+            self.config_patch_url,
+            {"max_participants": 1000},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.FULL)
+
+    # ── 26: PATCH sets max_participants=null, but time slots sold out → FULL
+
+    def test_patch_sets_max_null_but_timeslot_sold_out_stays_full(self):
+        field = self._create_timeslot_field()
+        opt = self._create_option(field, available_amount=1, order=0)
+        user1 = self._make_user()
+        reg1 = self._register_user(user1)
+        RegistrationFieldAnswer.objects.create(
+            registration=reg1, field=field, value_option=opt
+        )
+        self.rc.status = RegistrationStatus.FULL
+        self.rc.save(update_fields=["status"])
+
+        self.client.login(username="organiser_integ", password="testpassword")
+        response = self.client.patch(
+            self.config_patch_url,
+            {"max_participants": None},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.FULL)
+
+    # ── PATCH raises max_participants and inventory has stock → OPEN ────────
+
+    def test_patch_raises_max_and_inventory_has_stock_reverts_to_open(self):
+        field = self._create_inventory_field()
+        self._create_option(field, available_amount=10, order=0)
+        # Fill max_participants
+        for _ in range(5):
+            self._register_user(self._make_user())
+        self.rc.status = RegistrationStatus.FULL
+        self.rc.save(update_fields=["status"])
+
+        self.client.login(username="organiser_integ", password="testpassword")
+        response = self.client.patch(
+            self.config_patch_url,
+            {"max_participants": 20},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.OPEN)
+
+    # ── Explicit status="open" in PATCH body skips auto-adjustment ─────────
+
+    def test_explicit_status_in_patch_skips_auto_adjust(self):
+        """When the organiser explicitly sends status, auto-adjust is skipped."""
+        self.rc.max_participants = 1
+        self.rc.save(update_fields=["max_participants"])
+        self._register_user(self._make_user())
+        self._register_user(self._make_user())
+
+        self.client.login(username="organiser_integ", password="testpassword")
+        response = self.client.patch(
+            self.config_patch_url,
+            {"max_participants": 10, "status": "open"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.OPEN)
+
+    # ── CLOSED status is not overwritten by auto-adjust ────────────────────
+
+    def test_closed_status_not_overwritten_by_auto_adjust(self):
+        self.rc.status = RegistrationStatus.CLOSED
+        self.rc.save(update_fields=["status"])
+
+        self.client.login(username="organiser_integ", password="testpassword")
+        response = self.client.patch(
+            self.config_patch_url,
+            {"max_participants": 5},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.CLOSED)

--- a/backend/organization/tests/test_event_registration_sold_out.py
+++ b/backend/organization/tests/test_event_registration_sold_out.py
@@ -178,9 +178,10 @@ class TestEvaluateRegistrationStatusUnit(_EventRegistrationUnitBase):
         )
         self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.FULL)
 
-    # ── 6: Two required inventory fields, one sold out, one with stock → OPEN
+    # ── 6: Two required inventory fields, one sold out → FULL (per-field OR)
 
-    def test_two_required_fields_one_with_stock_returns_open(self):
+    def test_two_required_fields_one_sold_out_returns_full(self):
+        """Any single required field being sold out blocks registration."""
         field_a = self._create_inventory_field(order=0, label="Inv A")
         opt_a = self._create_option(field_a, available_amount=1, order=0, title="A1")
         reg = self._register()
@@ -189,7 +190,7 @@ class TestEvaluateRegistrationStatusUnit(_EventRegistrationUnitBase):
         )
         field_b = self._create_inventory_field(order=1, label="Inv B")
         self._create_option(field_b, available_amount=5, order=0, title="B1")
-        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.OPEN)
+        self.assertEqual(evaluate_registration_status(self.rc), RegistrationStatus.FULL)
 
     # ── 7: Required inventory field with null option → OPEN (unlimited) ────
 
@@ -762,13 +763,13 @@ class TestConfigPatchRespectsCapacitySoldOut(_IntegrationBase):
         self.rc.refresh_from_db()
         self.assertEqual(self.rc.status, RegistrationStatus.OPEN)
 
-    # ── Explicit status="open" in PATCH body skips auto-adjustment ─────────
+    # ── Organiser overrides FULL→OPEN with raised capacity → reopens ──────
 
-    def test_explicit_status_in_patch_skips_auto_adjust(self):
-        """When the organiser explicitly sends status, auto-adjust is skipped."""
+    def test_override_full_to_open_with_raised_capacity_reopens(self):
+        """Organiser reopens a full event and raises max_participants —
+        capacity check confirms OPEN."""
         self.rc.max_participants = 1
         self.rc.save(update_fields=["max_participants"])
-        self._register_user(self._make_user())
         self._register_user(self._make_user())
 
         self.client.login(username="organiser_integ", password="testpassword")
@@ -780,6 +781,118 @@ class TestConfigPatchRespectsCapacitySoldOut(_IntegrationBase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.rc.refresh_from_db()
         self.assertEqual(self.rc.status, RegistrationStatus.OPEN)
+
+    # ── Organiser reopens closed event but fields sold out → stays FULL ───
+
+    def test_reopen_closed_event_with_sold_out_fields_stays_full(self):
+        """When the organiser reopens a closed event whose required fields
+        are sold out, the capacity check snaps status to FULL."""
+        field = self._create_timeslot_field()
+        start = timezone.now() + timedelta(days=31)
+        end = timezone.now() + timedelta(days=31, hours=1)
+        opt = RegistrationFieldOption.objects.create(
+            field=field,
+            title="S1",
+            order=0,
+            available_amount=1,
+            start_time=start,
+            end_time=end,
+        )
+        user1 = self._make_user()
+        reg1 = self._register_user(user1)
+        RegistrationFieldAnswer.objects.create(
+            registration=reg1, field=field, value_option=opt
+        )
+        self.rc.status = RegistrationStatus.CLOSED
+        self.rc.save(update_fields=["status"])
+
+        self.client.login(username="organiser_integ", password="testpassword")
+        response = self.client.patch(
+            self.config_patch_url,
+            {
+                "status": "open",
+                "fields": [
+                    {
+                        "id": field.id,
+                        "field_type": "time_slot_select",
+                        "order": 0,
+                        "is_required": True,
+                        "label": "TS",
+                        "settings": {"title": "Slot"},
+                        "options": [
+                            {
+                                "id": opt.id,
+                                "title": "S1",
+                                "order": 0,
+                                "available_amount": 1,
+                                "start_time": start.isoformat(),
+                                "end_time": end.isoformat(),
+                            }
+                        ],
+                    }
+                ],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.FULL)
+
+    # ── Frontend echoes current status (OPEN→OPEN) → auto-adjust still runs ─
+
+    def test_unchanged_status_echo_does_not_skip_auto_adjust(self):
+        """When the frontend echoes back the current status (e.g. sends
+        "status":"open" while stored status is already open), auto-adjustment
+        must still run — the organiser didn't intend to override status."""
+        field = self._create_timeslot_field()
+        start = timezone.now() + timedelta(days=31)
+        end = timezone.now() + timedelta(days=31, hours=1)
+        opt = RegistrationFieldOption.objects.create(
+            field=field,
+            title="S1",
+            order=0,
+            available_amount=2,
+            start_time=start,
+            end_time=end,
+        )
+        user1 = self._make_user()
+        reg1 = self._register_user(user1)
+        RegistrationFieldAnswer.objects.create(
+            registration=reg1, field=field, value_option=opt
+        )
+        # 1 booked out of 2 — still open
+
+        self.client.login(username="organiser_integ", password="testpassword")
+        response = self.client.patch(
+            self.config_patch_url,
+            {
+                "status": "open",
+                "fields": [
+                    {
+                        "id": field.id,
+                        "field_type": "time_slot_select",
+                        "order": 0,
+                        "is_required": True,
+                        "label": "TS",
+                        "settings": {"title": "Slot"},
+                        "options": [
+                            {
+                                "id": opt.id,
+                                "title": "S1",
+                                "order": 0,
+                                "available_amount": 1,
+                                "start_time": start.isoformat(),
+                                "end_time": end.isoformat(),
+                            }
+                        ],
+                    }
+                ],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.FULL)
 
     # ── CLOSED status is not overwritten by auto-adjust ────────────────────
 
@@ -796,3 +909,60 @@ class TestConfigPatchRespectsCapacitySoldOut(_IntegrationBase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.rc.refresh_from_db()
         self.assertEqual(self.rc.status, RegistrationStatus.CLOSED)
+
+    # ── PATCH reduces option available_amount → triggers sold-out ──────────
+
+    def test_patch_reducing_option_amount_triggers_sold_out(self):
+        """Reducing available_amount on a time slot option via PATCH should
+        trigger the sold-out check and set status to FULL if all slots are
+        now booked."""
+        field = self._create_timeslot_field()
+        start = timezone.now() + timedelta(days=31)
+        end = timezone.now() + timedelta(days=31, hours=1)
+        opt = RegistrationFieldOption.objects.create(
+            field=field,
+            title="S1",
+            order=0,
+            available_amount=10,
+            start_time=start,
+            end_time=end,
+        )
+        user1 = self._make_user()
+        reg1 = self._register_user(user1)
+        RegistrationFieldAnswer.objects.create(
+            registration=reg1, field=field, value_option=opt
+        )
+        # 1 booked out of 10 — still open
+
+        self.client.login(username="organiser_integ", password="testpassword")
+        response = self.client.patch(
+            self.config_patch_url,
+            {
+                "fields": [
+                    {
+                        "id": field.id,
+                        "field_type": "time_slot_select",
+                        "order": 0,
+                        "is_required": True,
+                        "label": "TS",
+                        "settings": {"title": "Slot"},
+                        "options": [
+                            {
+                                "id": opt.id,
+                                "title": "S1",
+                                "order": 0,
+                                "available_amount": 1,
+                                "start_time": start.isoformat(),
+                                "end_time": end.isoformat(),
+                            }
+                        ],
+                    }
+                ]
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        opt.refresh_from_db()
+        self.assertEqual(opt.available_amount, 1)
+        self.rc.refresh_from_db()
+        self.assertEqual(self.rc.status, RegistrationStatus.FULL)

--- a/backend/organization/utility/event_registration.py
+++ b/backend/organization/utility/event_registration.py
@@ -1,0 +1,115 @@
+from typing import Union
+
+from django.db.models import Sum
+
+from organization.models.event_registration import (
+    EventRegistration,
+    EventRegistrationConfig,
+    RegistrationStatus,
+)
+from organization.models.registration_field import (
+    RegistrationFieldType,
+)
+
+
+def _is_option_sold_out(field, option):
+    """Return True if a single option has zero remaining capacity."""
+    if option.available_amount is None:
+        return False
+
+    active_answers = option.answers.filter(
+        registration__cancelled_at__isnull=True,
+    )
+    if field.field_type == RegistrationFieldType.INVENTORY:
+        booked = active_answers.aggregate(booked=Sum("value_number"))["booked"] or 0
+    else:
+        booked = active_answers.count()
+
+    return option.available_amount - booked <= 0
+
+
+def _are_required_fields_sold_out(rc: EventRegistrationConfig) -> bool:
+    """True if ALL required fields in at least one capacity-limited type group
+    (inventory OR time slot) are fully sold out.
+
+    A required field is sold out when every one of its options has zero
+    remaining capacity.  Fields with no options or with unlimited options
+    (available_amount=None) are never sold out.
+
+    The check is an OR across field-type groups: if every required inventory
+    field is sold out, the event is sold out regardless of time-slot
+    availability, and vice-versa.  This is because a guest must fill in every
+    required field — if any single required field has no available options,
+    registration is impossible.
+
+    Short-circuits: returns True as soon as one entire type group is sold out.
+    """
+    required_fields = rc.fields.filter(
+        field_type__in=[
+            RegistrationFieldType.INVENTORY,
+            RegistrationFieldType.TIME_SLOT_SELECT,
+        ],
+        is_required=True,
+    ).prefetch_related("options")
+
+    if not required_fields.exists():
+        return False
+
+    fields_by_type: dict[str, list] = {}
+    for field in required_fields:
+        fields_by_type.setdefault(field.field_type, []).append(field)
+
+    for _field_type, fields in fields_by_type.items():
+        group_sold_out = True
+        for field in fields:
+            options = field.options.all()
+            if not options.exists():
+                group_sold_out = False
+                break
+
+            for option in options:
+                if not _is_option_sold_out(field, option):
+                    group_sold_out = False
+                    break
+
+            if not group_sold_out:
+                break
+
+        if group_sold_out:
+            return True
+
+    return False
+
+
+def evaluate_registration_status(
+    rc: EventRegistrationConfig,
+) -> Union[RegistrationStatus, str]:
+    """Return the registration status the event should have right now.
+
+    Considers max_participants, required-inventory availability, and
+    required time-slot availability.
+
+    Returns RegistrationStatus.FULL or RegistrationStatus.OPEN.
+
+    Does NOT consider CLOSED or ENDED — those are set by other mechanisms
+    (manual close, deadline) and are preserved by the caller.
+
+    The caller is responsible for gating on auto-managed statuses: only
+    apply the result when the current status is OPEN or FULL.
+    """
+    max_participants_full = False
+    if rc.max_participants is not None:
+        active_count = EventRegistration.objects.filter(
+            registration_config=rc,
+            cancelled_at__isnull=True,
+        ).count()
+        if active_count >= rc.max_participants:
+            max_participants_full = True
+
+    if max_participants_full:
+        return RegistrationStatus.FULL
+
+    if _are_required_fields_sold_out(rc):
+        return RegistrationStatus.FULL
+
+    return RegistrationStatus.OPEN

--- a/backend/organization/utility/event_registration.py
+++ b/backend/organization/utility/event_registration.py
@@ -29,20 +29,15 @@ def _is_option_sold_out(field, option):
 
 
 def _are_required_fields_sold_out(rc: EventRegistrationConfig) -> bool:
-    """True if ALL required fields in at least one capacity-limited type group
-    (inventory OR time slot) are fully sold out.
+    """True if any required capacity-limited field is fully sold out.
 
     A required field is sold out when every one of its options has zero
     remaining capacity.  Fields with no options or with unlimited options
     (available_amount=None) are never sold out.
 
-    The check is an OR across field-type groups: if every required inventory
-    field is sold out, the event is sold out regardless of time-slot
-    availability, and vice-versa.  This is because a guest must fill in every
-    required field — if any single required field has no available options,
-    registration is impossible.
-
-    Short-circuits: returns True as soon as one entire type group is sold out.
+    A guest must fill in every required field — if even one required field
+    has no available options, registration is impossible.  So this is a
+    per-field OR: returns True as soon as ANY required field is sold out.
     """
     required_fields = rc.fields.filter(
         field_type__in=[
@@ -55,27 +50,18 @@ def _are_required_fields_sold_out(rc: EventRegistrationConfig) -> bool:
     if not required_fields.exists():
         return False
 
-    fields_by_type: dict[str, list] = {}
     for field in required_fields:
-        fields_by_type.setdefault(field.field_type, []).append(field)
+        options = field.options.all()
+        if not options.exists():
+            continue
 
-    for _field_type, fields in fields_by_type.items():
-        group_sold_out = True
-        for field in fields:
-            options = field.options.all()
-            if not options.exists():
-                group_sold_out = False
+        field_sold_out = True
+        for option in options:
+            if not _is_option_sold_out(field, option):
+                field_sold_out = False
                 break
 
-            for option in options:
-                if not _is_option_sold_out(field, option):
-                    group_sold_out = False
-                    break
-
-            if not group_sold_out:
-                break
-
-        if group_sold_out:
+        if field_sold_out:
             return True
 
     return False

--- a/backend/organization/views/event_registration_views.py
+++ b/backend/organization/views/event_registration_views.py
@@ -44,6 +44,7 @@ from organization.utility.email import (
     send_guest_cancellation_notification,
     send_organizer_message_to_guest,
 )
+from organization.utility.event_registration import evaluate_registration_status
 
 logger = logging.getLogger(__name__)
 
@@ -149,19 +150,20 @@ class EventRegistrationsView(APIView):
             )
 
         # ── 5. Capacity check (inside the lock; active registrations only) ───
-        if rc.max_participants is not None:
-            current_count = EventRegistration.objects.filter(
-                registration_config=rc,
-                cancelled_at__isnull=True,
-            ).count()
-            if current_count >= rc.max_participants:
-                # Ensure status reflects reality even if it was missed earlier.
+        # Use the consolidated utility which checks max_participants AND
+        # required capacity-limited fields (inventory, time slots).
+        suggested_status = evaluate_registration_status(rc)
+        if suggested_status == RegistrationStatus.FULL:
+            if rc.status in (
+                RegistrationStatus.OPEN,
+                RegistrationStatus.FULL,
+            ):
                 rc.status = RegistrationStatus.FULL
                 rc.save(update_fields=["status", "updated_at"])
-                return Response(
-                    {"message": "Sorry, the event is now fully booked."},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
+            return Response(
+                {"message": "Sorry, the event is now fully booked."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         # ── 6. Validate custom-field answers payload (if provided) ──────────
         submission_serializer = EventRegistrationSubmissionSerializer(
@@ -264,9 +266,12 @@ class EventRegistrationsView(APIView):
                 cancelled_at__isnull=True,
             ).count()
             available_seats = max(0, rc.max_participants - new_count)
-            if available_seats == 0:
-                rc.status = RegistrationStatus.FULL
-                rc.save(update_fields=["status", "updated_at"])
+
+        # Check all capacity conditions (max_participants + required fields).
+        suggested_status = evaluate_registration_status(rc)
+        if suggested_status == RegistrationStatus.FULL:
+            rc.status = RegistrationStatus.FULL
+            rc.save(update_fields=["status", "updated_at"])
 
         logger.info(
             "[EventRegistration] User %s registered for project '%s'",
@@ -463,13 +468,10 @@ class EventRegistrationsView(APIView):
         reg.cancelled_by = request.user
         reg.save(update_fields=["cancelled_at", "cancelled_by"])
 
-        # ── 8. Revert FULL → OPEN if cancellation freed a seat ──────────────
-        if rc.status == RegistrationStatus.FULL and rc.max_participants is not None:
-            active_count = EventRegistration.objects.filter(
-                registration_config=rc,
-                cancelled_at__isnull=True,
-            ).count()
-            if active_count < rc.max_participants:
+        # ── 8. Revert FULL → OPEN if cancellation freed capacity ────────────
+        if rc.status == RegistrationStatus.FULL:
+            suggested_status = evaluate_registration_status(rc)
+            if suggested_status == RegistrationStatus.OPEN:
                 rc.status = RegistrationStatus.OPEN
                 rc.save(update_fields=["status", "updated_at"])
 
@@ -944,13 +946,10 @@ class AdminCancelRegistrationView(APIView):
         reg.cancelled_by = request.user
         reg.save(update_fields=["cancelled_at", "cancelled_by"])
 
-        # ── 7. Revert FULL → OPEN if cancellation freed a seat ──────────────
-        if rc.status == RegistrationStatus.FULL and rc.max_participants is not None:
-            active_count = EventRegistration.objects.filter(
-                registration_config=rc,
-                cancelled_at__isnull=True,
-            ).count()
-            if active_count < rc.max_participants:
+        # ── 7. Revert FULL → OPEN if cancellation freed capacity ────────────
+        if rc.status == RegistrationStatus.FULL:
+            suggested_status = evaluate_registration_status(rc)
+            if suggested_status == RegistrationStatus.OPEN:
                 rc.status = RegistrationStatus.OPEN
                 rc.save(update_fields=["status", "updated_at"])
 

--- a/doc/spec/20260615_1313_close_event_when_required_inventory_sold_out.md
+++ b/doc/spec/20260615_1313_close_event_when_required_inventory_sold_out.md
@@ -1,0 +1,324 @@
+# Close Event for Registration When Required Capacity-Limited Fields Are Sold Out
+
+**Date**: 2026-06-15  
+**Status**: DRAFT  
+**Type**: Backend — enhancement  
+**GitHub Issue**: [#2058](https://github.com/climateconnect/climateconnect/issues/2058)
+
+---
+
+## Problem Statement
+
+An event has a max number of registrations and one or more capacity-limited fields (inventory and time slot). The system already sets the event registration status to `full` when `max_participants` is reached. However, there is a corner case: an event can run out of all items in a **required** inventory field, or all slots in a **required** time slot field, before `max_participants` is reached. When this happens, the registration stays `open` but no guest can actually complete registration — they hit a validation error on the field check.
+
+### Why it matters
+
+- **Dead-end UX**: Guests arrive at the registration form, fill it out, and get an error they cannot resolve. The event looks open but is functionally closed.
+- **No organiser visibility**: The organiser sees the event as "open" even though no one can register. They may not understand why registrations stopped.
+- **Inconsistency**: The system already handles the `max_participants` sold-out case — inventory and time slot sold-out should be treated the same way.
+
+### Current state
+
+- `EventRegistrationConfig.status` tracks registration state: `open`, `closed`, `full` (see `RegistrationStatus` in `backend/organization/models/event_registration.py`).
+- `RegistrationStatus.FULL` is set automatically when `max_participants` is reached (line 268 of `backend/organization/views/event_registration_views.py`).
+- `RegistrationStatus.FULL` is reverted to `OPEN` when a cancellation frees capacity (lines 466–474 and 947–955 of the same file).
+- **The "is the event full?" logic is duplicated inline at 5 separate call sites** (post-registration, registration validation guard, self-cancellation, admin cancellation, config PATCH serializer). There is no single utility that determines the correct status. Each site independently queries `max_participants` against active registration count and decides whether to set or revert `FULL`. Adding the inventory/timeslot check to each inline site would worsen this duplication.
+- `RegistrationField` has `is_required` (boolean) and `field_type` (including `inventory` and `time_slot_select`). `RegistrationFieldOption` has `available_amount` (nullable integer — null means unlimited).
+- At registration time, the view checks inventory availability and rejects the request if stock is insufficient (lines 206–222 of `event_registration_views.py`). But this only blocks the individual registration — it does not update the event status.
+- The remaining capacity is computed differently by field type: inventory fields use `available_amount - SUM(value_number of active answers)` (quantity-based), while time slot fields use `available_amount - COUNT(active answers)` (one seat per person).
+
+---
+
+## Scope
+
+### In scope
+
+1. After a successful registration, check whether all required capacity-limited fields (inventory and time slot) have exhausted all their options. If so, set the event registration status to `full`.
+2. After a cancellation (self or admin), check whether the event was set to `full` due to capacity-limited fields. If a required field now has available capacity again, revert to `open` — but only if `max_participants` also allows it.
+3. The same check when `max_participants` is PATCHed via the config serializer (mirroring the existing auto-adjustment logic at `serializers/event_registration.py:769–791`).
+
+### Out of scope (for now)
+
+- Frontend changes — the `full` status is already handled by the frontend (shown as "Sold out" / "Ausgebucht").
+- Email notifications to the organiser about inventory/timeslot-based sold-out (could be a follow-up).
+- Non-required inventory and time slot fields — the issue explicitly states these do not block registration.
+- `checkbox` and `option_select` field types — these do not have a capacity concept (`available_amount` is not used for them).
+
+---
+
+## Acceptance Criteria
+
+### AC-1: Registration triggers capacity sold-out check
+
+After a successful registration is saved, the system checks all required capacity-limited fields (inventory and time slot) on the event. If **every option** across **all required inventory fields** has `remaining_amount == 0`, OR **every option** across **all required time slot fields** has `remaining_amount == 0`, the event registration status is set to `full`.
+
+- "Every option" means: for each required field, all its `RegistrationFieldOption` entries have zero remaining capacity.
+- A field with **no options** is considered non-blocking (cannot be sold out).
+- **Inventory remaining**: `available_amount - SUM(value_number of active answers for that option)`. Quantity-based.
+- **Time slot remaining**: `available_amount - COUNT(active answers for that option)`. One seat per person.
+- Options with `available_amount = null` are unlimited and never sold out.
+
+### AC-2: Cancellation reverts capacity sold-out
+
+When a registration is cancelled (by guest or admin) and the event's status is `full`, the system checks whether any required capacity-limited field now has at least one option with `remaining_amount > 0`. If so, and the event also has available participant seats (`max_participants` is null or `active_count < max_participants`), the status reverts to `open`.
+
+- This mirrors the existing `max_participants` revert logic exactly.
+- The revert is gated on **both** conditions: capacity available AND seats available. An event that is full due to `max_participants` should not reopen just because inventory freed up.
+
+### AC-3: Config PATCH respects capacity sold-out
+
+When an organiser PATCHes `EventRegistrationConfig` (e.g. changes `max_participants`), the existing auto-adjustment logic (lines 769–791 of `serializers/event_registration.py`) is extended to also consider capacity-limited field availability. If the new `max_participants` would allow registrations but all required inventory and/or time slot fields are fully sold out, the status stays `full`.
+
+### AC-4: No false positives
+
+- Events with **no** required inventory or time slot fields behave exactly as before (only `max_participants` triggers sold-out).
+- Events where required capacity-limited fields have at least one option with remaining capacity are not affected.
+- Non-required fields do not influence the sold-out check regardless of their stock levels.
+- Unlimited options (`available_amount = null`) never count as sold out.
+
+---
+
+## Constraints
+
+- **Backend only** — no frontend changes. The `full` status and its UI treatment already exist.
+- **Consolidate into a single utility** — instead of adding the inventory/timeslot check to each of the 5 existing inline sites, create one utility function that determines the correct registration status considering `max_participants`, required inventory fields, and required time slot fields. All call sites call this utility. This also eliminates the existing `max_participants` duplication.
+- **No new models or migrations** — this is a logic-only change. No schema changes needed.
+- **No new dependencies** — uses existing ORM queries and aggregation.
+- **Performance** — the capacity check queries `RegistrationFieldAnswer` with aggregation per option. For typical events with a handful of fields and options, this is negligible. No caching needed.
+
+---
+
+## Domain Context
+
+### Required capacity-limited field semantics
+
+A `RegistrationField` with `is_required = True` and a capacity-limited `field_type` (`inventory` or `time_slot_select`) means the guest **must** select at least one option from this field to complete registration. When all options in such a field have zero remaining capacity, no new guest can register — the registration view's validation (lines 206–222) will reject them.
+
+A capacity-limited field with `is_required = False` does not block registration. Guests can skip it. So even if all its options are sold out, the event should remain open.
+
+The two field types differ in how capacity is consumed:
+- **Inventory** (`field_type = "inventory"`): quantity-based. Each answer has a `value_number` (e.g. "2 t-shirts"). Remaining = `available_amount - SUM(value_number of active answers)`.
+- **Time slot** (`field_type = "time_slot_select"`): seat-based. Each answer consumes one slot. Remaining = `available_amount - COUNT(active answers)`.
+
+### How remaining capacity is computed
+
+For a given `RegistrationFieldOption`:
+
+**Inventory fields:**
+```
+remaining = available_amount - SUM(value_number WHERE registration is active)
+```
+
+**Time slot fields:**
+```
+remaining = available_amount - COUNT(registration WHERE registration is active)
+```
+
+- `available_amount = null` → unlimited (remaining is always "enough").
+- Active registration = `cancelled_at IS NULL`.
+- `value_number` is the quantity the guest selected (e.g. "2 t-shirts") — only relevant for inventory fields.
+
+This computation already exists in `RegistrationFieldOptionSerializer.get_remaining_amount()` (in `serializers/registration_field.py:134–148`) and in the view's validation (lines 206–222). The sold-out check reuses the same aggregation pattern, with the field-type-dependent calculation.
+
+### Existing sold-out flow (max_participants) — duplicated inline
+
+The current "is the event full?" check is copy-pasted at 5 sites, each with slightly different shape but the same core logic (count active registrations vs `max_participants`):
+
+1. **Post-registration** (step 8, line 259): inline count → if equals `max_participants`, set `status = FULL`.
+2. **Registration validation guard** (step 5, line 151): inline count → if already at capacity, set `status = FULL` and return error.
+3. **Self-cancellation** (step 8, line 466): inline count → if `FULL` and count < `max_participants`, revert to `OPEN`.
+4. **Admin cancellation** (step 7, line 947): identical copy of #3.
+5. **Config PATCH** (serializer, line 769): inline count → auto-adjust status when `max_participants` changes.
+
+Adding the inventory/timeslot check to each of these as additional inline code would compound the duplication. Instead, a single utility replaces all 5 inline checks.
+
+### When multiple conditions can trigger sold-out
+
+An event can be `FULL` due to:
+- `max_participants` reached, or
+- all required inventory fields sold out, or
+- all required time slot fields sold out, or
+- any combination of the above.
+
+On revert (cancellation), the status should only return to `OPEN` when **all** conditions allow it: seats available AND inventory available AND time slots available. This means:
+- If the event was full due to inventory, and a cancellation frees inventory, but `max_participants` is reached → stay `full`.
+- If the event was full due to `max_participants`, and a cancellation frees a seat, but inventory is still sold out → stay `full`.
+- If the event was full due to time slots, and a cancellation frees a slot, but inventory is sold out → stay `full`.
+- If all conditions are resolved → revert to `open`.
+
+---
+
+## AI Agent Insights
+
+### Why consolidate into one utility
+
+The existing codebase has 5 inline copies of the "is the event at capacity?" check. Each was written independently and they've drifted slightly in shape (some check `max_participants is not None` explicitly, some wrap the count in a helper). Adding the inventory check to each would mean 5 more inline code blocks, all of which must stay in sync. A single `evaluate_registration_status()` function means:
+- One place to change when a new sold-out condition is added in the future.
+- One place to test the decision logic.
+- Call sites become simpler: they just ask "what should the status be?" and apply the result.
+
+The existing `_compute_available_seats` helper (line 311) is retained as-is — it serves a different purpose (returning the numeric value for the API response) and is not a replacement for status evaluation.
+
+### Simplification: aggregate across all required capacity-limited fields
+
+Rather than checking each field independently, the check can aggregate across all required capacity-limited fields in a single query. The logic is:
+
+```python
+# Pseudocode — not a prescription
+required_fields = rc.fields.filter(
+    field_type__in=["inventory", "time_slot_select"], is_required=True
+)
+for field in required_fields:
+    has_available_option = False
+    for option in field.options.all():
+        if option.available_amount is None:
+            has_available_option = True
+            break
+        if field.field_type == "inventory":
+            booked = (
+                RegistrationFieldAnswer.objects.filter(
+                    value_option=option,
+                    registration__cancelled_at__isnull=True,
+                ).aggregate(total=Sum("value_number"))["total"]
+                or 0
+            )
+        else:  # time_slot_select
+            booked = RegistrationFieldAnswer.objects.filter(
+                value_option=option,
+                registration__cancelled_at__isnull=True,
+            ).count()
+        if option.available_amount - booked > 0:
+            has_available_option = True
+            break
+    if not has_available_option:
+        # This required field is fully sold out
+        continue
+    else:
+        return  # At least one required field has capacity — not sold out
+# All required fields sold out → set FULL
+```
+
+This is a short-circuit: as soon as one required field has capacity, we stop. No unnecessary queries.
+
+### Edge case: no required capacity-limited fields
+
+If there are no required inventory or time slot fields, the check trivially passes (no field is sold out), and the event stays in whatever status the `max_participants` check determined. The function should early-return when `required_fields` is empty.
+
+### Edge case: required field with no options
+
+A required capacity-limited field that has zero `RegistrationFieldOption` entries cannot be "sold out" (there's nothing to sell). The check should skip such fields.
+
+### Why not cache or denormalize
+
+The capacity sold-out check runs only on registration and cancellation — two infrequent operations. The aggregation is lightweight (a few SUM/COUNT queries on indexed columns). Adding a denormalized `is_sold_out` flag would add complexity (keeping it in sync on every answer create/delete) for no measurable performance gain.
+
+### Interaction with the registration validation guard
+
+The existing registration validation guard (step 5, line 151) catches stale `FULL` status. By using `evaluate_registration_status()` here too, the inventory/timeslot check is automatically included: if the status was somehow left as `OPEN` but capacity-limited fields are actually sold out, the validation guard catches it before the guest gets a confusing field-level validation error. This makes the system self-healing.
+
+### The serializer call site
+
+The config PATCH serializer (line 769) currently has its own inline auto-adjustment. After consolidation, the serializer calls `evaluate_registration_status()` instead. One nuance: the serializer only auto-adjusts when no explicit `status` was passed in the request AND the current status is auto-managed (i.e. not `CLOSED` — an organiser-set status). This existing guard is preserved. The utility function itself does not need to know about `CLOSED` or `ENDED` — it returns what the status *should* be based on capacity and field availability, and the caller decides whether to apply it.
+
+---
+
+## Implementation Notes
+
+### Core utility: `evaluate_registration_status`
+
+Create a single function that replaces all 5 inline `max_participants` checks and adds the inventory check. It takes an `EventRegistrationConfig` and returns the status that the event **should** have based on current capacity and inventory.
+
+**Location**: `backend/organization/utility/event_registration.py` (new file). Placed in `utility/` rather than as a view method because it is also called from the serializer (which lives in a different module). A static method on the view would create a circular import.
+
+**Signature**:
+```python
+def evaluate_registration_status(rc: EventRegistrationConfig) -> str:
+    """Return the registration status the event should have right now.
+
+    Considers max_participants, required-inventory availability, and
+    required time-slot availability.
+    Returns RegistrationStatus.FULL or RegistrationStatus.OPEN.
+    Does NOT consider CLOSED or ENDED — those are set by other mechanisms
+    (manual close, deadline) and are preserved by the caller.
+    """
+```
+
+**Return value semantics**:
+- Returns `RegistrationStatus.FULL` if any of:
+  - `max_participants` is set and active registrations >= `max_participants`, OR
+  - all required inventory fields are fully sold out (every option at zero remaining), OR
+  - all required time slot fields are fully sold out (every option at zero remaining).
+- Returns `RegistrationStatus.OPEN` otherwise.
+- Returns `RegistrationStatus.OPEN` if there are no required capacity-limited fields and `max_participants` is not set (unlimited everything).
+
+**Caller responsibility**: The caller checks whether the current status is one that should be auto-managed (i.e. not `CLOSED` or `ENDED`). If the event is currently `OPEN` or `FULL`, the caller applies the utility's result. If the event is `CLOSED` or `ENDED`, the caller leaves the status untouched.
+
+### Capacity sold-out sub-logic: `_are_required_fields_sold_out`
+
+A helper function (private to the utility module) that takes an `EventRegistrationConfig` and returns `True` if all required capacity-limited fields (inventory and time slot) are sold out. Called by `evaluate_registration_status`.
+
+```python
+def _are_required_fields_sold_out(rc: EventRegistrationConfig) -> bool:
+    """True if every required inventory and time slot field has zero remaining capacity across all options."""
+```
+
+**Logic** (short-circuit):
+1. Fetch required inventory and time slot fields with their options (`prefetch_related`).
+2. If no required capacity-limited fields → return `False` (nothing can be sold out).
+3. For each field:
+   a. If the field has no options → skip (can't be sold out).
+   b. If any option has `available_amount is None` → the field is not sold out (unlimited).
+   c. Otherwise, compute remaining capacity per option:
+      - Inventory: `SUM(value_number)` for active answers.
+      - Time slot: `COUNT(active answers)`.
+   d. If any option has remaining > 0 → the field is not sold out.
+   e. If all options are at zero → this field is sold out, continue to next field.
+4. If every required field is sold out → return `True`.
+
+This is a short-circuit: as soon as one required field has capacity, the function returns `False`. No unnecessary queries.
+
+### Integration points — replacing inline logic
+
+Each call site replaces its inline `max_participants` check with a call to `evaluate_registration_status`:
+
+| Location | File | Before | After |
+|----------|------|--------|-------|
+| `EventRegistrationsView.post()` — step 5 (line 151) | `views/event_registration_views.py` | Inline count vs `max_participants` → set `FULL` + error | Call `evaluate_registration_status(rc)`. If `FULL`, set status and return error. |
+| `EventRegistrationsView.post()` — step 8 (line 259) | `views/event_registration_views.py` | Inline count vs `max_participants` → set `FULL` | Call `evaluate_registration_status(rc)`. If `FULL`, set status. |
+| `EventRegistrationsView.delete()` — step 8 (line 466) | `views/event_registration_views.py` | Inline count < `max_participants` → revert to `OPEN` | Call `evaluate_registration_status(rc)`. If `OPEN`, set status. Only acts when current status is `FULL`. |
+| `AdminCancelRegistrationView.patch()` — step 7 (line 947) | `views/event_registration_views.py` | Identical inline count → revert to `OPEN` | Same as self-cancellation. |
+| `EditEventRegistrationConfigSerializer.update()` (line 769) | `serializers/event_registration.py` | Inline count → auto-adjust | Call `evaluate_registration_status(rc)`. Apply result (but only when no explicit `status` was passed and current status is auto-managed). |
+
+### No new tests framework needed
+
+Tests should use the existing Django test framework with Factory Boy. Test cases:
+
+**`evaluate_registration_status` unit tests** (isolated from views):
+1. No `max_participants`, no required capacity-limited fields → returns `OPEN`.
+2. `max_participants=10`, 5 active registrations → returns `OPEN`.
+3. `max_participants=10`, 10 active registrations → returns `FULL`.
+4. Required inventory field, all options have stock → returns `OPEN`.
+5. Required inventory field, all options sold out → returns `FULL`.
+6. Two required inventory fields, one sold out, one with stock → returns `OPEN`.
+7. Required inventory field with `available_amount=null` option → returns `OPEN` (unlimited never sold out).
+8. Required inventory field with zero options → returns `OPEN` (can't be sold out).
+9. Non-required inventory field, all sold out → returns `OPEN` (non-required doesn't count).
+10. `max_participants=10` at capacity AND required inventory sold out → returns `FULL`.
+11. `max_participants=10` at capacity but inventory has stock → returns `FULL`.
+12. Required time slot field, all options sold out → returns `FULL`.
+13. Required time slot field, one option has remaining seats → returns `OPEN`.
+14. Required time slot field with `available_amount=null` option → returns `OPEN`.
+15. Non-required time slot field, all sold out → returns `OPEN`.
+16. Both required inventory and required time slot, inventory sold out but time slots available → returns `OPEN`.
+17. Both required inventory and required time slot, both sold out → returns `FULL`.
+
+**Integration tests** (through views):
+18. Registration fills last required inventory item → status becomes `full`.
+19. Registration fills last required time slot → status becomes `full`.
+20. Registration when `max_participants` not reached but inventory sold out → status becomes `full`.
+21. Cancellation frees inventory item → status reverts to `open` (if seats also available).
+22. Cancellation frees time slot → status reverts to `open` (if seats also available).
+23. Cancellation frees inventory but `max_participants` still full → status stays `full`.
+24. Registration on event with stale `open` status but inventory sold out → returns error and sets `full`.
+25. Config PATCH raises `max_participants` above current count, but inventory sold out → status stays `full`.
+26. Config PATCH sets `max_participants=null`, but time slots sold out → status stays `full`.


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Implements #2058 
