### PR TITLE
Fix line break handling and also use short summary as fallback

### DIFF
--- a/frontend/src/utils/calendarHelpers.test.ts
+++ b/frontend/src/utils/calendarHelpers.test.ts
@@ -1,37 +1,8 @@
 import {
-  escapeIcalText,
   toGoogleCalendarDate,
   buildGoogleCalendarUrl,
   buildIcalEventData,
 } from "./calendarHelpers";
-
-describe("escapeIcalText", () => {
-  it("returns empty string for null/undefined", () => {
-    expect(escapeIcalText(null)).toBe("");
-    expect(escapeIcalText(undefined)).toBe("");
-    expect(escapeIcalText("")).toBe("");
-  });
-
-  it("escapes backslashes", () => {
-    expect(escapeIcalText("foo\\bar")).toBe("foo\\\\bar");
-  });
-
-  it("escapes semicolons", () => {
-    expect(escapeIcalText("foo;bar")).toBe("foo\\;bar");
-  });
-
-  it("escapes commas", () => {
-    expect(escapeIcalText("foo,bar")).toBe("foo\\,bar");
-  });
-
-  it("escapes newlines", () => {
-    expect(escapeIcalText("foo\nbar")).toBe("foo\\nbar");
-  });
-
-  it("escapes multiple special characters", () => {
-    expect(escapeIcalText("a;b,c\\d\ne")).toBe("a\\;b\\,c\\\\d\\ne");
-  });
-});
 
 describe("toGoogleCalendarDate", () => {
   it("returns empty string for null/undefined", () => {
@@ -97,6 +68,33 @@ describe("buildGoogleCalendarUrl", () => {
     const params = new URL(url).searchParams;
     expect(params.get("details")).toBe("https://example.com/event");
   });
+
+  it("falls back to short_description when description is not set", () => {
+    const event = {
+      name: "Event",
+      start_date: "2026-07-15T10:00:00Z",
+      end_date: "2026-07-15T12:00:00Z",
+      short_description: "A short summary.",
+    };
+    const url = buildGoogleCalendarUrl(event, "https://example.com/event");
+    const params = new URL(url).searchParams;
+    expect(params.get("details")).toContain("A short summary.");
+    expect(params.get("details")).toContain("https://example.com/event");
+  });
+
+  it("prefers description over short_description when both are set", () => {
+    const event = {
+      name: "Event",
+      start_date: "2026-07-15T10:00:00Z",
+      end_date: "2026-07-15T12:00:00Z",
+      description: "Full description.",
+      short_description: "Short summary.",
+    };
+    const url = buildGoogleCalendarUrl(event, "https://example.com/event");
+    const params = new URL(url).searchParams;
+    expect(params.get("details")).toContain("Full description.");
+    expect(params.get("details")).not.toContain("Short summary.");
+  });
 });
 
 describe("buildIcalEventData", () => {
@@ -139,5 +137,52 @@ describe("buildIcalEventData", () => {
     };
     const data = buildIcalEventData(event, "https://example.com/event");
     expect(data.description).toBe("https://example.com/event");
+  });
+
+  it("preserves actual newlines in description (no pre-escaping)", () => {
+    const event = {
+      name: "Event",
+      start_date: "2026-07-15T10:00:00Z",
+      end_date: "2026-07-15T12:00:00Z",
+      description: "Line one.\nLine two.",
+    };
+    const data = buildIcalEventData(event, "https://example.com/event");
+    expect(data.description).toBe("Line one.\nLine two.\n\nhttps://example.com/event");
+  });
+
+  it("preserves commas in description (no pre-escaping)", () => {
+    const event = {
+      name: "Event",
+      start_date: "2026-07-15T10:00:00Z",
+      end_date: "2026-07-15T12:00:00Z",
+      description: "First, second, third.",
+    };
+    const data = buildIcalEventData(event, "https://example.com/event");
+    expect(data.description).toContain("First, second, third.");
+  });
+
+  it("falls back to short_description when description is not set", () => {
+    const event = {
+      name: "Event",
+      start_date: "2026-07-15T10:00:00Z",
+      end_date: "2026-07-15T12:00:00Z",
+      short_description: "A short summary.",
+    };
+    const data = buildIcalEventData(event, "https://example.com/event");
+    expect(data.description).toContain("A short summary.");
+    expect(data.description).toContain("https://example.com/event");
+  });
+
+  it("prefers description over short_description when both are set", () => {
+    const event = {
+      name: "Event",
+      start_date: "2026-07-15T10:00:00Z",
+      end_date: "2026-07-15T12:00:00Z",
+      description: "Full description.",
+      short_description: "Short summary.",
+    };
+    const data = buildIcalEventData(event, "https://example.com/event");
+    expect(data.description).toContain("Full description.");
+    expect(data.description).not.toContain("Short summary.");
   });
 });

--- a/frontend/src/utils/calendarHelpers.ts
+++ b/frontend/src/utils/calendarHelpers.ts
@@ -1,12 +1,3 @@
-export function escapeIcalText(text: string | null | undefined): string {
-  if (!text) return "";
-  return text
-    .replace(/\\/g, "\\\\")
-    .replace(/;/g, "\\;")
-    .replace(/,/g, "\\,")
-    .replace(/\n/g, "\\n");
-}
-
 export function toGoogleCalendarDate(dateStr: string | null | undefined): string {
   if (!dateStr) return "";
   const d = new Date(dateStr);
@@ -27,16 +18,22 @@ type CalendarEvent = {
   start_date?: string;
   end_date?: string;
   description?: string;
+  short_description?: string;
   location?: string;
   is_online?: boolean;
 };
 
+function getEventDescription(event: CalendarEvent): string | undefined {
+  return event.description || event.short_description || undefined;
+}
+
 export function buildGoogleCalendarUrl(event: CalendarEvent, eventUrl: string): string {
+  const desc = getEventDescription(event);
   const params = new URLSearchParams({
     action: "TEMPLATE",
     text: event.name || "",
     dates: `${toGoogleCalendarDate(event.start_date)}/${toGoogleCalendarDate(event.end_date)}`,
-    details: event.description ? `${event.description}\n\n${eventUrl}` : eventUrl,
+    details: desc ? `${desc}\n\n${eventUrl}` : eventUrl,
     location: event.is_online ? "Online" : event.location || "",
   });
   return `https://calendar.google.com/calendar/render?${params.toString()}`;
@@ -53,14 +50,13 @@ export function buildIcalEventData(
   description: string;
   location: string;
 } {
+  const desc = getEventDescription(event);
   return {
     start: new Date(event.start_date!),
     end: new Date(event.end_date!),
     summary: event.name || "",
     url: eventUrl,
-    description: event.description
-      ? escapeIcalText(event.description) + "\\n\\n" + eventUrl
-      : eventUrl,
+    description: desc ? desc + "\n\n" + eventUrl : eventUrl,
     location: event.is_online ? "Online" : event.location || "",
   };
 }


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Bug fix and improvement for add to calendar feature #2081 
