### PR TITLE
localize rich text editor texts

### DIFF
--- a/backend/organization/admin.py
+++ b/backend/organization/admin.py
@@ -116,6 +116,7 @@ class ProjectAdmin(admin.ModelAdmin):
                     "project_type",
                     "short_description",
                     "description",
+                    "description_html",
                     "devlink_component",
                     "image",
                     "thumbnail_image",

--- a/frontend/public/texts/general_texts.json
+++ b/frontend/public/texts/general_texts.json
@@ -35,6 +35,86 @@
     "en": "Website",
     "de": "Webseite"
   },
+  "edit_link_add_title": {
+    "en": "Add link",
+    "de": "Link hinzufügen"
+  },
+  "edit_link_edit_title": {
+    "en": "Edit link",
+    "de": "Link bearbeiten"
+  },
+  "edit_link_text_input_label": {
+    "en": "Text",
+    "de": "Text"
+  },
+  "edit_link_href_input_label": {
+    "en": "Link",
+    "de": "Link"
+  },
+  "edit_link_cancel_button_label": {
+    "en": "Cancel",
+    "de": "Abbrechen"
+  },
+  "edit_link_save_button_label": {
+    "en": "Save",
+    "de": "Speichern"
+  },
+  "view_link_edit_button_label": {
+    "en": "Edit",
+    "de": "Bearbeiten"
+  },
+  "view_link_remove_button_label": {
+    "en": "Remove",
+    "de": "Entfernen"
+  },
+  "table_insert_column_before": {
+    "en": "Insert column before",
+    "de": "Spalte davor einfügen"
+  },
+  "table_insert_column_after": {
+    "en": "Insert column after",
+    "de": "Spalte danach einfügen"
+  },
+  "table_delete_column": {
+    "en": "Delete column",
+    "de": "Spalte löschen"
+  },
+  "table_insert_row_above": {
+    "en": "Insert row above",
+    "de": "Zeile oben einfügen"
+  },
+  "table_insert_row_below": {
+    "en": "Insert row below",
+    "de": "Zeile unten einfügen"
+  },
+  "table_delete_row": {
+    "en": "Delete row",
+    "de": "Zeile löschen"
+  },
+  "table_merge_cells": {
+    "en": "Merge cells",
+    "de": "Zellen verbinden"
+  },
+  "table_split_cell": {
+    "en": "Split cell",
+    "de": "Zelle teilen"
+  },
+  "table_toggle_header_row": {
+    "en": "Toggle header row",
+    "de": "Kopfzeile umschalten"
+  },
+  "table_toggle_header_column": {
+    "en": "Toggle header column",
+    "de": "Kopfspalte umschalten"
+  },
+  "table_toggle_header_cell": {
+    "en": "Toggle header cell",
+    "de": "Kopfzelle umschalten"
+  },
+  "table_delete_table": {
+    "en": "Delete table",
+    "de": "Tabelle löschen"
+  },
   "description": {
     "en": "Description",
     "de": "Beschreibung"

--- a/frontend/src/components/editProject/ProjectDescriptionEditor.tsx
+++ b/frontend/src/components/editProject/ProjectDescriptionEditor.tsx
@@ -32,6 +32,7 @@ import {
 import makeStyles from "@mui/styles/makeStyles";
 import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
+import { getLinkBubbleMenuLabels } from "../richText/richTextLabels";
 
 const CHARACTER_LIMIT = 4000;
 
@@ -156,7 +157,7 @@ export default function ProjectDescriptionEditor({
                   <MenuButtonItalic />
                   <MenuButtonBulletedList />
                   <MenuButtonOrderedList />
-                  <MenuButtonEditLink />
+                  <MenuButtonEditLink tooltipLabel={texts.editor_edit_link} />
                   <MenuButton
                     tooltipLabel={texts.project_description_youTube_button}
                     IconComponent={YouTubeIcon}
@@ -194,7 +195,7 @@ export default function ProjectDescriptionEditor({
           ),
         }}
       >
-        {() => <LinkBubbleMenu />}
+        {() => <LinkBubbleMenu labels={getLinkBubbleMenuLabels(locale)} />}
       </RichTextEditor>
 
       <Dialog open={youtubeModalOpen} onClose={handleCloseYoutubeModal} maxWidth="sm" fullWidth>

--- a/frontend/src/components/project/SendEmailToGuestsModal.tsx
+++ b/frontend/src/components/project/SendEmailToGuestsModal.tsx
@@ -28,6 +28,7 @@ import getTexts from "../../../public/texts/texts";
 import { Project } from "../../types";
 import UserContext from "../context/UserContext";
 import OrganizerMessageEditor, { stripHtml } from "../richText/OrganizerMessageEditor";
+import { getLinkBubbleMenuLabels, getTableMenuControlLabels } from "../richText/richTextLabels";
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -403,6 +404,8 @@ export default function SendEmailToGuestsModal({
                 editable={!isSending}
                 error={errors.message}
                 ariaLabel={texts.email_message}
+                linkBubbleMenuLabels={getLinkBubbleMenuLabels(locale)}
+                tableMenuControlLabels={getTableMenuControlLabels(locale)}
                 tooltipLabels={{
                   bold: texts.editor_bold,
                   italic: texts.editor_italic,

--- a/frontend/src/components/richText/OrganizerMessageEditor.tsx
+++ b/frontend/src/components/richText/OrganizerMessageEditor.tsx
@@ -30,6 +30,7 @@ import {
 } from "mui-tiptap";
 
 import { emojiItems, emojiRender } from "./emojiSuggestion";
+import type { LinkBubbleMenuLabels, TableMenuControlLabels } from "./richTextLabels";
 
 const CHARACTER_LIMIT = 5000;
 
@@ -110,6 +111,8 @@ type Props = {
   showCharCount?: boolean;
   ariaLabel?: string;
   tooltipLabels?: TooltipLabels;
+  linkBubbleMenuLabels?: LinkBubbleMenuLabels;
+  tableMenuControlLabels?: TableMenuControlLabels;
 };
 
 const stripHtml = (html: string) => html.replace(/<[^>]*>/g, "").trim();
@@ -122,6 +125,8 @@ export default function OrganizerMessageEditor({
   showCharCount = true,
   ariaLabel,
   tooltipLabels,
+  linkBubbleMenuLabels,
+  tableMenuControlLabels,
 }: Props) {
   const classes = useStyles();
   const rteRef = useRef<RichTextEditorRef>(null);
@@ -162,7 +167,7 @@ export default function OrganizerMessageEditor({
             <MenuDivider />
             <MenuButtonEditLink tooltipLabel={t?.editLink ?? "Edit link"} />
             <MenuButtonAddTable tooltipLabel={t?.addTable ?? "Add table"} />
-            <TableMenuControls />
+            <TableMenuControls labels={tableMenuControlLabels} />
           </MenuControlsContainer>
         )}
         RichTextFieldProps={{
@@ -178,7 +183,7 @@ export default function OrganizerMessageEditor({
           ) : undefined,
         }}
       >
-        {() => <LinkBubbleMenu />}
+        {() => <LinkBubbleMenu labels={linkBubbleMenuLabels} />}
       </RichTextEditor>
       {error && <Typography className={classes.errorText}>{error}</Typography>}
     </div>

--- a/frontend/src/components/richText/richTextLabels.ts
+++ b/frontend/src/components/richText/richTextLabels.ts
@@ -1,0 +1,79 @@
+import getTexts from "../../../public/texts/texts";
+import type { CcLocale } from "../../types";
+
+/**
+ * Labels consumed by mui-tiptap's <LinkBubbleMenu /> (EditLinkMenuContent and
+ * ViewLinkMenuContent). Keeping them in one place lets every rich-text editor
+ * localize the link modal consistently without duplicating strings.
+ */
+export type LinkBubbleMenuLabels = {
+  editLinkAddTitle: string;
+  editLinkEditTitle: string;
+  editLinkTextInputLabel: string;
+  editLinkHrefInputLabel: string;
+  editLinkCancelButtonLabel: string;
+  editLinkSaveButtonLabel: string;
+  viewLinkEditButtonLabel: string;
+  viewLinkRemoveButtonLabel: string;
+};
+
+/**
+ * Returns the localized labels for mui-tiptap's <LinkBubbleMenu /> for the given
+ * locale. The strings live in general_texts (merged into every page), so this
+ * works regardless of which page/editor calls it.
+ */
+export function getLinkBubbleMenuLabels(locale: CcLocale): LinkBubbleMenuLabels {
+  const t = getTexts({ page: "general", locale });
+  return {
+    editLinkAddTitle: t.edit_link_add_title,
+    editLinkEditTitle: t.edit_link_edit_title,
+    editLinkTextInputLabel: t.edit_link_text_input_label,
+    editLinkHrefInputLabel: t.edit_link_href_input_label,
+    editLinkCancelButtonLabel: t.edit_link_cancel_button_label,
+    editLinkSaveButtonLabel: t.edit_link_save_button_label,
+    viewLinkEditButtonLabel: t.view_link_edit_button_label,
+    viewLinkRemoveButtonLabel: t.view_link_remove_button_label,
+  };
+}
+
+/**
+ * Labels consumed by mui-tiptap's <TableMenuControls />. Centralizing them here
+ * lets every rich-text editor that supports tables localize the table controls
+ * consistently.
+ */
+export type TableMenuControlLabels = {
+  insertColumnBefore: string;
+  insertColumnAfter: string;
+  deleteColumn: string;
+  insertRowAbove: string;
+  insertRowBelow: string;
+  deleteRow: string;
+  mergeCells: string;
+  splitCell: string;
+  toggleHeaderRow: string;
+  toggleHeaderColumn: string;
+  toggleHeaderCell: string;
+  deleteTable: string;
+};
+
+/**
+ * Returns the localized labels for mui-tiptap's <TableMenuControls /> for the
+ * given locale. The strings live in general_texts (merged into every page).
+ */
+export function getTableMenuControlLabels(locale: CcLocale): TableMenuControlLabels {
+  const t = getTexts({ page: "general", locale });
+  return {
+    insertColumnBefore: t.table_insert_column_before,
+    insertColumnAfter: t.table_insert_column_after,
+    deleteColumn: t.table_delete_column,
+    insertRowAbove: t.table_insert_row_above,
+    insertRowBelow: t.table_insert_row_below,
+    deleteRow: t.table_delete_row,
+    mergeCells: t.table_merge_cells,
+    splitCell: t.table_split_cell,
+    toggleHeaderRow: t.table_toggle_header_row,
+    toggleHeaderColumn: t.table_toggle_header_column,
+    toggleHeaderCell: t.table_toggle_header_cell,
+    deleteTable: t.table_delete_table,
+  };
+}

--- a/frontend/src/components/shareProject/CheckboxFieldEditor.tsx
+++ b/frontend/src/components/shareProject/CheckboxFieldEditor.tsx
@@ -16,6 +16,7 @@ import {
 import makeStyles from "@mui/styles/makeStyles";
 import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
+import { getLinkBubbleMenuLabels } from "../richText/richTextLabels";
 
 const CHARACTER_LIMIT = 500;
 
@@ -116,7 +117,7 @@ export default function CheckboxFieldEditor({
             : () => (
                 <MenuControlsContainer>
                   <MenuButtonBold />
-                  <MenuButtonEditLink />
+                  <MenuButtonEditLink tooltipLabel={texts.editor_edit_link} />
                 </MenuControlsContainer>
               )
         }
@@ -142,7 +143,7 @@ export default function CheckboxFieldEditor({
         }}
       >
         {/* render prop ensures LinkBubbleMenu re-renders on every editor transaction */}
-        {() => <LinkBubbleMenu />}
+        {() => <LinkBubbleMenu labels={getLinkBubbleMenuLabels(locale)} />}
       </RichTextEditor>
     </>
   );


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Minor change, just localizing the texts of the rich-text-editor. Strangely tiptap doesn't have i18n built in, so we have to provide the texts ourselves. 
