### PR TITLE
Clean up old redirects and add wue.climatehub.org redirect

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -12,51 +12,7 @@ const {
   WASSERAKTIONSWOCHEN_PARENT_SLUG,
 } = require("./public/data/wasseraktionswochen_config");
 
-const BASE_URL = process.env.BASE_URL || "https://climateconnect.earth";
 const LOCATION_HUBS = (process.env.LOCATION_HUBS || "").split(",").filter(Boolean);
-const CLIMATEORG_ACTIVE = process.env.CLIMATEORG_ACTIVE === "true";
-
-function buildSubdomainRedirects() {
-  const potsdamProjectRedirects = [
-    {
-      source: "/balkonsolar",
-      has: [{ type: "host", value: "potsdam.climateconnect.earth" }],
-      destination: `${BASE_URL}/de/projects/potsdam-balkon-solar?hub=potsdam&utm_source=subdomain&utm_medium=redirect&utm_campaign=potsdam&utm_content=balkonsolar`,
-      permanent: true,
-    },
-    {
-      source: "/stadtacker",
-      has: [{ type: "host", value: "potsdam.climateconnect.earth" }],
-      destination: `${BASE_URL}/de/projects/stadtacker-eine-bildungsgartnerei-der-zukunft-fur-potsdam?hub=potsdam&utm_source=subdomain&utm_medium=redirect&utm_campaign=potsdam&utm_content=stadtacker`,
-      permanent: true,
-    },
-    {
-      source: "/fassadenbegrünung",
-      has: [{ type: "host", value: "potsdam.climateconnect.earth" }],
-      destination: `${BASE_URL}/de/projects/stadtgrun-fassadenbegrunung?hub=potsdam&utm_source=subdomain&utm_medium=redirect&utm_campaign=potsdam&utm_content=fassadenbegruenung`,
-      permanent: true,
-    },
-  ];
-
-  const subdomainRedirectsDe = LOCATION_HUBS.map((hubSlug) => ({
-    source: "/:path*",
-    has: [
-      { type: "host", value: `${hubSlug}.climateconnect.earth` },
-      { type: "header", key: "Accept-Language", value: "^de" },
-    ],
-    destination: `${BASE_URL}/de/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
-    permanent: true,
-  }));
-
-  const subdomainRedirectsEn = LOCATION_HUBS.map((hubSlug) => ({
-    source: "/:path*",
-    has: [{ type: "host", value: `${hubSlug}.climateconnect.earth` }],
-    destination: `${BASE_URL}/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
-    permanent: true,
-  }));
-
-  return [...potsdamProjectRedirects, ...subdomainRedirectsDe, ...subdomainRedirectsEn];
-}
 
 module.exports = withBundleAnalyzer({
   generateBuildId: async () => process.env.BUILD_SHA || "dev",
@@ -85,7 +41,6 @@ module.exports = withBundleAnalyzer({
     "LETS_ENCRYPT_FILE_CONTENT",
     "SOCKET_URL",
     "WASSERAKTIONSWOCHEN_FEATURE",
-    "CLIMATEORG_ACTIVE",
     "WEBFLOW_API_TOKEN",
     "WEBFLOW_SITE_ID",
     "FRONTEND_SENTRY_DSN",
@@ -159,133 +114,106 @@ module.exports = withBundleAnalyzer({
       });
     }
 
-    let domainRedirects = [];
+    const domainRedirects = [
+      // 1. Potsdam project shortcuts on potsdam.climateconnect.earth
+      {
+        source: "/balkonsolar",
+        has: [{ type: "host", value: "potsdam.climateconnect.earth" }],
+        destination: `https://climatehub.org/de/projects/potsdam-balkon-solar?hub=potsdam&utm_source=subdomain&utm_medium=redirect&utm_campaign=potsdam&utm_content=balkonsolar`,
+        permanent: true,
+      },
+      {
+        source: "/stadtacker",
+        has: [{ type: "host", value: "potsdam.climateconnect.earth" }],
+        destination: `https://climatehub.org/de/projects/stadtacker-eine-bildungsgartnerei-der-zukunft-fur-potsdam?hub=potsdam&utm_source=subdomain&utm_medium=redirect&utm_campaign=potsdam&utm_content=stadtacker`,
+        permanent: true,
+      },
+      {
+        source: "/fassadenbegrünung",
+        has: [{ type: "host", value: "potsdam.climateconnect.earth" }],
+        destination: `https://climatehub.org/de/projects/stadtgrun-fassadenbegrunung?hub=potsdam&utm_source=subdomain&utm_medium=redirect&utm_campaign=potsdam&utm_content=fassadenbegruenung`,
+        permanent: true,
+      },
+      // 2. Cross-domain subdomain redirects (German first, then English fallback)
+      ...LOCATION_HUBS.map((hubSlug) => ({
+        source: "/:path*",
+        has: [
+          { type: "host", value: `${hubSlug}.climateconnect.earth` },
+          { type: "header", key: "Accept-Language", value: "^de" },
+        ],
+        destination: `https://climatehub.org/de/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
+        permanent: true,
+      })),
+      ...LOCATION_HUBS.map((hubSlug) => ({
+        source: "/:path*",
+        has: [{ type: "host", value: `${hubSlug}.climateconnect.earth` }],
+        destination: `https://climatehub.org/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
+        permanent: true,
+      })),
+      // 3. New-domain subdomain redirects (potsdam.climatehub.org → climatehub.org/hubs/potsdam)
+      ...LOCATION_HUBS.map((hubSlug) => ({
+        source: "/:path*",
+        has: [
+          { type: "host", value: `${hubSlug}.climatehub.org` },
+          { type: "header", key: "Accept-Language", value: "^de" },
+        ],
+        destination: `https://climatehub.org/de/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
+        permanent: true,
+      })),
+      ...LOCATION_HUBS.map((hubSlug) => ({
+        source: "/:path*",
+        has: [{ type: "host", value: `${hubSlug}.climatehub.org` }],
+        destination: `https://climatehub.org/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
+        permanent: true,
+      })),
+      // 4. Subdomain aliases (e.g. wue → wuerzburg)
+      {
+        source: "/:path*",
+        has: [
+          { type: "host", value: "wue.climateconnect.earth" },
+          { type: "header", key: "Accept-Language", value: "^de" },
+        ],
+        destination: `https://climatehub.org/de/hubs/wuerzburg?utm_source=subdomain&utm_medium=redirect&utm_campaign=wue`,
+        permanent: true,
+      },
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "wue.climateconnect.earth" }],
+        destination: `https://climatehub.org/hubs/wuerzburg?utm_source=subdomain&utm_medium=redirect&utm_campaign=wue`,
+        permanent: true,
+      },
+      {
+        source: "/:path*",
+        has: [
+          { type: "host", value: "wue.climatehub.org" },
+          { type: "header", key: "Accept-Language", value: "^de" },
+        ],
+        destination: `https://climatehub.org/de/hubs/wuerzburg?utm_source=subdomain&utm_medium=redirect&utm_campaign=wue`,
+        permanent: true,
+      },
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "wue.climatehub.org" }],
+        destination: `https://climatehub.org/hubs/wuerzburg?utm_source=subdomain&utm_medium=redirect&utm_campaign=wue`,
+        permanent: true,
+      },
+      // 5. Main domain catch-all (locale: false to preserve /de prefix in external redirect)
+      {
+        source: "/de/:path*",
+        has: [{ type: "host", value: "climateconnect.earth" }],
+        destination: `https://climatehub.org/de/:path*`,
+        permanent: true,
+        locale: false,
+      },
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "climateconnect.earth" }],
+        destination: `https://climatehub.org/:path*`,
+        permanent: true,
+      },
+    ];
 
