### PR TITLE
Add backend and frontend version info

### DIFF
--- a/.github/workflows/master_climate-backend-appservice(slot2).yml
+++ b/.github/workflows/master_climate-backend-appservice(slot2).yml
@@ -42,6 +42,9 @@ jobs:
 
       # Optional: Add step to run tests here (PyTest, Django test suites, etc.)
 
+      - name: Write build info
+        run: echo '{"sha":"${{ github.sha }}","ref":"${{ github.ref_name }}","built_at":"${{ github.event.head_commit.timestamp }}"}' > backend/build_info.json
+
       - name: Zip artifact for deployment
         run: zip release.zip ./* -r
 

--- a/.github/workflows/master_climateconnect-frontend-appservice(slot2).yml
+++ b/.github/workflows/master_climateconnect-frontend-appservice(slot2).yml
@@ -48,6 +48,8 @@ jobs:
           yarn devlink-sync
           yarn build
         env:
+          BUILD_SHA: ${{ github.sha }}
+          BUILD_TIMESTAMP: ${{ github.event.head_commit.timestamp }}
           API_HOST: ${{ secrets.API_HOST }}
           CUSTOM_HUB_URLS: ${{ secrets.CUSTOM_HUB_URLS }}
           API_URL: ${{ secrets.API_URL }}

--- a/backend/climateconnect_api/views/status_views.py
+++ b/backend/climateconnect_api/views/status_views.py
@@ -1,3 +1,6 @@
+import json
+import pathlib
+
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.permissions import AllowAny
@@ -9,3 +12,14 @@ class PingPongView(APIView):
 
     def get(self, request):
         return Response({"result": "pong"}, status=status.HTTP_200_OK)
+
+
+class BuildInfoView(APIView):
+    permission_classes = (AllowAny,)
+
+    def get(self, request):
+        info_path = pathlib.Path(__file__).resolve().parents[2] / "build_info.json"
+        try:
+            return Response(json.loads(info_path.read_text()), status=status.HTTP_200_OK)
+        except FileNotFoundError:
+            return Response({"sha": "dev", "ref": "local", "built_at": None}, status=status.HTTP_200_OK)

--- a/backend/climateconnect_main/urls.py
+++ b/backend/climateconnect_main/urls.py
@@ -52,6 +52,7 @@ urls = [
         name="swagger-ui",
     ),
     path("ping/", status_views.PingPongView.as_view(), name="ping-pong-api"),
+    path("api/version/", status_views.BuildInfoView.as_view(), name="build-info-api"),
     # User views
     path("login/", user_views.LoginView.as_view(), name="login-api"),
     path("logout/", knox_views.LogoutView.as_view(), name="logout-api"),

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -59,6 +59,7 @@ function buildSubdomainRedirects() {
 }
 
 module.exports = withBundleAnalyzer({
+  generateBuildId: async () => process.env.BUILD_SHA || "dev",
   // Workaround for Next 15 pages-router dev HMR crash when receiving malformed
   // `isrManifest` payloads (data can be `{}` before router is ready).
   devIndicators: false,
@@ -73,6 +74,8 @@ module.exports = withBundleAnalyzer({
     "API_URL",
     "BASE_URL",
     "BASE_URL_HOST",
+    "BUILD_SHA",
+    "BUILD_TIMESTAMP",
     "CUSTOM_HUB_URLS",
     "DONATION_CAMPAIGN_RUNNING",
     "ENVIRONMENT",

--- a/frontend/pages/api/version.ts
+++ b/frontend/pages/api/version.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res
+    .status(200)
+    .json({ sha: process.env.BUILD_SHA ?? "dev", built_at: process.env.BUILD_TIMESTAMP ?? null });
+}


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Minor devex change to add version information so we can see what build is actually running in production or staging. 
