### PR TITLE
Add missing localisations to event calendar

### DIFF
--- a/frontend/public/texts/getHubTexts.ts
+++ b/frontend/public/texts/getHubTexts.ts
@@ -171,6 +171,10 @@ export default function getHubTexts({ hubName, hubAmbassador }) {
       en: "More upcoming events",
       de: "Weitere anstehende Veranstaltungen",
     },
+    search_events: {
+      en: "Search events",
+      de: "Veranstaltungen suchen",
+    },
   };
 
   if (hubName === "Fashion") return { ...generalHubTexts, ...getFashionHubDescription() };

--- a/frontend/src/components/eventCalendar/EventCalendarEventList.tsx
+++ b/frontend/src/components/eventCalendar/EventCalendarEventList.tsx
@@ -260,7 +260,7 @@ export default function EventCalendarEventList({
             <Box key={group.key} ref={isLastGroup ? lastElementRef : undefined}>
               <div className={classes.dayHeader}>
                 <Badge
-                  badgeContent={isToday ? "Today" : null}
+                  badgeContent={isToday ? texts.today : null}
                   color="secondary"
                   className={classes.todayBadge}
                   anchorOrigin={{ vertical: "top", horizontal: "right" }}


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

small change for #2174 