### PR TITLE
Phase 1 of hub context refactor

### DIFF
--- a/frontend/public/lib/hubLink.test.ts
+++ b/frontend/public/lib/hubLink.test.ts
@@ -1,0 +1,94 @@
+import { withHub } from "./hubLink";
+
+describe("withHub", () => {
+  describe("locale prefix", () => {
+    it("applies the locale prefix for a relative href (de)", () => {
+      expect(withHub("/browse", { locale: "de", hubUrl: "erlangen" })).toBe(
+        "/de/browse?hub=erlangen"
+      );
+    });
+
+    it("applies no locale prefix for en", () => {
+      expect(withHub("/browse", { locale: "en", hubUrl: "erlangen" })).toBe("/browse?hub=erlangen");
+    });
+
+    it("applies the locale prefix without a hub when none is active", () => {
+      expect(withHub("/browse", { locale: "de" })).toBe("/de/browse");
+    });
+
+    it("does not double-apply an already-present locale prefix", () => {
+      expect(withHub("/de/browse", { locale: "de", hubUrl: "erlangen" })).toBe(
+        "/de/browse?hub=erlangen"
+      );
+    });
+  });
+
+  describe("& join", () => {
+    it("appends ?hub= with & when a query already exists", () => {
+      expect(withHub("/projects/foo?tab=about", { hubUrl: "erlangen" })).toBe(
+        "/projects/foo?tab=about&hub=erlangen"
+      );
+    });
+  });
+
+  describe("anchor preservation", () => {
+    it("places ?hub= before the fragment and preserves the anchor", () => {
+      expect(withHub("/chat/abc#comments", { hubUrl: "erlangen" })).toBe(
+        "/chat/abc?hub=erlangen#comments"
+      );
+    });
+  });
+
+  describe("already-present ?hub=", () => {
+    it("does not append a second ?hub=", () => {
+      expect(withHub("/projects/foo?hub=erlangen", { hubUrl: "erlangen" })).toBe(
+        "/projects/foo?hub=erlangen"
+      );
+    });
+  });
+
+  describe("hub-route skip", () => {
+    it("skips ?hub= for a hub landing route (no locale prefix)", () => {
+      expect(withHub("/hubs/erlangen", { hubUrl: "erlangen" })).toBe("/hubs/erlangen");
+    });
+
+    it("skips ?hub= for a hub landing route (with /de prefix)", () => {
+      expect(withHub("/de/hubs/erlangen", { locale: "de", hubUrl: "erlangen" })).toBe(
+        "/de/hubs/erlangen"
+      );
+    });
+
+    it("skips ?hub= for a sub-hub browse route", () => {
+      expect(withHub("/hubs/erlangen/zerowaste/browse", { hubUrl: "erlangen" })).toBe(
+        "/hubs/erlangen/zerowaste/browse"
+      );
+    });
+  });
+
+  describe("absolute-URL passthrough", () => {
+    it("returns external URLs unchanged", () => {
+      expect(withHub("https://example.com/x?y=1#z", { hubUrl: "erlangen" })).toBe(
+        "https://example.com/x?y=1#z"
+      );
+    });
+  });
+
+  describe("encoding", () => {
+    it("URL-encodes the slug in a single place", () => {
+      expect(withHub("/browse", { hubUrl: "erlangen/special" })).toBe(
+        "/browse?hub=erlangen%2Fspecial"
+      );
+    });
+  });
+
+  describe("no hub active", () => {
+    it("returns the href unchanged when no hub is active", () => {
+      expect(withHub("/browse", { locale: "de" })).toBe("/de/browse");
+      expect(withHub("/browse")).toBe("/browse");
+    });
+
+    it("returns the href unchanged when leaveHub is set", () => {
+      expect(withHub("/browse", { hubUrl: "erlangen", leaveHub: true })).toBe("/browse");
+    });
+  });
+});

