### PR TITLE
Improve display of organisation projects

### DIFF
--- a/backend/organization/views/organization_views.py
+++ b/backend/organization/views/organization_views.py
@@ -968,7 +968,7 @@ class ListOrganizationProjectsAPIView(ListAPIView):
         return ProjectParents.objects.filter(
             parent_organization__url_slug=self.kwargs["url_slug"],
             project__is_draft=False,
-        ).order_by("id")
+        ).order_by("-project__created_at")
 
 
 class ListOrganizationMembersAPIView(ListAPIView):

--- a/doc/spec/20260701_1622_organization_projects_newest_first.md
+++ b/doc/spec/20260701_1622_organization_projects_newest_first.md
@@ -1,0 +1,67 @@
+# Organization Projects: Newest First + Load More
+
+**Date**: 2026-07-01
+**Status**: DRAFT
+**Type**: Enhancement — full stack
+
+---
+
+## Problem Statement
+
+Two issues with how organization projects are displayed:
+
+1. **Sorting**: The endpoint `GET /api/organizations/{slug}/projects/` returns projects sorted by `ProjectParents.id` ascending — oldest first. Visitors to an organization page expect to see the most recent projects first.
+
+2. **Pagination**: The organization page (`frontend/pages/organizations/[organizationUrl].tsx`) only fetches the first page (12 projects). Pagination metadata (`next`, `count`) is discarded. Organizations with more than 12 projects have the rest silently hidden with no way to access them.
+
+### Current behavior
+
+- Backend view: `ListOrganizationProjectsAPIView` in `backend/organization/views/organization_views.py:960`
+- Queryset: `ProjectParents.objects.filter(...).order_by("id")`
+- Frontend: `getProjectsByOrganization` in `frontend/pages/organizations/[organizationUrl].tsx:392` — calls the API once server-side, extracts only `resp.data.results`, discards `next`/`count`
+- Rendering: `<ProjectPreviews projects={projects} hubUrl={hubUrl} />` — no `loadFunc`/`hasMore`/`isLoading` props passed, so infinite scroll is disabled
+- Result: oldest 12 projects shown, rest hidden
+
+### Desired behavior
+
+- Projects sorted by creation date, newest first
+- "Load more" / infinite scroll to fetch subsequent pages (20 per page)
+- Visitors see recent activity immediately and can browse all projects
+
+---
+
+## Acceptance Criteria
+
+### Sorting
+1. `GET /api/organizations/{slug}/projects/` returns projects ordered by their `created_at` descending (newest first)
+2. Ordering is consistent across pages and regardless of page size
+
+### Load More
+3. Organization page shows the first 12 projects on initial load (unchanged)
+4. A "Load More" button is displayed below the project list when more projects exist
+5. Clicking the button fetches the next page (12 projects) and appends them to the list
+6. Loading indicator shown on the button while fetching
+7. Button disappears when all projects are loaded (`next` is null in the API response)
+8. No infinite scroll — the page has multiple lists, so a manual button is required
+
+### General
+9. No regression: drafts remain excluded, permissions unchanged, pagination backend unchanged
+
+---
+
+## Constraints
+
+- The `created_at` field on `Project` is `auto_now_add=True` and exists on all projects — no migration needed
+- The queryset currently operates on `ProjectParents`, so ordering must cross the relation to `project__created_at`
+- `ProjectPreviews` already supports `loadFunc`/`hasMore`/`isLoading` props — but uses `useInfiniteScroll` internally. A "Load More" button will need to be placed outside/after the component instead.
+- Backend pagination class (`ProjectsPagination`) already returns `next`/`count` — no backend pagination changes needed
+
+---
+
+## AI Insights
+
+- The `Project` model's default ordering (`["-rating", "-id"]`) is not used by this endpoint because the queryset is on `ProjectParents`, not `Project`. Changing the view's `.order_by()` is the correct lever.
+- Sorting by `project__created_at` will produce a JOIN on the `Project` table. Since every `ProjectParents` row has a non-null `project` FK (required field), this is safe and performant.
+- An index on `Project.created_at` may already exist from Django's `auto_now_add` — worth verifying for pagination performance on large orgs.
+- A "Load More" button pattern is simpler than infinite scroll — state tracks `nextPage` (number) and `hasMore` (boolean). Button click calls the API with `?page=nextPage`, appends results, increments page, sets `hasMore` based on `resp.data.next`.
+- The API always returns `next` (URL or null) in the paginated response — the frontend just needs to check it to know when to stop loading.

