### PR TITLE
Change event registration button text to just 'Register'

### DIFF
--- a/frontend/public/texts/project_texts.tsx
+++ b/frontend/public/texts/project_texts.tsx
@@ -1712,8 +1712,8 @@ export default function getProjectTexts({ project, user, url_slug, locale, creat
       de: "Für Veranstaltung anmelden",
     },
     register_now: {
-      en: "Register now",
-      de: "Jetzt anmelden",
+      en: "Register",
+      de: "Anmelden",
     },
     booked_out: {
       en: "Booked Out",


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Minor text change to reduce the button size so that it fits better. 
