### PR TITLE
Update styling and text for event calendar

### DIFF
--- a/frontend/public/texts/general_texts.json
+++ b/frontend/public/texts/general_texts.json
@@ -925,7 +925,7 @@
   },
   "event_calendar": {
     "en": "Event calendar",
-    "de": "Veranstaltungskalender"
+    "de": "Eventkalender"
   },
   "filters": {
     "en": "Filters",
@@ -945,10 +945,10 @@
   },
   "no_events": {
     "en": "No events found for the selected filters.",
-    "de": "Keine Veranstaltungen für die ausgewählten Filter gefunden."
+    "de": "Keine Events für die ausgewählten Filter gefunden."
   },
   "error_loading_events": {
     "en": "Failed to load events.",
-    "de": "Veranstaltungen konnten nicht geladen werden."
+    "de": "Events konnten nicht geladen werden."
   }
 }

--- a/frontend/public/texts/getHubTexts.ts
+++ b/frontend/public/texts/getHubTexts.ts
@@ -161,19 +161,19 @@ export default function getHubTexts({ hubName, hubAmbassador }) {
     },
     upcoming_events: {
       en: "Upcoming events",
-      de: "Anstehende Veranstaltungen",
+      de: "Kommende Events",
     },
     event_calendar: {
       en: "Event Calendar",
-      de: "Event-Kalender",
+      de: "Eventkalender",
     },
     more_upcoming_events: {
       en: "More upcoming events",
-      de: "Weitere anstehende Veranstaltungen",
+      de: "Weitere anstehende Events",
     },
     search_events: {
       en: "Search events",
-      de: "Veranstaltungen suchen",
+      de: "Events suchen",
     },
   };
 

--- a/frontend/src/components/browse/UpcomingEventsGroup.tsx
+++ b/frontend/src/components/browse/UpcomingEventsGroup.tsx
@@ -1,5 +1,6 @@
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import DateRangeRoundedIcon from "@mui/icons-material/DateRangeRounded";
 import { Button, Typography } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import React, { useContext } from "react";
@@ -49,7 +50,7 @@ const useStyles = makeStyles((theme) => ({
   },
   title: {
     fontWeight: 700,
-    fontSize: 22,
+    fontSize: 20,
     color: theme.palette.primary.main,
     display: "flex",
     alignItems: "center",
@@ -74,6 +75,19 @@ const useStyles = makeStyles((theme) => ({
     whiteSpace: "nowrap",
     textTransform: "none",
     alignSelf: "center",
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+    "& .MuiButton-startIcon": {
+      marginRight: theme.spacing(0.5),
+    },
+    "& .MuiButton-endIcon": {
+      marginLeft: theme.spacing(0.5),
+    },
+  },
+  calendarButtonLabel: {
+    [theme.breakpoints.down(450)]: {
+      display: "none",
+    },
   },
 }));
 
@@ -102,12 +116,13 @@ export default function UpcomingEventsGroup({
             <Button
               className={classes.calendarButton}
               href={calendarHref}
+              startIcon={<DateRangeRoundedIcon />}
               endIcon={<ArrowForwardIcon />}
               variant="contained"
               color="primary"
               size="small"
             >
-              {texts.event_calendar}
+              <span className={classes.calendarButtonLabel}>{texts.event_calendar}</span>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Text and styling improvements for #2174 
