### PR TITLE
Implement phase 3 of hubcontext refactor

### DIFF
--- a/frontend/public/lib/headerLinks.ts
+++ b/frontend/public/lib/headerLinks.ts
@@ -9,7 +9,7 @@ import InfoIcon from "@mui/icons-material/Info";
 import MailOutlineIcon from "@mui/icons-material/MailOutline";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import SettingsIcon from "@mui/icons-material/Settings";
-import { getLocalePrefix } from "./apiOperations";
+import { appHref } from "./appLink";
 import { getCustomHubData } from "../data/customHubData";
 import { WASSERAKTIONSWOCHEN_PATH } from "../data/wasseraktionswochen_config";
 
@@ -24,12 +24,10 @@ const COMMON_LINKS = {
     onlyShowIconOnMobile: true,
     icon: NotificationsIcon,
     alwaysDisplayDirectly: true,
-    onlyShowLoggedIn: true,
-    // Fixed issue where missing href caused redirection issues on mobile.
     onlyShowOnNormalScreen: true,
   },
   SHARE: (hubUrl?: string) => ({
-    href: hubUrl ? `/share?hub=${hubUrl}` : `/share`,
+    href: appHref("/share", { hubUrl }),
     iconForDrawer: AddCircleIcon,
     icon: AddCircleOutlineIcon,
     hideDesktopIconUnderSm: true,
@@ -328,7 +326,12 @@ const getStaticLinkFromItem = (locale, item) => {
   if (item.isExternalLink) {
     return item.href;
   }
-  return `${getLocalePrefix(locale)}${item.href}`;
+  // Static / hub-switcher targets are global or hub-route destinations, so the
+  // active `?hub=` must never be appended (Category C). `appHref` applies the
+  // locale prefix and — because hub routes (`/hubs/...`) already convey the hub
+  // in their path — skips `?hub=` automatically, preventing a stale
+  // `?hub=<old>` from leaking onto a different hub.
+  return appHref(item.href, { leaveHub: true, locale });
 };
 
 export { getLinks, getLoggedInLinks, getStaticLinks, getStaticLinkFromItem, COMMON_LINKS };

--- a/frontend/src/components/browse/BrowseContent.tsx
+++ b/frontend/src/components/browse/BrowseContent.tsx
@@ -609,7 +609,6 @@ export default function BrowseContent({
               hasMore={state.hasMore.organizations}
               loadFunc={() => handleLoadMoreData("organizations")}
               organizations={state.items.organizations}
-              hubUrl={hubUrl}
               parentHandlesGridItems
               isLoading={isFetchingMoreData}
             />

--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { Box, Link, Theme, useMediaQuery } from "@mui/material";
+import { Box, Theme, useMediaQuery } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import FacebookIcon from "@mui/icons-material/Facebook";
 import FavoriteIcon from "@mui/icons-material/Favorite";
@@ -6,7 +6,7 @@ import GitHubIcon from "@mui/icons-material/GitHub";
 import InstagramIcon from "@mui/icons-material/Instagram";
 import YouTubeIcon from "@mui/icons-material/YouTube";
 import React, { useContext } from "react";
-import { getLocalePrefix } from "../../../public/lib/apiOperations";
+import AppLink from "../general/AppLink";
 import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
 import SocialMediaButton from "../general/SocialMediaButton";
@@ -163,15 +163,15 @@ const SmallFooter = ({
     >
       <Box className={classes.flexContainer}>
         <Box className={classes.leftBox}>
-          <Link href={getLocalePrefix(locale) + "/imprint"} color="inherit" underline="hover">
+          <AppLink href="/imprint" leaveHub color="inherit" underline="hover">
             <span className={`${classes.inheritColor} ${classes.link}`}>{texts.imprint}</span>
-          </Link>
-          <Link href={getLocalePrefix(locale) + "/privacy"} color="inherit" underline="hover">
+          </AppLink>
+          <AppLink href="/privacy" leaveHub color="inherit" underline="hover">
             <span className={`${classes.inheritColor} ${classes.link}`}>{texts.privacy}</span>
-          </Link>
-          <Link href={getLocalePrefix(locale) + "/terms"} color="inherit" underline="hover">
+          </AppLink>
+          <AppLink href="/terms" leaveHub color="inherit" underline="hover">
             <span className={classes.inheritColor}>{texts.terms}</span>
-          </Link>
+          </AppLink>
         </Box>
         {!isNarrowScreen && (
           <Box component="span" className={classes.centerText}>

--- a/frontend/src/components/general/AppLink.tsx
+++ b/frontend/src/components/general/AppLink.tsx
@@ -1,40 +1,31 @@
-import Link from "next/link";
+import NextLink from "next/link";
 import { useRouter } from "next/router";
-import React, { ComponentProps, useContext } from "react";
+import React, { useContext } from "react";
+import MuiLink, { LinkProps as MuiLinkProps } from "@mui/material/Link";
 import { appHref } from "../../../public/lib/appLink";
 import { HubContext } from "../context/HubContext";
 
-type NextLinkProps = ComponentProps<typeof Link>;
-
-export interface AppLinkProps extends Omit<NextLinkProps, "href"> {
-  /**
-   * Destination href. Relative paths (starting with `/`) receive the locale
-   * prefix and — unless `leaveHub` is set — the active `?hub=` slug. Absolute /
-   * external URLs are passed through untouched.
-   */
-  href: NextLinkProps["href"];
-  /**
-   * When true, the active hub is *not* appended (Category B — "intentionally
-   * leave hub"). Greppable so reviewers can audit leave-hub decisions.
-   */
-  leaveHub?: boolean;
-}
-
 /**
- * The standard internal-navigation link: a thin wrapper over `next/link` that
- * builds a hub- and locale-aware href so callers never hand-concatenate
- * `?hub=` or the locale prefix.
+ * The standard internal-navigation link. It is an extension of MUI's `Link`:
+ * every MUI `Link` prop (`color`, `underline`, `variant`, `typography`, ...)
+ * keeps working exactly as before, and we only add `leaveHub`.
  *
- * "Preserve hub" is the default: the active hub slug (read from `HubContext`)
- * is appended as `?hub=<slug>` for internal cross-entity navigation, and the
- * locale prefix is applied to relative paths. Both transformations are
- * delegated to the shared `appHref` helper, so query strings, fragments and
- * encoding are always well-formed.
+ * Under the hood it renders MUI's `Link` with `next/link` as the underlying
+ * component, so clicks are handled by the Next.js router. The `href` is built
+ * by `appHref` from the active hub (read from `HubContext`) and the current
+ * locale, so callers never hand-concatenate `?hub=` or the locale prefix.
  *
- * The resolved href is pre-prefixed and passed to `next/link` *without* a
- * `locale` prop — matching the existing `next/link` call sites, so no double
- * prefix is produced. All other props are forwarded unchanged.
+ * "Preserve hub" is the default: the active hub slug is appended as
+ * `?hub=<slug>` for internal cross-entity navigation. External / absolute URLs
+ * are passed through untouched. `leaveHub` opts out of the `?hub=` append
+ * (Category B — intentionally leaving the hub) and is greppable so reviewers
+ * can audit leave-hub decisions.
  */
+export type AppLinkProps = MuiLinkProps & {
+  href: string | object;
+  leaveHub?: boolean;
+};
+
 export default function AppLink({ href, leaveHub = false, ...rest }: AppLinkProps) {
   const router = useRouter();
   const { hubUrl } = useContext(HubContext);
@@ -44,5 +35,5 @@ export default function AppLink({ href, leaveHub = false, ...rest }: AppLinkProp
   const resolvedHref =
     typeof href === "string" ? appHref(href, { leaveHub, hubUrl, locale: router.locale }) : href;
 
-  return <Link href={resolvedHref} {...rest} />;
+  return <MuiLink component={NextLink} href={resolvedHref} {...rest} />;
 }

--- a/frontend/src/components/general/LoginNudge.tsx
+++ b/frontend/src/components/general/LoginNudge.tsx
@@ -1,7 +1,7 @@
-import { Link, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import React, { useContext } from "react";
-import { getLocalePrefix } from "../../../public/lib/apiOperations";
+import AppLink from "../general/AppLink";
 import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
 import { useRouter } from "next/router";
@@ -29,31 +29,26 @@ export default function LoginNudge({ whatToDo, fullPage, className }: Props) {
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "general", locale: locale });
 
-  const urlParams = new URLSearchParams(window.location.search);
-  const hub = urlParams.get("hub");
   const router = useRouter();
   const currentPath = router.asPath;
   const encodedRedirectUrl = encodeURIComponent(currentPath);
-  let path_to_signin = `${getLocalePrefix(locale)}/signin?`;
-  let path_to_signup = `${getLocalePrefix(locale)}/signup`;
-  path_to_signin += `redirect=${encodedRedirectUrl}`;
-
-  if (hub && hub !== "") {
-    path_to_signin += `&hub=${hub}`;
-    path_to_signup += `?hub=${hub}`;
-  }
+  // `AppLink` reads the active hub from `HubContext` and applies the locale,
+  // appending `?hub=<slug>` and joining the existing `?redirect=` query with
+  // `&` (never a second `?`). The component no longer has to source hub state.
+  const signinHref = `/signin?redirect=${encodedRedirectUrl}`;
+  const signupHref = "/signup";
 
   return (
     <div className={`${fullPage && classes.loginNudge} ${className}`}>
       <Typography className={fullPage ? classes.loginNudgeText : undefined}>
         {texts.please}{" "}
-        <Link underline="always" color="primary" href={path_to_signin}>
+        <AppLink underline="always" color="primary" href={signinHref}>
           {texts.log_in}
-        </Link>{" "}
+        </AppLink>{" "}
         {texts.or}{" "}
-        <Link underline="always" color="primary" href={path_to_signup}>
+        <AppLink underline="always" color="primary" href={signupHref}>
           {texts.sign_up}
-        </Link>{" "}
+        </AppLink>{" "}
         {whatToDo}.
       </Typography>
     </div>

--- a/frontend/src/components/organization/MiniOrganizationPreview.tsx
+++ b/frontend/src/components/organization/MiniOrganizationPreview.tsx
@@ -1,8 +1,8 @@
-import { Avatar, IconButton, Link, Theme, Tooltip, Typography } from "@mui/material";
+import { Avatar, IconButton, Theme, Tooltip, Typography } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import CloseIcon from "@mui/icons-material/Close";
 import React, { useContext } from "react";
-import { getLocalePrefix } from "../../../public/lib/apiOperations";
+import AppLink from "../general/AppLink";
 import getTexts from "../../../public/texts/texts";
 import UserContext from "../context/UserContext";
 import { getImageUrl } from "./../../../public/lib/imageOperations";
@@ -63,16 +63,13 @@ export default function MiniOrganizationPreview({
   nolink,
   doNotShowName,
   inline,
-  hubUrl,
 }: any) {
-  const { locale } = useContext(UserContext);
-  const queryString = hubUrl ? "?hub=" + hubUrl : "";
   if (!nolink)
     return (
-      <Link
+      <AppLink
         className={className}
         color="inherit"
-        href={getLocalePrefix(locale) + `/organizations/${organization.url_slug}${queryString}`}
+        href={`/organizations/${organization.url_slug}`}
         target="_blank"
         underline="hover"
       >
@@ -83,7 +80,7 @@ export default function MiniOrganizationPreview({
           doNotShowName={doNotShowName}
           inline={inline}
         />
-      </Link>
+      </AppLink>
     );
   else
     return (

--- a/frontend/src/components/organization/OrganizationPreview.tsx
+++ b/frontend/src/components/organization/OrganizationPreview.tsx
@@ -1,8 +1,7 @@
-import { Box, Card, CardActions, Link, Tooltip, Typography } from "@mui/material";
+import { Box, Card, CardActions, Tooltip, Typography } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
-import React, { useContext } from "react";
-import { getLocalePrefix } from "../../../public/lib/apiOperations";
-import UserContext from "../context/UserContext";
+import React from "react";
+import AppLink from "../general/AppLink";
 import OrganizationPreviewHeader from "./OrganizationPreviewHeader";
 import OrganizationPreviewBody from "./OrganizationPreviewBody";
 import { AssignmentSharp, GroupSharp } from "@mui/icons-material";
@@ -74,16 +73,14 @@ const useStyles = makeStyles((theme) => {
   };
 });
 
-export default function OrganizationPreview({ organization, hubUrl }) {
+export default function OrganizationPreview({ organization }: { organization: any }) {
   const classes = useStyles();
-  const { locale } = useContext(UserContext);
-  const queryString = hubUrl ? "?hub=" + hubUrl : "";
 
   return (
-    <Link
-      href={getLocalePrefix(locale) + `/organizations/${organization.url_slug}${queryString}`}
-      className={classes.noUnderline}
+    <AppLink
+      href={`/organizations/${organization.url_slug}`}
       underline="hover"
+      className={classes.noUnderline}
     >
       <Card className={classes.root} variant="outlined">
         <OrganizationPreviewHeader organization={organization} />
@@ -107,6 +104,6 @@ export default function OrganizationPreview({ organization, hubUrl }) {
           </Box>
         </CardActions>
       </Card>
-    </Link>
+    </AppLink>
   );
 }

--- a/frontend/src/components/organization/OrganizationPreviews.tsx
+++ b/frontend/src/components/organization/OrganizationPreviews.tsx
@@ -21,14 +21,13 @@ export default function OrganizationPreviews({
   loadFunc,
   organizations,
   parentHandlesGridItems,
-  hubUrl,
   isLoading = false,
 }) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
   const texts = getTexts({ page: "organization", locale: locale });
   const toOrganizationPreviews = (organizations) =>
-    organizations.map((o) => <GridItem key={o.url_slug} organization={o} hubUrl={hubUrl} />);
+    organizations.map((o) => <GridItem key={o.url_slug} organization={o} />);
 
   const [gridItems, setGridItems] = useState(toOrganizationPreviews(organizations));
 
@@ -68,7 +67,7 @@ export default function OrganizationPreviews({
               {organization.props ? (
                 organization
               ) : (
-                <OrganizationPreview organization={organization} hubUrl={hubUrl} />
+                <OrganizationPreview organization={organization} />
               )}
             </Grid>
           );
@@ -79,6 +78,6 @@ export default function OrganizationPreviews({
   );
 }
 
-function GridItem({ organization, hubUrl }) {
-  return <OrganizationPreview organization={organization} hubUrl={hubUrl} />;
+function GridItem({ organization }) {
+  return <OrganizationPreview organization={organization} />;
 }

--- a/frontend/src/components/organization/OrganizationPreviewsFixed.tsx
+++ b/frontend/src/components/organization/OrganizationPreviewsFixed.tsx
@@ -63,7 +63,7 @@ export default function OrganizationPreviewsFixed({ organizations, isLoading }) 
                   className={`${classes.organization} ${index === 0 && classes.first}`}
                   key={organization.url_slug}
                 >
-                  <OrganizationPreview organization={organization} hubUrl="" />
+                  <OrganizationPreview organization={organization} />
                 </span>
               );
             })}

--- a/frontend/src/components/profile/ProfileRoot.tsx
+++ b/frontend/src/components/profile/ProfileRoot.tsx
@@ -261,7 +261,7 @@ export default function ProfileRoot({
           )}
         </div>
         {organizations && organizations.length > 0 ? (
-          <OrganizationPreviews organizations={organizations} hubUrl={hubUrl} />
+          <OrganizationPreviews organizations={organizations} />
         ) : (
           <Typography>
             {(isOwnAccount ? texts.you_are : texts.user_name_is) +

--- a/frontend/src/components/project/ProjectContent.test.tsx
+++ b/frontend/src/components/project/ProjectContent.test.tsx
@@ -4,7 +4,15 @@ import "@testing-library/jest-dom";
 import { ThemeProvider } from "@mui/material/styles";
 import theme from "../../themes/theme";
 import UserContext from "../context/UserContext";
+import { HubContext } from "../context/HubContext";
 import ProjectContent from "./ProjectContent";
+
+// `AppLink` (used via `MiniOrganizationPreview`) reads the active hub from
+// `HubContext` and the locale from the Next router, so tests that render
+// `ProjectContent` must provide both contexts.
+jest.mock("next/router", () => ({
+  useRouter: () => ({ locale: "en" }),
+}));
 
 // ResizeObserver is not available in JSDOM
 beforeAll(() => {
@@ -55,23 +63,25 @@ function renderProjectContent(projectOverrides = {}) {
   return render(
     <ThemeProvider theme={theme}>
       <UserContext.Provider value={defaultContext as any}>
-        <ProjectContent
-          discussionTabLabel=""
-          handleTabChange={jest.fn()}
-          latestParentComment={[]}
-          leaveProject={jest.fn()}
-          project={project}
-          projectTabsRef={{ current: null }}
-          typesByTabValue={{}}
-          showRequesters={false}
-          toggleShowRequests={jest.fn()}
-          handleSendProjectJoinRequest={jest.fn()}
-          requestedToJoinProject={false}
-          hubUrl={undefined}
-          eventRegistration={null}
-          onEventRegistrationUpdated={jest.fn()}
-          onMembersRefreshed={jest.fn()}
-        />
+        <HubContext.Provider value={{ hubUrl: "", hubData: null, hubTheme: null, hubs: [] }}>
+          <ProjectContent
+            discussionTabLabel=""
+            handleTabChange={jest.fn()}
+            latestParentComment={[]}
+            leaveProject={jest.fn()}
+            project={project}
+            projectTabsRef={{ current: null }}
+            typesByTabValue={{}}
+            showRequesters={false}
+            toggleShowRequests={jest.fn()}
+            handleSendProjectJoinRequest={jest.fn()}
+            requestedToJoinProject={false}
+            hubUrl={undefined}
+            eventRegistration={null}
+            onEventRegistrationUpdated={jest.fn()}
+            onMembersRefreshed={jest.fn()}
+          />
+        </HubContext.Provider>
       </UserContext.Provider>
     </ThemeProvider>
   );


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Part 3 of #2130 

This part shows how to use the new concept and directly fixes a link bug where the hub context was lost because calling components forgot to set the hub property. 
