### PR TITLE
make subdomain redirects permanent

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -44,14 +44,14 @@ function buildSubdomainRedirects() {
       { type: "header", key: "Accept-Language", value: "^de" },
     ],
     destination: `${BASE_URL}/de/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
-    permanent: false,
+    permanent: true,
   }));
 
   const subdomainRedirectsEn = LOCATION_HUBS.map((hubSlug) => ({
     source: "/:path*",
     has: [{ type: "host", value: `${hubSlug}.climateconnect.earth` }],
     destination: `${BASE_URL}/en/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
-    permanent: false,
+    permanent: true,
   }));
 
   return [...potsdamProjectRedirects, ...subdomainRedirectsDe, ...subdomainRedirectsEn];


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

minor adjustment