--- a/frontend/pages/organizations/[organizationUrl].tsx
+++ b/frontend/pages/organizations/[organizationUrl].tsx
@@ -82,7 +82,7 @@ export async function getServerSideProps(ctx) {
   const hubUrl = ctx.query.hub;
   const [
     organization,
-    projects,
+    projectsData,
     members,
     organizationTypes,
     rolesOptions,
@@ -100,7 +100,8 @@ export async function getServerSideProps(ctx) {
   return {
     props: nullifyUndefinedValues({
       organization: organization,
-      projects: projects,
+      projects: projectsData?.projects ?? null,
+      projectsHasMore: projectsData?.hasMore ?? false,
       members: members,
       organizationTypes: organizationTypes,
       rolesOptions: rolesOptions,
@@ -114,6 +115,7 @@ export async function getServerSideProps(ctx) {
 export default function OrganizationPage({
   organization,
   projects,
+  projectsHasMore,
   members,
   rolesOptions,
   following,
@@ -176,6 +178,7 @@ export default function OrganizationPage({
           isUserFollowing={isUserFollowing}
           organization={organization}
           projects={projects}
+          projectsHasMore={projectsHasMore}
           members={members}
           /*TODO(unused) organizationTypes={organizationTypes} */
           infoMetadata={infoMetadata}
@@ -199,6 +202,7 @@ function OrganizationLayout({
   isUserFollowing,
   organization,
   projects,
+  projectsHasMore,
   members,
   infoMetadata,
   user,
@@ -210,6 +214,11 @@ function OrganizationLayout({
   const classes = useStyles();
   const cookies = new Cookies();
   const router = useRouter();
+
+  const [allProjects, setAllProjects] = useState(projects || []);
+  const [hasMoreProjects, setHasMoreProjects] = useState(projectsHasMore);
+  const [nextPage, setNextPage] = useState(2);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   const getRoleName = (permission) => {
     const permission_to_show = permission === "all" ? "read write" : permission;
@@ -256,6 +265,29 @@ function OrganizationLayout({
     );
 
   const membersWithAdditionalInfo = getMembersWithAdditionalInfo(members);
+
+  const handleLoadMoreProjects = async () => {
+    if (isLoadingMore || !hasMoreProjects) return;
+    setIsLoadingMore(true);
+    try {
+      const resp = await apiRequest({
+        method: "get",
+        url: `/api/organizations/${organization.url_slug}/projects/?page=${nextPage}`,
+        token: cookies.get("auth_token"),
+        locale: locale,
+      });
+      if (resp.data) {
+        const newProjects = parseProjectStubs(resp.data.results);
+        setAllProjects((prev) => [...prev, ...newProjects]);
+        setHasMoreProjects(!!resp.data.next);
+        setNextPage((prev) => prev + 1);
+      }
+    } catch (err) {
+      console.log(err);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  };
 
   const isTinyScreen = useMediaQuery<Theme>(theme.breakpoints.down("sm"));
   const isSmallScreen = useMediaQuery<Theme>(theme.breakpoints.down("md"));
@@ -316,8 +348,22 @@ function OrganizationLayout({
             </Button>
           )}
         </div>
-        {projects && projects.length ? (
-          <ProjectPreviews projects={projects} hubUrl={hubUrl} />
+        {allProjects && allProjects.length ? (
+          <>
+            <ProjectPreviews projects={allProjects} hubUrl={hubUrl} parentHandlesGridItems />
+            {hasMoreProjects && (
+              <Button
+                variant="outlined"
+                color="primary"
+                onClick={handleLoadMoreProjects}
+                disabled={isLoadingMore}
+                fullWidth
+                sx={{ mt: 2 }}
+              >
+                {isLoadingMore ? texts.loading : texts.load_more}
+              </Button>
+            )}
+          </>
         ) : (
           <Typography className={classes.no_content_yet}>
             {texts.this_organization_has_not_listed_any_projects_yet}
@@ -399,7 +445,10 @@ async function getProjectsByOrganization(organizationUrl, token, locale) {
     });
     if (!resp.data) return null;
     else {
-      return parseProjectStubs(resp.data.results);
+      return {
+        projects: parseProjectStubs(resp.data.results),
+        hasMore: !!resp.data.next,
+      };
     }
   } catch (err) {
     console.log(err);

--- a/frontend/public/texts/general_texts.json
+++ b/frontend/public/texts/general_texts.json
@@ -826,5 +826,13 @@
   "search": {
     "en": "Search",
     "de": "Suche"
+  },
+  "load_more": {
+    "en": "Load more",
+    "de": "Mehr laden"
+  },
+  "loading": {
+    "en": "Loading...",
+    "de": "Lädt..."
   }
 }


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Implements #2099 