-    if (CLIMATEORG_ACTIVE) {
-      // Post-switch: climateconnect.earth → climatehub.org (permanent 301)
-      domainRedirects = [
-        // 1. Potsdam project shortcuts on potsdam.climateconnect.earth
-        {
-          source: "/balkonsolar",
-          has: [{ type: "host", value: "potsdam.climateconnect.earth" }],
-          destination: `https://climatehub.org/de/projects/potsdam-balkon-solar?hub=potsdam&utm_source=subdomain&utm_medium=redirect&utm_campaign=potsdam&utm_content=balkonsolar`,
-          permanent: true,
-        },
-        {
-          source: "/stadtacker",
-          has: [{ type: "host", value: "potsdam.climateconnect.earth" }],
-          destination: `https://climatehub.org/de/projects/stadtacker-eine-bildungsgartnerei-der-zukunft-fur-potsdam?hub=potsdam&utm_source=subdomain&utm_medium=redirect&utm_campaign=potsdam&utm_content=stadtacker`,
-          permanent: true,
-        },
-        {
-          source: "/fassadenbegrünung",
-          has: [{ type: "host", value: "potsdam.climateconnect.earth" }],
-          destination: `https://climatehub.org/de/projects/stadtgrun-fassadenbegrunung?hub=potsdam&utm_source=subdomain&utm_medium=redirect&utm_campaign=potsdam&utm_content=fassadenbegruenung`,
-          permanent: true,
-        },
-        // 2. Cross-domain subdomain redirects (German first, then English fallback)
-        ...LOCATION_HUBS.map((hubSlug) => ({
-          source: "/:path*",
-          has: [
-            { type: "host", value: `${hubSlug}.climateconnect.earth` },
-            { type: "header", key: "Accept-Language", value: "^de" },
-          ],
-          destination: `https://climatehub.org/de/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
-          permanent: true,
-        })),
-        ...LOCATION_HUBS.map((hubSlug) => ({
-          source: "/:path*",
-          has: [{ type: "host", value: `${hubSlug}.climateconnect.earth` }],
-          destination: `https://climatehub.org/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
-          permanent: true,
-        })),
-        // 3. New-domain subdomain redirects (potsdam.climatehub.org → climatehub.org/hubs/potsdam)
-        ...LOCATION_HUBS.map((hubSlug) => ({
-          source: "/:path*",
-          has: [
-            { type: "host", value: `${hubSlug}.climatehub.org` },
-            { type: "header", key: "Accept-Language", value: "^de" },
-          ],
-          destination: `https://climatehub.org/de/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
-          permanent: true,
-        })),
-        ...LOCATION_HUBS.map((hubSlug) => ({
-          source: "/:path*",
-          has: [{ type: "host", value: `${hubSlug}.climatehub.org` }],
-          destination: `https://climatehub.org/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
-          permanent: true,
-        })),
-        // 4. Main domain catch-all (locale: false to preserve /de prefix in external redirect)
-        {
-          source: "/de/:path*",
-          has: [{ type: "host", value: "climateconnect.earth" }],
-          destination: `https://climatehub.org/de/:path*`,
-          permanent: true,
-          locale: false,
-        },
-        {
-          source: "/:path*",
-          has: [{ type: "host", value: "climateconnect.earth" }],
-          destination: `https://climatehub.org/:path*`,
-          permanent: true,
-        },
-      ];
-    } else {
-      // Pre-switch: climatehub.org → climateconnect.earth (temporary 302)
-      domainRedirects = [
-        // 1. Potsdam project shortcuts on potsdam.climatehub.org
-        {
-          source: "/balkonsolar",
-          has: [{ type: "host", value: "potsdam.climatehub.org" }],
-          destination: `${BASE_URL}/de/projects/potsdam-balkon-solar?hub=potsdam&utm_source=subdomain&utm_medium=redirect&utm_campaign=potsdam&utm_content=balkonsolar`,
-          permanent: false,
-        },
-        {
-          source: "/stadtacker",
-          has: [{ type: "host", value: "potsdam.climatehub.org" }],
-          destination: `${BASE_URL}/de/projects/stadtacker-eine-bildungsgartnerei-der-zukunft-fur-potsdam?hub=potsdam&utm_source=subdomain&utm_medium=redirect&utm_campaign=potsdam&utm_content=stadtacker`,
-          permanent: false,
-        },
-        {
-          source: "/fassadenbegrünung",
-          has: [{ type: "host", value: "potsdam.climatehub.org" }],
-          destination: `${BASE_URL}/de/projects/stadtgrun-fassadenbegrunung?hub=potsdam&utm_source=subdomain&utm_medium=redirect&utm_campaign=potsdam&utm_content=fassadenbegruenung`,
-          permanent: false,
-        },
-        // 2. Cross-domain subdomain redirects (German first, then English fallback)
-        ...LOCATION_HUBS.map((hubSlug) => ({
-          source: "/:path*",
-          has: [
-            { type: "host", value: `${hubSlug}.climatehub.org` },
-            { type: "header", key: "Accept-Language", value: "^de" },
-          ],
-          destination: `${BASE_URL}/de/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
-          permanent: false,
-        })),
-        ...LOCATION_HUBS.map((hubSlug) => ({
-          source: "/:path*",
-          has: [{ type: "host", value: `${hubSlug}.climatehub.org` }],
-          destination: `${BASE_URL}/hubs/${hubSlug}?utm_source=subdomain&utm_medium=redirect&utm_campaign=${hubSlug}`,
-          permanent: false,
-        })),
-        // 3. Main domain catch-all (locale: false to preserve /de prefix in external redirect)
-        {
-          source: "/de/:path*",
-          has: [{ type: "host", value: "climatehub.org" }],
-          destination: `${BASE_URL}/de/:path*`,
-          permanent: false,
-          locale: false,
-        },
-        {
-          source: "/:path*",
-          has: [{ type: "host", value: "climatehub.org" }],
-          destination: `${BASE_URL}/:path*`,
-          permanent: false,
-        },
-      ];
-    }
-
-    return [...domainRedirects, ...buildSubdomainRedirects(), ...existingRedirects];
+    return [...domainRedirects, ...existingRedirects];
   },
   webpack(config) {
     config.module.rules.push({


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Implements #2184 and cleans up now obsolete old redirects.
