### PR TITLE
Rename text input field

### DIFF
--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -1395,8 +1395,8 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       de: "Zeitfenster-Auswahl",
     },
     field_type_text: {
-      en: "Text",
-      de: "Textfeld",
+      en: "Text Input",
+      de: "Texteingabe",
     },
     registration_text_field_title_label: {
       en: "Title (shown to guest)",


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Minor text change after feedback.
