### PR TITLE
Implement phase 1 of hubcontext refactor

### DIFF
--- a/doc/spec/20260715_review_phase1_hub_context.md
+++ b/doc/spec/20260715_review_phase1_hub_context.md
@@ -1,0 +1,168 @@
+# Code Review — Phase 1: `HubProvider` + `HubContext`
+
+**Date:** 2026-07-15
+**Scope:** Uncommitted changes implementing Phase 1 of `doc/spec/20260715_hub_context_rollout.md`
+**Spec:** `doc/spec/20260715_hub_context_rollout.md`
+**Companion spec:** `doc/spec/20260701_1205_refactor_frontend_hub_context.md`
+
+## Files reviewed
+
+| File | Status | Lines changed |
+|------|--------|---------------|
+| `frontend/src/components/context/HubContext.tsx` | New (untracked) | 104 |
+| `frontend/src/components/context/HubContext.test.tsx` | New (untracked) | 98 |
+| `frontend/pages/_app.tsx` | Modified | +40 / -4 |
+
+## Gate check
+
+| Gate | Result |
+|------|--------|
+| `yarn test` | 34/34 passed (4 suites) |
+| `yarn lint` | Clean |
+| `yarn format` | Clean |
+| `yarn build` | Succeeds |
+
+## Findings
+
+### 1. `getInitialProps` disables static optimization for ALL pages — should-fix
+
+**Location:** `frontend/pages/_app.tsx:350-361`
+
+Adding `MyApp.getInitialProps` disables Next.js Automatic Static Optimization for every page in the application. Pages that currently have no `getServerSideProps` (e.g. `index.tsx`, `stream.tsx`, `zoom.tsx`, `terms.tsx`) will now be server-rendered on every request instead of being statically cached.
+
+The spec describes the fetch as "once on the server (getInitialProps)" but does not call out this side effect. In practice the impact is limited because nearly every page already uses `getServerSideProps`, but it is still a regression for the handful that do not.
+
+**Options:**
+- Document this as a known trade-off in the spec and revisit during Phase 8 if it measurably affects TTFB.
+- If those static-capable pages must remain static, consider alternative approaches (e.g. a middleware-injected header, a singleton cache at the module level, or fetching the hubs list only inside pages that need it — which is the current state, to be consolidated in Phase 8).
+
+### 2. Double `getAllHubs` calls during SSR — fix now for 4 of 6 pages
+
+**Location:** `frontend/pages/_app.tsx:356` plus six page-level `getServerSideProps` functions
+
+The following pages call `getAllHubs` in their own `getServerSideProps`:
+
+| Page | Line | SSR usage | Can drop now? |
+|------|------|-----------|---------------|
+| `pages/browse.tsx` | 33 | Pure pass-through → `allHubs` prop | **Yes** |
+| `pages/events.tsx` | 47 | Pure pass-through → `allHubs` prop | **Yes** |
+| `pages/projects/[projectId]/index.tsx` | 102 | Pure pass-through → `hubs` prop | **Yes** |
+| `pages/hubs.tsx` | 47 | Pure pass-through → `hubs` prop | **Yes** |
+| `pages/hubs/[hubUrl]/events.tsx` | 61 | Hub existence check (→ 404) + pass-through | No (needs list for routing) |
+| `src/components/hub/HubBrowsePage.tsx` | 101 | Filters to `sectorHubs` subset + pass-through | No (needs list for derivation) |
+
+Every SSR request to these six pages currently hits the hubs API twice (once in `_app.getInitialProps`, once in the page). The spec defers this cleanup to Phase 8, but **4 of the 6 pages can already drop their `getAllHubs` call today** because they only use the result as a prop — and the identical data is now available via `HubContext.hubs`.
+
+**Suggested change (can be done in this PR or a quick follow-up):**
+
+For each of the 4 "pure pass-through" pages, remove the `getAllHubs` call from `getServerSideProps` and have the component read `hubs` from `useContext(HubContext)` instead of receiving it as a prop. This eliminates 4 redundant API calls per SSR request with no behavior change. Example for `pages/hubs.tsx`:
+
+```diff
+ // getServerSideProps — remove getAllHubs
+ export async function getServerSideProps(ctx: { locale: any }) {
+-  return {
+-    props: {
+-      hubs: await getAllHubs(ctx.locale),
+-    },
+-  };
++  return { props: {} };
+ }
+
+ // Component — read from context
+-export default function Hubs({ hubs }) {
++export default function Hubs() {
++  const { hubs } = useContext(HubContext);
+   // ... rest unchanged
+```
+
+The remaining 2 pages (`hubs/[hubUrl]/events.tsx`, `HubBrowsePage.tsx`) legitimately need the list in `getServerSideProps` for routing/filtering logic and should keep the call until Phase 8.
+
+### 3. `act()` warnings in HubContext tests — minor
+
+**Location:** `frontend/src/components/context/HubContext.test.tsx:81-89`
+
+The test "fetches hub data and theme on slug change, cached by slug" produces six React `act()` warnings in the console. The cause is that `setHubData`/`setHubTheme` (called inside a `useEffect` async callback at `HubContext.tsx:92-93`) are not wrapped in `act()` before `waitFor` checks the result.
+
+The tests still pass because `waitFor` retries until the assertion succeeds, but the warnings pollute the test output and may become errors in future React versions.
+
+**Suggested fix:** Replace `waitFor(() => expect(...))` with `await screen.findBy*` patterns or wrap the render in `act()`:
+
+```tsx
+it("fetches hub data and theme on slug change, cached by slug", async () => {
+  setRouter({ hubUrl: "erlangen" });
+  const { result } = renderHubContext([]);
+  await waitFor(() => {
+    expect(result.current.hubData).toEqual({ url_slug: "erlangen" });
+    expect(result.current.hubTheme).toEqual({ primary: "#fff" });
+  });
+  expect(mockGetHubData).toHaveBeenCalledWith("erlangen", "en");
+  expect(mockGetHubTheme).toHaveBeenCalledWith("erlangen");
+});
+```
+
+### 4. `any[]` typing for hubs — nice-to-have
+
+**Location:** `HubContext.tsx:17`, `_app.tsx:38`, `_app.tsx:339`, `HubContext.tsx:43`
+
+The hubs list is typed as `any[]` throughout. The codebase already has a `HubData` type in `src/types`. At minimum, the `HubContextValue.hubs` field and the `HubProvider.initialHubs` prop could use a narrow shape like `{ url_slug: string; name: string }[]` to get basic autocompletion and type checking without coupling to the full `HubData` type.
+
+### 5. Shim correctness — verified ✅
+
+**Location:** `frontend/pages/_app.tsx:45`, `_app.tsx:290`
+
+`HubContext` is new, so there are no existing direct consumers of it yet. The shim operates on the `UserContext` side: the old code at the pre-change `_app.tsx:284` called `getHubslugFromUrl(router.query)` directly to set `UserContext.hubUrl`; the new code reads the equivalent value from `HubContext` via `useContext(HubContext)` at line 45 and assigns it to the same `UserContext.hubUrl` field at line 290. Since `HubContext` internally calls the same `getHubslugFromUrl(router.query)` at `HubContext.tsx:47`, the values are identical and existing `UserContext.hubUrl` consumers are unaffected.
+
+### 6. Provider nesting is correct ✅
+
+**Location:** `frontend/pages/_app.tsx:333-348`, `_app.tsx:305-330`
+
+`HubProvider` wraps `AppContent`, which contains `FeatureToggleProvider` → `UserContext.Provider`. `useContext(HubContext)` at line 45 is inside `AppContent`, correctly reading from the outer `HubProvider`. The nesting order matches the spec.
+
+### 7. Hubs-list fallback fetch logic is correct ✅
+
+**Location:** `frontend/src/components/context/HubContext.tsx:48,58-70`
+
+When the server provides `initialHubs` (array or `null`):
+- `null` (API failure) → `useState(null ?? [])` initializes to `[]`; `!null` is `true` → client-side fallback fires.
+- `[]` (empty result) → `useState([] ?? [])` initializes to `[]`; `![]` is `false` → no refetch.
+- `[...hubs]` (normal) → uses the server data directly; no refetch.
+
+When `initialHubs` is `undefined` (not provided): `useState(undefined ?? [])` initializes to `[]`; `!undefined` is `true` → client-side fallback fires.
+
+All paths are correct.
+
+### 8. Hub data/theme caching is correct ✅
+
+**Location:** `frontend/src/components/context/HubContext.tsx:53-54,72-100`
+
+`useRef` caches keyed by slug. On slug change, cached values are set synchronously before the async fetch begins, then overwritten when the fetch completes. The `cancelled` flag in the cleanup function prevents stale state updates on rapid navigation. This matches the spec's "cached by slug" requirement.
+
+### 9. `getInitialProps` error handling — acceptable
+
+**Location:** `frontend/pages/_app.tsx:354-359`
+
+The outer try/catch around `getAllHubs` is technically unreachable because `getAllHubs` already catches internally and returns `null`. However, it provides a safety net for unexpected errors (e.g. if the import itself fails). The `console.log(e)` could be `console.error(e)` for consistency with other error handlers in the codebase, but this is cosmetic.
+
+### 10. `App.getInitialProps` call order — correct ✅
+
+**Location:** `frontend/pages/_app.tsx:351-352`
+
+`await App.getInitialProps(appContext)` is called first, preserving each page's own data fetching. The hubs fetch is appended to `pageProps` afterwards. This ensures existing page props are not overwritten.
+
+## Spec compliance checklist
+
+| Spec requirement | Status |
+|-----------------|--------|
+| `HubProvider` placed outside `UserContext.Provider` | ✅ |
+| Hubs list fetched once on the server (`getInitialProps`) | ✅ (per SSR request; see finding #1, #2) |
+| Exposes: active hub slug, active hub object, active hub theme, full hubs list | ✅ |
+| Active slug derived from `router.query` (`hubUrl` preferred, `?hub=` fallback) | ✅ |
+| `UserContext.hubUrl` becomes a shim reading from `HubContext` | ✅ |
+| Hub data/theme fetched on slug change, cached by slug | ✅ |
+| Resolver unit tests (`?hub=`, `/hubs/<slug>`, sub-hub → top-level slug) | ✅ |
+| Hubs-list fetched once test | ✅ |
+| Behavior unchanged (shim keeps old API working) | ✅ |
+
+## Recommendation
+
+**Ready to merge** with one caveat: finding #1 (static optimization regression) should be acknowledged in the spec or commit message. Finding #2 recommends dropping `getAllHubs` from 4 pure pass-through pages now — this is a small, low-risk change that eliminates redundant API calls immediately rather than waiting for Phase 8. The `act()` warnings (#3) can be fixed in a follow-up. All other findings are cosmetic.

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,7 +1,9 @@
 import CssBaseline from "@mui/material/CssBaseline";
 import { Theme, StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
 import { useRouter } from "next/router";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useContext, useState } from "react";
+import App from "next/app";
+import { getAllHubs } from "../public/lib/hubOperations";
 import ReactGA from "react-ga4";
 // Add global styles
 import "react-multi-carousel/lib/styles.css";
@@ -10,13 +12,13 @@ import { apiRequest } from "../public/lib/apiOperations";
 import { getCookieProps } from "../public/lib/cookieOperations";
 import WebSocketService from "../public/lib/webSockets";
 import UserContext from "../src/components/context/UserContext";
+import { HubContext, HubProvider } from "../src/components/context/HubContext";
 import { FeatureToggleProvider } from "../src/components/featureToggle";
 import { FeatureToggles } from "../src/hooks/types/featureToggle";
 import type { CcEnvironment } from "../public/lib/environmentOperations";
 import theme from "../src/themes/theme";
-import { CcLocale, DonationGoal } from "../src/types";
+import { CcLocale, DonationGoal, HubListItem } from "../src/types";
 import "../devlink/css/global.css";
-import { getHubslugFromUrl } from "../public/lib/hubOperations";
 
 declare module "@mui/styles/defaultTheme" {
   // eslint-disable-next-line no-unused-vars
@@ -25,7 +27,7 @@ declare module "@mui/styles/defaultTheme" {
 
 // This is lifted from a Material UI template at https://github.com/mui-org/material-ui/blob/master/examples/nextjs/pages/_app.js.
 
-export default function MyApp({
+function AppContent({
   Component,
   pageProps = {},
 }: {
@@ -33,10 +35,14 @@ export default function MyApp({
   pageProps: {
     featureToggles?: FeatureToggles;
     environment?: CcEnvironment;
+    hubs?: HubListItem[];
     [key: string]: any;
   };
 }) {
   const router = useRouter();
+  // `hubUrl` is shimmed to read from HubContext so existing consumers of
+  // `UserContext.hubUrl` keep working unchanged during the migration.
+  const { hubUrl: activeHubUrl } = useContext(HubContext);
   // Cookies
   const cookies = new Cookies();
   const token = cookies.get("auth_token");
@@ -281,7 +287,7 @@ export default function MyApp({
     CUSTOM_HUB_URLS: CUSTOM_HUB_URLS,
     setNotificationsRead: setNotificationsRead,
     pathName: pathName,
-    hubUrl: getHubslugFromUrl(router.query),
+    hubUrl: activeHubUrl,
     ReactGA: ReactGA,
     updateCookies: updateCookies,
     socketConnectionState: socketConnectionState,
@@ -323,6 +329,36 @@ export default function MyApp({
     </>
   );
 }
+
+export default function MyApp({
+  Component,
+  pageProps = {},
+}: {
+  Component: any;
+  pageProps: {
+    hubs?: HubListItem[];
+    [key: string]: any;
+  };
+}) {
+  return (
+    <HubProvider initialHubs={pageProps.hubs}>
+      <AppContent Component={Component} pageProps={pageProps} />
+    </HubProvider>
+  );
+}
+
+MyApp.getInitialProps = async (appContext: any) => {
+  // Run the page's own data fetching first so existing pageProps are preserved.
+  const appProps = await App.getInitialProps(appContext);
+  const locale = appContext.router.locale ?? "en";
+  let hubs = null;
+  try {
+    hubs = await getAllHubs(locale);
+  } catch (e) {
+    console.log(e);
+  }
+  return { ...appProps, pageProps: { ...appProps.pageProps, hubs } };
+};
 
 const getNotificationsToSetRead = (notifications, pageProps) => {
   let notifications_to_set_unread: any[] = [];

--- a/frontend/pages/browse.tsx
+++ b/frontend/pages/browse.tsx
@@ -9,11 +9,11 @@ import {
   getSectorOptions,
   getSkillsOptions,
 } from "../public/lib/getOptions";
-import { getAllHubs } from "../public/lib/hubOperations";
 import { getLocationFilteredBy } from "../public/lib/locationOperations";
 import { nullifyUndefinedValues } from "../public/lib/profileOperations";
 import BrowseContent from "../src/components/browse/BrowseContent";
 import UserContext from "../src/components/context/UserContext";
+import { HubContext } from "../src/components/context/HubContext";
 import TopOfPage from "../src/components/hooks/TopOfPage";
 import WideLayout from "../src/components/layouts/WideLayout";
 import BrowseContext from "../src/components/context/BrowseContext";
@@ -23,14 +23,12 @@ export async function getServerSideProps(ctx) {
   const { hideInfo } = NextCookies(ctx);
   const [
     organization_types,
-    hubs,
     location_filtered_by,
     projectTypes,
     sectorOptions,
     skills,
   ] = await Promise.all([
     getOrganizationTagsOptions(ctx.locale),
-    getAllHubs(ctx.locale),
     getLocationFilteredBy(ctx.query, ctx.locale),
     getProjectTypeOptions(ctx.locale),
     getSectorOptions(ctx.locale),
@@ -44,17 +42,17 @@ export async function getServerSideProps(ctx) {
         skills: skills,
       },
       hideInfo: hideInfo === "true",
-      hubs: hubs,
       initialLocationFilter: location_filtered_by,
       projectTypes: projectTypes,
     }),
   };
 }
 
-export default function Browse({ filterChoices, hubs, initialLocationFilter, projectTypes }) {
+export default function Browse({ filterChoices, initialLocationFilter, projectTypes }) {
   const cookies = new Cookies();
   const token = cookies.get("auth_token");
   const { locale, refreshUser } = useContext(UserContext);
+  const { hubs } = useContext(HubContext);
 
   // Refresh user data when returning to this page
   useEffect(() => {

--- a/frontend/pages/events.tsx
+++ b/frontend/pages/events.tsx
@@ -3,12 +3,12 @@ import NextCookies from "next-cookies";
 import React, { useContext, useMemo } from "react";
 import { useRouter } from "next/router";
 import { Theme, useMediaQuery } from "@mui/material";
-import { getAllHubs } from "../public/lib/hubOperations";
 import { getSectorOptions } from "../public/lib/getOptions";
 import { apiRequest } from "../public/lib/apiOperations";
 import { getFeatureTogglesFromRequest } from "../src/hooks/featureToggles";
 import getTexts from "../public/texts/texts";
 import UserContext from "../src/components/context/UserContext";
+import { HubContext } from "../src/components/context/HubContext";
 import WideLayout from "../src/components/layouts/WideLayout";
 import HubTabsNavigation from "../src/components/hub/HubTabsNavigation";
 import EventCalendarContent from "../src/components/eventCalendar/EventCalendarContent";
@@ -44,7 +44,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const locale = ctx.locale ?? "en";
   const token = NextCookies(ctx).auth_token;
 
-  const [hubs, sectorOptions] = await Promise.all([getAllHubs(locale), getSectorOptions(locale)]);
+  const [sectorOptions] = await Promise.all([getSectorOptions(locale)]);
 
   let initialEvents: any[] = [];
   try {
@@ -62,15 +62,15 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 
   return {
     props: {
-      hubs,
       filterChoices: { sectors: sectorOptions },
       initialEvents,
     },
   };
 };
 
-export default function EventsPage({ hubs, filterChoices, initialEvents }: any) {
+export default function EventsPage({ filterChoices, initialEvents }: any) {
   const { locale, hubUrl } = useContext(UserContext);
+  const { hubs } = useContext(HubContext);
   const router = useRouter();
   const isNarrowScreen = useMediaQuery<Theme>((theme) => theme.breakpoints.down("md"));
   const texts = useMemo(() => getTexts({ page: "hub", locale: locale }), [locale]);

--- a/frontend/pages/hubs.tsx
+++ b/frontend/pages/hubs.tsx
@@ -1,9 +1,9 @@
 import { Container, Theme, Typography, useMediaQuery } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import React, { useContext } from "react";
-import { getAllHubs } from "../public/lib/hubOperations";
 import getTexts from "../public/texts/texts";
 import UserContext from "../src/components/context/UserContext";
+import { HubContext } from "../src/components/context/HubContext";
 import HubHeaderImage from "../src/components/hub/HubHeaderImage";
 import HubPreviews from "../src/components/hub/HubPreviews";
 import NavigationSubHeader from "../src/components/hub/NavigationSubHeader";
@@ -41,18 +41,17 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export async function getServerSideProps(ctx: { locale: any }) {
+export async function getServerSideProps() {
   return {
-    props: {
-      hubs: await getAllHubs(ctx.locale),
-    },
+    props: {},
   };
 }
 
-export default function Hubs({ hubs }) {
+export default function Hubs() {
   const classes = useStyles();
   const isNarrowScreen = useMediaQuery<Theme>(theme.breakpoints.down("sm"));
   const { locale } = useContext(UserContext);
+  const { hubs } = useContext(HubContext);
   const texts = getTexts({ page: "hub", locale: locale });
   return (
     <WideLayout largeFooter noSpaceBottom title={texts.climate_action_hubs}>

--- a/frontend/pages/projects/[projectId]/index.tsx
+++ b/frontend/pages/projects/[projectId]/index.tsx
@@ -10,7 +10,6 @@ import PageNotFound from "../../../src/components/general/PageNotFound";
 import WideLayout from "../../../src/components/layouts/WideLayout";
 import ProjectPageRoot from "../../../src/components/project/ProjectPageRoot";
 import HubsSubHeader from "../../../src/components/indexPage/hubsSubHeader/HubsSubHeader";
-import { getAllHubs } from "../../../public/lib/hubOperations";
 import { useMediaQuery } from "@mui/material";
 import { getImageUrl } from "../../../public/lib/imageOperations";
 import { Theme } from "@mui/material/styles";
@@ -22,6 +21,7 @@ import theme from "../../../src/themes/theme";
 import { NOTIFICATION_TYPES } from "../../../src/components/communication/notifications/Notification";
 import { getProjectTypeOptions } from "../../../public/lib/getOptions";
 import BrowseContext from "../../../src/components/context/BrowseContext";
+import { HubContext } from "../../../src/components/context/HubContext";
 import { parseData } from "../../../public/lib/parsingOperations";
 import {
   WASSERAKTIONSWOCHEN_PARENT_SLUG,
@@ -89,7 +89,6 @@ export async function getServerSideProps(ctx) {
     posts,
     comments,
     userInteractions,
-    hubs,
     similarProjects,
     hubSupporters,
     hubThemeData,
@@ -99,7 +98,6 @@ export async function getServerSideProps(ctx) {
     getPostsByProject(projectUrl, auth_token, ctx.locale),
     getCommentsByProject(projectUrl, auth_token, ctx.locale),
     auth_token ? getUsersInteractionWithProject(projectUrl, auth_token, ctx.locale) : false,
-    getAllHubs(ctx.locale),
     getSimilarProjects(projectUrl, ctx.locale, hubUrl),
     hubUrl ? getHubSupporters(hubUrl, ctx.locale) : null,
     hubUrl ? getHubTheme(hubUrl) : null,
@@ -132,7 +130,6 @@ export async function getServerSideProps(ctx) {
       isRegistered: userInteractions.is_registered ?? false,
       hasAttended: userInteractions.has_attended ?? false,
       adminCancelled: userInteractions.admin_cancelled ?? false,
-      hubs: hubs,
       similarProjects: similarProjects,
       hubSupporters: hubSupporters,
       hubUrl,
@@ -154,7 +151,6 @@ export default function ProjectPage({
   isRegistered,
   hasAttended,
   adminCancelled,
-  hubs,
   similarProjects,
   hubSupporters,
   hubUrl,
@@ -174,6 +170,7 @@ export default function ProjectPage({
   const [numberOfLikes, setNumberOfLikes] = useState(project?.number_of_likes);
   const [numberOfFollowers, setNumberOfFollowers] = useState(project?.number_of_followers);
   const { CUSTOM_HUB_URLS, locale, user } = useContext(UserContext);
+  const { hubs } = useContext(HubContext);
   const texts = getTexts({ page: "project", locale: locale, project: project });
   const [showSimilarProjects, setShowSimilarProjects] = useState(true);
   const [projectTypes, setProjectTypes] = useState([]);

--- a/frontend/public/lib/hubOperations.test.ts
+++ b/frontend/public/lib/hubOperations.test.ts
@@ -1,0 +1,23 @@
+import { getHubslugFromUrl } from "./hubOperations";
+
+describe("getHubslugFromUrl", () => {
+  it("resolves the hub slug from the ?hub= query param", () => {
+    expect(getHubslugFromUrl({ hub: "erlangen" })).toBe("erlangen");
+  });
+
+  it("resolves the hub slug from the /hubs/<slug> path param (preferred)", () => {
+    expect(getHubslugFromUrl({ hubUrl: "erlangen" })).toBe("erlangen");
+  });
+
+  it("prefers the path param over ?hub= when both are present", () => {
+    expect(getHubslugFromUrl({ hubUrl: "erlangen", hub: "marburg" })).toBe("erlangen");
+  });
+
+  it("resolves the top-level slug from a sub-hub path (/hubs/<slug>/<subHub>/browse)", () => {
+    expect(getHubslugFromUrl({ hubUrl: "erlangen", subHub: "zerowaste" })).toBe("erlangen");
+  });
+
+  it("returns undefined when no hub is present", () => {
+    expect(getHubslugFromUrl({})).toBeUndefined();
+  });
+});

--- a/frontend/src/components/context/HubContext.test.tsx
+++ b/frontend/src/components/context/HubContext.test.tsx
@@ -1,0 +1,110 @@
+import { useContext } from "react";
+import type { ReactNode } from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { HubContext, HubProvider } from "./HubContext";
+import { HubListItem } from "../../types";
+
+const mockGetAllHubs = jest.fn();
+const mockGetHubData = jest.fn();
+const mockGetHubTheme = jest.fn();
+
+jest.mock("../../../public/lib/hubOperations", () => ({
+  getAllHubs: (...args: any[]) => mockGetAllHubs(...args),
+  getHubslugFromUrl: (query: any) => query.hubUrl || query.hub,
+}));
+jest.mock("../../../public/lib/getHubData", () => ({
+  getHubData: (...args: any[]) => mockGetHubData(...args),
+}));
+jest.mock("../../themes/fetchHubTheme", () => ({
+  __esModule: true,
+  default: (...args: any[]) => mockGetHubTheme(...args),
+}));
+
+const mockUseRouter = jest.fn();
+jest.mock("next/router", () => ({
+  useRouter: () => mockUseRouter(),
+}));
+
+const setRouter = (query: Record<string, any>, locale = "en") =>
+  mockUseRouter.mockReturnValue({ query, locale });
+
+// Renders the provider and lets the async hub data/theme fetch settle so that
+// the resulting state updates happen inside `act()` (no console warnings).
+const renderHubContext = (initialHubs?: HubListItem[]) => {
+  const hook = renderHook(() => useContext(HubContext), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <HubProvider initialHubs={initialHubs}>{children}</HubProvider>
+    ),
+  });
+  return hook;
+};
+
+const settleHubFetch = (result: ReturnType<typeof renderHubContext>["result"]) =>
+  waitFor(() => expect(result.current.hubData).not.toBeNull());
+
+describe("HubProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAllHubs.mockResolvedValue([{ url_slug: "erlangen", name: "Erlangen" }]);
+    mockGetHubData.mockResolvedValue({ url_slug: "erlangen" });
+    mockGetHubTheme.mockResolvedValue({ primary: "#fff" });
+  });
+
+  it("exposes the active hub slug derived from the URL query", async () => {
+    setRouter({ hubUrl: "erlangen" });
+    const { result } = renderHubContext([]);
+    expect(result.current.hubUrl).toBe("erlangen");
+    await settleHubFetch(result);
+  });
+
+  it("falls back to ?hub= when no path param is present", async () => {
+    setRouter({ hub: "marburg" });
+    const { result } = renderHubContext([]);
+    expect(result.current.hubUrl).toBe("marburg");
+    await settleHubFetch(result);
+  });
+
+  it("resolves the top-level slug on a sub-hub path", async () => {
+    setRouter({ hubUrl: "erlangen", subHub: "zerowaste" });
+    const { result } = renderHubContext([]);
+    expect(result.current.hubUrl).toBe("erlangen");
+    await settleHubFetch(result);
+  });
+
+  it("fetches the hubs list exactly once on the client when not provided by the server", async () => {
+    setRouter({});
+    renderHubContext(undefined);
+    await waitFor(() => expect(mockGetAllHubs).toHaveBeenCalledTimes(1));
+  });
+
+  it("does NOT refetch the hubs list when the server already provided it", () => {
+    setRouter({});
+    renderHubContext([{ url_slug: "erlangen", name: "Erlangen" }]);
+    expect(mockGetAllHubs).not.toHaveBeenCalled();
+  });
+
+  it("exposes the server-provided hubs list", () => {
+    const hubs: HubListItem[] = [{ url_slug: "erlangen", name: "Erlangen" }];
+    setRouter({});
+    const { result } = renderHubContext(hubs);
+    expect(result.current.hubs).toBe(hubs);
+  });
+
+  it("fetches hub data and theme on slug change, cached by slug", async () => {
+    setRouter({ hubUrl: "erlangen" });
+    const { result } = renderHubContext([]);
+    await waitFor(() => {
+      expect(result.current.hubData).toEqual({ url_slug: "erlangen" });
+      expect(result.current.hubTheme).toEqual({ primary: "#fff" });
+    });
+    expect(mockGetHubData).toHaveBeenCalledWith("erlangen", "en");
+    expect(mockGetHubTheme).toHaveBeenCalledWith("erlangen");
+  });
+
+  it("clears hub data/theme when no hub is active", () => {
+    setRouter({});
+    const { result } = renderHubContext([]);
+    expect(result.current.hubData).toBeNull();
+    expect(result.current.hubTheme).toBeNull();
+  });
+});

--- a/frontend/src/components/context/HubContext.tsx
+++ b/frontend/src/components/context/HubContext.tsx
@@ -1,0 +1,104 @@
+import React, { createContext, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/router";
+import { getAllHubs, getHubslugFromUrl } from "../../../public/lib/hubOperations";
+import { getHubData } from "../../../public/lib/getHubData";
+import getHubTheme from "../../themes/fetchHubTheme";
+import { HubData, HubListItem, LocaleType } from "../../types";
+
+export interface HubContextValue {
+  /** Active hub slug derived from the URL (top-level slug on sub-hub pages). */
+  hubUrl: string;
+  /** Full active hub object, when one is set. */
+  hubData: HubData | null;
+  /** Active hub theme, when a hub is active and a theme exists. */
+  hubTheme: any | null;
+  /** Full hubs list, fetched once and shared app-wide. */
+  hubs: HubListItem[];
+}
+
+const defaultHubContextValue: HubContextValue = {
+  hubUrl: "",
+  hubData: null,
+  hubTheme: null,
+  hubs: [],
+};
+
+export const HubContext = createContext<HubContextValue>(defaultHubContextValue);
+
+/**
+ * App-wide source of truth for "the active hub". It is placed *outside*
+ * `UserContext.Provider` in `pages/_app.tsx` so that `UserContext.hubUrl` can
+ * be shimmed to read from here during the migration.
+ *
+ * - The hubs list is fetched once (on the server via `getInitialProps`) and
+ *   shared by every page; the client never refetches it.
+ * - The active slug is derived reactively from `router.query` (path `hubUrl`
+ *   preferred, `?hub=` fallback) and updates on client-side navigation.
+ * - Hub data + theme are fetched on slug change and cached by slug.
+ */
+export function HubProvider({
+  initialHubs,
+  children,
+}: {
+  initialHubs?: HubListItem[];
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const hubUrl = getHubslugFromUrl(router.query) || "";
+  const [hubs, setHubs] = useState<any[]>(initialHubs ?? []);
+  const [hubData, setHubData] = useState<HubData | null>(null);
+  const [hubTheme, setHubTheme] = useState<any | null>(null);
+
+  // In-memory caches keyed by slug so repeated visits to a hub don't refetch.
+  const hubDataCache = useRef<Record<string, HubData | null>>({});
+  const hubThemeCache = useRef<Record<string, any | null>>({});
+
+  // Fallback client-side fetch of the hubs list if the server didn't provide
+  // it (e.g. after a full client-side reload before any SSR pass).
+  useEffect(() => {
+    let cancelled = false;
+    if (!initialHubs) {
+      (async () => {
+        const list = await getAllHubs(router.locale as LocaleType);
+        if (!cancelled) setHubs(list ?? []);
+      })();
+    }
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialHubs]);
+
+  // Fetch hub data + theme whenever the active slug changes, cached by slug.
+  useEffect(() => {
+    if (!hubUrl) {
+      setHubData(null);
+      setHubTheme(null);
+      return;
+    }
+
+    const cachedData = hubDataCache.current[hubUrl];
+    const cachedTheme = hubThemeCache.current[hubUrl];
+    if (cachedData !== undefined) setHubData(cachedData);
+    if (cachedTheme !== undefined) setHubTheme(cachedTheme);
+
+    let cancelled = false;
+    (async () => {
+      const locale = (router.locale as LocaleType) ?? "en";
+      const [data, theme] = await Promise.all([getHubData(hubUrl, locale), getHubTheme(hubUrl)]);
+      if (cancelled) return;
+      hubDataCache.current[hubUrl] = data;
+      hubThemeCache.current[hubUrl] = theme;
+      setHubData(data);
+      setHubTheme(theme);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hubUrl]);
+
+  const value: HubContextValue = { hubUrl, hubData, hubTheme, hubs };
+  return <HubContext.Provider value={value}>{children}</HubContext.Provider>;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -278,6 +278,17 @@ export interface HubData {
   [key: string]: any;
 }
 
+/**
+ * Minimal shape of an item in the shared hubs list (from `/api/hubs/`).
+ * `url_slug` and `name` are the fields consumed app-wide; the index signature
+ * keeps the type permissive for optional fields like `icon` / `landing_page_component`.
+ */
+export interface HubListItem {
+  url_slug: string;
+  name: string;
+  [key: string]: any;
+}
+
 export type DonationGoal = {
   goal_name: string | undefined;
   goal_start: string | undefined;


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Phase 1 implementation for #2130 