--- a/frontend/public/lib/hubLink.ts
+++ b/frontend/public/lib/hubLink.ts
@@ -1,0 +1,90 @@
+import { getLocalePrefix } from "./apiOperations";
+import { appendQueryParam } from "./urlOperations";
+
+export interface WithHubOptions {
+  /** When true, the `?hub=` parameter is never appended (Category B). */
+  leaveHub?: boolean;
+  /** Active hub slug. Falls back to the empty string (no hub active). */
+  hubUrl?: string;
+  /** Locale used to compute the locale prefix. Only applied to relative hrefs. */
+  locale?: string;
+}
+
+const isAbsoluteUrl = (href: string): boolean => /^(https?:)?\/\//i.test(href);
+
+/**
+ * Strip an optional leading locale prefix (e.g. `/de/hubs/erlangen` ->
+ * `/hubs/erlangen`). English carries no prefix, so the only segment that can
+ * appear here is a known locale (`en`, `de`).
+ */
+const stripLocalePrefix = (path: string): string => {
+  const match = path.match(/^\/(en|de)(\/.*)?$/);
+  if (match) {
+    return match[2] ?? "/";
+  }
+  return path;
+};
+
+/**
+ * A "hub route" conveys the hub in its path, so a `?hub=` query parameter is
+ * redundant. Covers both the dedicated landing page (`/hubs/<slug>`) and the
+ * sub-hub browse page (`/hubs/<slug>/<subHub>/browse`).
+ */
+const isHubRoute = (path: string): boolean => /^\/hubs\/[^/]+/.test(path);
+
+const hrefHasQueryParam = (href: string, key: string): boolean => {
+  try {
+    const url = new URL(href, "http://localhost.invalid");
+    return url.searchParams.has(key);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Build a final href that (a) carries the locale prefix for relative paths and
+ * (b) appends `?hub=<slug>` when a hub is active and the destination does not
+ * already convey the hub.
+ *
+ * All query/fragment/encoding construction is delegated to the shared URI
+ * utility (`appendQueryParam`), so the result is always well-formed. This is
+ * the function form of the future `<HubLink>` component.
+ *
+ * `withHub` leaves absolute/external URLs untouched and never appends `?hub=`
+ * when: `leaveHub` is set, no hub is active, the destination is a hub route
+ * (`/hubs/...`), or a `?hub=` is already present.
+ */
+export const withHub = (href: string, options?: WithHubOptions): string => {
+  if (!href || isAbsoluteUrl(href)) {
+    return href;
+  }
+
+  const { leaveHub = false, hubUrl, locale } = options ?? {};
+
+  // 1. Locale prefix — only for relative paths, never double-applied.
+  let result = href;
+  if (locale) {
+    const prefix = getLocalePrefix(locale);
+    if (prefix && !result.startsWith(prefix)) {
+      result = `${prefix}${result}`;
+    }
+  }
+
+  // 2. Decide whether `?hub=` should be appended.
+  const slug = hubUrl ?? "";
+  if (leaveHub || !slug) {
+    return result;
+  }
+
+  // The hub is already in the URL when the (locale-stripped) path is a hub route.
+  if (isHubRoute(stripLocalePrefix(result))) {
+    return result;
+  }
+
+  // A `?hub=` is already present — never append a second one.
+  if (hrefHasQueryParam(result, "hub")) {
+    return result;
+  }
+
+  return appendQueryParam(result, "hub", slug);
+};

--- a/frontend/public/lib/urlOperations.test.ts
+++ b/frontend/public/lib/urlOperations.test.ts
@@ -1,0 +1,45 @@
+import { appendQueryParam, withQuery } from "./urlOperations";
+
+describe("appendQueryParam", () => {
+  it("appends a query param to a href with no existing query", () => {
+    expect(appendQueryParam("/browse", "hub", "erlangen")).toBe("/browse?hub=erlangen");
+  });
+
+  it("joins with & when a query already exists", () => {
+    expect(appendQueryParam("/projects/foo?tab=about", "hub", "erlangen")).toBe(
+      "/projects/foo?tab=about&hub=erlangen"
+    );
+  });
+
+  it("places the param before the fragment and preserves the anchor", () => {
+    expect(appendQueryParam("/chat/abc#comments", "hub", "erlangen")).toBe(
+      "/chat/abc?hub=erlangen#comments"
+    );
+  });
+
+  it("URL-encodes the value in a single place", () => {
+    expect(appendQueryParam("/browse", "hub", "erlangen/special")).toBe(
+      "/browse?hub=erlangen%2Fspecial"
+    );
+  });
+
+  it("appends to absolute URLs without dropping the origin", () => {
+    expect(appendQueryParam("https://climateconnect.earth/browse", "hub", "erlangen")).toBe(
+      "https://climateconnect.earth/browse?hub=erlangen"
+    );
+  });
+});
+
+describe("withQuery", () => {
+  it("appends multiple params in order and joins existing query with &", () => {
+    expect(withQuery("/browse?x=1", { hub: "erlangen", tab: "about" })).toBe(
+      "/browse?x=1&hub=erlangen&tab=about"
+    );
+  });
+
+  it("preserves an anchor across multiple params", () => {
+    expect(withQuery("/chat/abc#comments", { hub: "erlangen" })).toBe(
+      "/chat/abc?hub=erlangen#comments"
+    );
+  });
+});

--- a/frontend/public/lib/urlOperations.ts
+++ b/frontend/public/lib/urlOperations.ts
@@ -1,6 +1,54 @@
 import { getLocationFilterKeys } from "../data/locationFilters";
 import possibleFilters from "../data/possibleFilters";
 
+/**
+ * Dummy origin used to parse relative hrefs through the platform `URL` API so
+ * that pathname / search / hash are split correctly even when no real origin
+ * is available (e.g. in unit tests or server-side code).
+ */
+const ABSOLUTE_BASE = "http://localhost.invalid";
+
+const isAbsoluteUrl = (href: string): boolean => /^(https?:)?\/\//i.test(href);
+
+/**
+ * Serialize a parsed `URL` back to a string, dropping the dummy origin for
+ * relative hrefs while keeping absolute URLs intact.
+ */
+const serializeUrl = (href: string, url: URL): string => {
+  if (isAbsoluteUrl(href)) {
+    return url.toString();
+  }
+  return url.pathname + url.search + url.hash;
+};
+
+/**
+ * Append a single query parameter to an href, returning a well-formed URL.
+ *
+ * Built on the platform `URL` / `URLSearchParams` APIs so the result is always
+ * well-formed: an existing query string is joined with `&` (never a second
+ * `?`), a fragment (`#anchor`) is preserved and placed *after* the query, and
+ * the value is URL-encoded in exactly one place.
+ *
+ * Works for both relative paths (`/browse?x=1#top`) and absolute URLs.
+ */
+export const appendQueryParam = (href: string, key: string, value: string): string => {
+  const url = new URL(href, ABSOLUTE_BASE);
+  url.searchParams.append(key, value);
+  return serializeUrl(href, url);
+};
+
+/**
+ * Append several query parameters at once (in insertion order). See
+ * `appendQueryParam` for the well-formedness guarantees.
+ */
+export const withQuery = (href: string, params: Record<string, string>): string => {
+  const url = new URL(href, ABSOLUTE_BASE);
+  Object.keys(params).forEach((key) => {
+    url.searchParams.append(key, params[key]);
+  });
+  return serializeUrl(href, url);
+};
+
 const encodeObjectToQueryParams = (obj) => {
   if (!obj) {
     return "";


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

First phase 0 implementation for #2130 
No functional change, no risk of introducing regression
