### PR TITLE
Improve old description conversion and wysiwyg experience

### DIFF
--- a/backend/organization/admin.py
+++ b/backend/organization/admin.py
@@ -88,7 +88,7 @@ class ProjectAdmin(admin.ModelAdmin):
         "project_parent__parent_user__user_profile__name",
         "project_parent__parent_organization__name",
     )
-    list_filter = ("status", "has_children", "project_type")
+    list_filter = ("status", "has_children", "project_type", "updated_at")
     list_display = (
         "name",
         "url_slug",
@@ -98,6 +98,7 @@ class ProjectAdmin(admin.ModelAdmin):
         "has_children",
         "project_type",
         "created_at",
+        "updated_at",
     )
     raw_id_fields = ("parent_project",)  # Better UX for selecting parent project
     readonly_fields = (

--- a/backend/organization/management/commands/migrate_descriptions_to_tiptap_v2.py
+++ b/backend/organization/management/commands/migrate_descriptions_to_tiptap_v2.py
@@ -1,0 +1,133 @@
+import logging
+from datetime import datetime
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from organization.models import Project
+from organization.models.translations import ProjectTranslation
+from organization.utility.legacy_description_to_tiptap import (
+    legacy_description_to_tiptap_html_v2,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Re-convert legacy plain-text descriptions to Tiptap HTML (v2), "
+        "preserving line breaks / blank-line structure. Only affects "
+        "projects and translations whose updated_at predates --deployed-at "
+        "(i.e. not hand-edited since deployment)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--deployed-at",
+            required=True,
+            help=(
+                "ISO datetime (e.g. 2026-07-08T12:00:00Z). Rows with "
+                "updated_at >= this are skipped (hand-edited since deployment)."
+            ),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Count and show a sample without saving.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=500,
+            help="Number of rows per batch (default: 500).",
+        )
+
+    def handle(self, *args, **options):
+        deployed_at = self._parse_deployed_at(options["deployed_at"])
+        dry_run = options["dry_run"]
+        batch_size = options["batch_size"]
+
+        # --- Projects ---
+        projects = (
+            Project.objects.filter(description__isnull=False)
+            .exclude(description="")
+            .filter(updated_at__lt=deployed_at)
+        )
+        total = projects.count()
+
+        if total == 0:
+            self.stdout.write("No projects to migrate.")
+        elif dry_run:
+            self.stdout.write(f"DRY RUN: {total} projects would be migrated.")
+            for proj in projects[:3]:
+                after = legacy_description_to_tiptap_html_v2(proj.description)
+                self.stdout.write(f"\n--- Project {proj.id} ({proj.url_slug}) ---")
+                self.stdout.write(f"BEFORE:\n{proj.description[:200]}...")
+                self.stdout.write(f"AFTER:\n{after[:500]}...")
+        else:
+            migrated = self._migrate(
+                projects, "description", "description_html", batch_size
+            )
+            logger.info("Migrated %d project descriptions (v2)", migrated)
+            self.stdout.write(
+                self.style.SUCCESS(f"Migrated {migrated} project descriptions (v2)")
+            )
+
+        # --- Translations ---
+        translations = (
+            ProjectTranslation.objects.filter(description_translation__isnull=False)
+            .exclude(description_translation="")
+            .filter(updated_at__lt=deployed_at)
+        )
+        trans_total = translations.count()
+
+        if trans_total == 0:
+            self.stdout.write("No translations to migrate.")
+        elif dry_run:
+            self.stdout.write(
+                f"DRY RUN: {trans_total} translations would be migrated."
+            )
+        else:
+            migrated_trans = self._migrate(
+                translations,
+                "description_translation",
+                "description_html_translation",
+                batch_size,
+            )
+            logger.info("Migrated %d translation descriptions (v2)", migrated_trans)
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Migrated {migrated_trans} translation descriptions (v2)"
+                )
+            )
+
+    def _migrate(self, queryset, source_field, target_field, batch_size):
+        """Re-convert in batches. updated_at is intentionally NOT written, so the
+        deployment filter stays valid and we don't falsely mark rows as edited."""
+        ids = list(queryset.values_list("id", flat=True))
+        total = len(ids)
+        migrated = 0
+        model = queryset.model
+        for i in range(0, total, batch_size):
+            batch_ids = ids[i : i + batch_size]
+            batch = list(model.objects.filter(id__in=batch_ids))
+            for obj in batch:
+                setattr(
+                    obj,
+                    target_field,
+                    legacy_description_to_tiptap_html_v2(getattr(obj, source_field)),
+                )
+            model.objects.bulk_update(batch, [target_field], batch_size=batch_size)
+            migrated += len(batch)
+            self.stdout.write(f"Processed {migrated}/{total}...")
+        return migrated
+
+    @staticmethod
+    def _parse_deployed_at(value: str) -> datetime:
+        parsed = parse_datetime(value)
+        if parsed is None:
+            raise CommandError(f"Invalid --deployed-at value: {value!r}")
+        if parsed.tzinfo is None:
+            parsed = timezone.make_aware(parsed, timezone.utc)
+        return parsed

--- a/backend/organization/management/commands/migrate_descriptions_to_tiptap_v2.py
+++ b/backend/organization/management/commands/migrate_descriptions_to_tiptap_v2.py
@@ -85,9 +85,7 @@ class Command(BaseCommand):
         if trans_total == 0:
             self.stdout.write("No translations to migrate.")
         elif dry_run:
-            self.stdout.write(
-                f"DRY RUN: {trans_total} translations would be migrated."
-            )
+            self.stdout.write(f"DRY RUN: {trans_total} translations would be migrated.")
         else:
             migrated_trans = self._migrate(
                 translations,

--- a/backend/organization/tests/test_project_description_tiptap.py
+++ b/backend/organization/tests/test_project_description_tiptap.py
@@ -7,6 +7,7 @@ from climateconnect_api.utility.html import (
 )
 from organization.utility.legacy_description_to_tiptap import (
     legacy_description_to_tiptap_html,
+    legacy_description_to_tiptap_html_v2,
 )
 
 
@@ -91,6 +92,110 @@ class TestLegacyDescriptionToTiptap(TestCase):
         result = legacy_description_to_tiptap_html("http://youtu.be/dQw4w9WgXcQ,")
         self.assertIn('<div data-youtube-video="">', result)
         self.assertIn("dQw4w9WgXcQ", result)
+
+
+class TestLegacyDescriptionToTiptapV2(TestCase):
+    """v2 preserves the original line-break layout: blank lines become empty
+    <p><br></p> (visible even with margin:0, matching the tiptap editor), and
+    intra-paragraph single newlines become <br>."""
+
+    def test_blank_lines_create_empty_paragraphs(self):
+        # A blank line becomes an empty <p><br></p> so it stays visible even with
+        # margin:0 (mirrors project 775's structure).
+        text = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
+        result = legacy_description_to_tiptap_html_v2(text)
+        self.assertEqual(
+            result,
+            "<p>First paragraph.</p><p><br></p><p>Second paragraph.</p>"
+            "<p><br></p><p>Third paragraph.</p>",
+        )
+
+    def test_intra_paragraph_newline_becomes_br(self):
+        text = "Line one\nLine two\nLine three"
+        result = legacy_description_to_tiptap_html_v2(text)
+        self.assertEqual(result, "<p>Line one<br>Line two<br>Line three</p>")
+
+    def test_mixed_blank_and_soft_breaks(self):
+        text = "Title\n\nBullet line 1\nBullet line 2\n\nFooter"
+        result = legacy_description_to_tiptap_html_v2(text)
+        self.assertEqual(
+            result,
+            "<p>Title</p><p><br></p><p>Bullet line 1<br>Bullet line 2</p>"
+            "<p><br></p><p>Footer</p>",
+        )
+
+    def test_youtube_url_own_line(self):
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        result = legacy_description_to_tiptap_html_v2(url)
+        self.assertIn('<div data-youtube-video="">', result)
+        self.assertIn(
+            'src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"', result
+        )
+
+    def test_youtube_embed_kept_within_paragraph(self):
+        text = "Intro text\n\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ\n\nOutro"
+        result = legacy_description_to_tiptap_html_v2(text)
+        self.assertIn("<p>Intro text</p><p><br></p>", result)
+        self.assertIn('<div data-youtube-video="">', result)
+        self.assertIn("<p><br></p><p>Outro</p>", result)
+
+    def test_youtube_url_mixed_with_text_v2(self):
+        # Mirrors the v1 test_youtube_url_mixed_with_text: a YouTube URL embedded
+        # in a line of text must become an embed, with the surrounding text in
+        # their own paragraphs (not just an autolinked <a>).
+        result = legacy_description_to_tiptap_html_v2(
+            "Check this out: https://www.youtube.com/watch?v=dQw4w9WgXcQ cool right?"
+        )
+        self.assertIn("Check this out:", result)
+        self.assertIn("cool right?", result)
+        self.assertIn('<div data-youtube-video="">', result)
+        self.assertIn("<p>Check this out:</p>", result)
+        self.assertIn("<p>cool right?</p>", result)
+        # The URL itself must NOT appear as a plain autolinked <a>.
+        self.assertNotIn(
+            '<a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"', result
+        )
+
+    def test_bare_url_autolinked(self):
+        result = legacy_description_to_tiptap_html_v2(
+            "Visit https://example.com for info"
+        )
+        self.assertIn('<a href="https://example.com"', result)
+        self.assertIn("https://example.com</a>", result)
+
+    def test_html_escaped_in_text(self):
+        result = legacy_description_to_tiptap_html_v2("A < B & C > D")
+        self.assertIn("&lt;", result)
+        self.assertIn("&amp;", result)
+        self.assertIn("&gt;", result)
+
+    def test_empty_input(self):
+        self.assertEqual(legacy_description_to_tiptap_html_v2(""), "")
+        self.assertEqual(legacy_description_to_tiptap_html_v2(None), "")
+        self.assertEqual(legacy_description_to_tiptap_html_v2("   "), "")
+
+    def test_trailing_blank_lines_ignored(self):
+        text = "Only paragraph.\n\n\n"
+        result = legacy_description_to_tiptap_html_v2(text)
+        self.assertEqual(result, "<p>Only paragraph.</p>")
+
+    def test_blank_line_preserves_visible_gap_like_old_display(self):
+        # Reproduces the user's reported structure: text A, blank, text B, blank,
+        # then C/D/E on consecutive lines. Blank lines must become empty <p> so
+        # the rendered output shows a gap (matching the old display), while the
+        # single line breaks between C/D/E stay as <br>.
+        text = "text A\n\ntext B\n\ntext C\ntext D\ntext E"
+        result = legacy_description_to_tiptap_html_v2(text)
+        self.assertEqual(
+            result,
+            "<p>text A</p><p><br></p><p>text B</p><p><br></p>"
+            "<p>text C<br>text D<br>text E</p>",
+        )
+
+    def test_leading_and_trailing_blank_lines_ignored(self):
+        text = "\n\nOnly paragraph.\n\n\n"
+        result = legacy_description_to_tiptap_html_v2(text)
+        self.assertEqual(result, "<p>Only paragraph.</p>")
 
 
 class TestSanitizeHtmlProjectDescription(TestCase):

--- a/backend/organization/utility/legacy_description_to_tiptap.py
+++ b/backend/organization/utility/legacy_description_to_tiptap.py
@@ -164,7 +164,9 @@ def legacy_description_to_tiptap_html_v2(text: str | None) -> str:
 
     def flush() -> None:
         if current:
-            autolinked = [_autolink_text(line.strip()) for line in current if line.strip()]
+            autolinked = [
+                _autolink_text(line.strip()) for line in current if line.strip()
+            ]
             if autolinked:
                 parts.append(f"<p>{'<br>'.join(autolinked)}</p>")
             current.clear()
@@ -194,7 +196,7 @@ def legacy_description_to_tiptap_html_v2(text: str | None) -> str:
             if vid:
                 flush()
                 before = stripped[: mixed.start()].strip()
-                after = stripped[mixed.end():].strip()
+                after = stripped[mixed.end() :].strip()
                 if before:
                     parts.append(f"<p>{_autolink_text(before)}</p>")
                 parts.append(_youtube_embed(vid))

--- a/backend/organization/utility/legacy_description_to_tiptap.py
+++ b/backend/organization/utility/legacy_description_to_tiptap.py
@@ -9,6 +9,14 @@ YOUTUBE_RE = re.compile(
     r"(?:/(?:[\w-]+\?v=|embed/|v/)?|/)([\w-]+)(\S+)?$"
 )
 
+# Non-anchored variant used to find a YouTube URL embedded within a line of text
+# (e.g. "Check this out: https://youtube.com/watch?v=abc cool!").
+YOUTUBE_RE_IN_LINE = re.compile(
+    r"((?:https?:)?//)?((?:www|m|music)\.)?"
+    r"(?:youtube\.com|youtu\.be|youtube-nocookie\.com)"
+    r"(?:/(?:[\w-]+\?v=|embed/|v/)?|/)([\w-]+)(\S+)?"
+)
+
 # Bare URL / email autolink patterns
 URL_RE = re.compile(r"(https?://[^\s<>\"']+|www\.[^\s<>\"']+)")
 EMAIL_RE = re.compile(r"([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)")
@@ -20,6 +28,16 @@ def _extract_youtube_id(url: str) -> str | None:
     if m:
         return m.group(3)
     return None
+
+
+def _youtube_embed(video_id: str) -> str:
+    """Return the Tiptap/ProseMirror HTML for a YouTube video embed."""
+    return (
+        f'<div data-youtube-video="">'
+        f'<iframe src="https://www.youtube-nocookie.com/embed/{video_id}" '
+        f'width="640" height="480" allowfullscreen="true"></iframe>'
+        f"</div>"
+    )
 
 
 def _autolink_text(text: str) -> str:
@@ -104,4 +122,87 @@ def legacy_description_to_tiptap_html(text: str | None) -> str:
         if current_text:
             parts.append(f"<p>{_autolink_text(' '.join(current_text))}</p>")
 
+    return "".join(parts)
+
+
+def legacy_description_to_tiptap_html_v2(text: str | None) -> str:
+    """Improved converter that preserves the original line-break layout.
+
+    Unlike legacy_description_to_tiptap_html (which dropped blank lines and made
+    every line its own <p>, flattening the structure), this keeps the visual
+    layout of the legacy plain-text description so the rendered output is
+    WYSIWYG with what authors expect:
+
+    * A blank line in the source becomes an *empty paragraph* (<p><br></p>). Even
+      though the rendered description uses no margin between paragraphs, the <br>
+      gives that empty paragraph one line of height, so the blank line is visible
+      in BOTH the tiptap editor (which renders empty paragraphs the same way) and
+      the read-only display. This preserves the spacing authors created with
+      blank lines (e.g. a "title" line separated from the body by blank lines).
+    * A single line break (no blank line) within a block is preserved as a <br>
+      inside the same <p>, so consecutive lines stay together without an extra gap.
+    * A line that is entirely a YouTube URL becomes a standalone embed.
+    * Bare URLs / emails are autolinked.
+
+    Leading and trailing blank lines are ignored so they don't add stray spacing.
+    """
+    if not text or not text.strip():
+        return ""
+
+    # Normalize line endings
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+
+    lines = text.split("\n")
+    # Drop leading/trailing blank lines so they don't produce empty paragraphs.
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+
+    parts: list[str] = []
+    current: list[str] = []
+
+    def flush() -> None:
+        if current:
+            autolinked = [_autolink_text(line.strip()) for line in current if line.strip()]
+            if autolinked:
+                parts.append(f"<p>{'<br>'.join(autolinked)}</p>")
+            current.clear()
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            # Blank line → close the current paragraph and emit an empty
+            # paragraph so the blank line is visible in the rendered output.
+            flush()
+            parts.append("<p><br></p>")
+            continue
+
+        # A line that is entirely a YouTube URL → standalone embed.
+        video_id = _extract_youtube_id(stripped)
+        if video_id:
+            flush()
+            parts.append(_youtube_embed(video_id))
+            continue
+
+        # A line that mixes text with a YouTube URL (e.g. "See this:
+        # https://youtube... cool!") → flush any pending paragraph, then emit the
+        # leading text, the embed, and the trailing text as separate blocks.
+        mixed = YOUTUBE_RE_IN_LINE.search(stripped)
+        if mixed:
+            vid = _extract_youtube_id(mixed.group(0))
+            if vid:
+                flush()
+                before = stripped[: mixed.start()].strip()
+                after = stripped[mixed.end():].strip()
+                if before:
+                    parts.append(f"<p>{_autolink_text(before)}</p>")
+                parts.append(_youtube_embed(vid))
+                if after:
+                    parts.append(f"<p>{_autolink_text(after)}</p>")
+                continue
+
+        current.append(line)
+
+    flush()
     return "".join(parts)

--- a/frontend/src/components/project/ProjectContent.test.tsx
+++ b/frontend/src/components/project/ProjectContent.test.tsx
@@ -96,6 +96,16 @@ describe("ProjectContent", () => {
       expect(screen.getByText("Hello")).toBeInTheDocument();
     });
 
+    it("keeps empty <p> tags from the editor (blank lines) in the DOM", () => {
+      // The tiptap editor stores a blank line the author created as an empty
+      // <p></p>. It must not be stripped, so the display CSS can render it as a
+      // visible empty line (WYSIWYG with the editor).
+      renderProjectContent({
+        description_html: "<p>And a new paragraph</p><p></p><p>Empty line above</p>",
+      });
+      expect(document.querySelector("p:empty")).not.toBeNull();
+    });
+
     it("renders YouTube iframe from description_html", () => {
       const html =
         '<div data-youtube-video=""><iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ" width="640" height="480"></iframe></div>';

--- a/frontend/src/components/project/ProjectContent.tsx
+++ b/frontend/src/components/project/ProjectContent.tsx
@@ -130,6 +130,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     // Reuse the tiptap editor's own styles (margin:0 on p/headings/lists, link &
     // list styling) so the rendered description is WYSIWYG with the editor.
     ...getEditorStyles(theme),
+    // The tiptap editor renders an empty paragraph (<p></p>, e.g. a blank line
+    // the author created) as a visible empty line — ProseMirror injects a <br>
+    // into empty blocks in the editable view. In the read-only display that <br>
+    // is absent, so an empty <p> collapses to zero height. Give it one line of
+    // height (via a hidden non-breaking space) so blank lines created in the
+    // editor stay visible. This matches the editor without changing global CSS.
+    "& p:empty::before": {
+      content: '"\\00a0"',
+      visibility: "hidden",
+    },
     "& ul, & ol": {
       paddingLeft: "1.5em",
     },

--- a/frontend/src/components/project/ProjectContent.tsx
+++ b/frontend/src/components/project/ProjectContent.tsx
@@ -17,6 +17,7 @@ import Posts from "./../communication/Posts";
 import UserContext from "../context/UserContext";
 import ProjectContentSideButtons from "./Buttons/ProjectContentSideButtons";
 import { getDevlinkComponent } from "../../utils/getDevlinkComponent";
+import { getEditorStyles } from "mui-tiptap";
 
 const useStyles = makeStyles((theme: Theme) => ({
   createdBy: {
@@ -126,9 +127,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   projectDescription: {
     wordBreak: "break-word",
+    // Reuse the tiptap editor's own styles (margin:0 on p/headings/lists, link &
+    // list styling) so the rendered description is WYSIWYG with the editor.
+    ...getEditorStyles(theme),
     "& ul, & ol": {
       paddingLeft: "1.5em",
-      margin: "0.5em 0",
     },
     "& iframe": {
       maxWidth: 640,


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

improvement for #1748 that adresses user feedback and due to that needed to adjust the conversion of the old description.