### PR TITLE
Call am_i_following api when user is login

### DIFF
--- a/doc/spec/20260804_1030_prevent_guest_am_i_following_calls_on_org_pages.md
+++ b/doc/spec/20260804_1030_prevent_guest_am_i_following_calls_on_org_pages.md
@@ -1,0 +1,108 @@
+# Prevent guest users from triggering the organization follow-state API on organization pages
+
+**Status**: DRAFT
+**Type**: Frontend
+**Issue**: #2175
+**Date created**: 2026-08-04
+
+---
+
+## Problem Statement
+
+The organization detail page currently calls the follow-state endpoint at `/api/organizations/[org slug]/am_i_following/` even when the user is not authenticated.
+
+This causes unnecessary backend errors and noisy error logs for guest users visiting organization pages. The issue is especially visible on the organization detail page flow where the page fetches follow-state during server-side data loading.
+
+The expected behavior is that this follow-status request is only made for authenticated users.
+
+---
+
+## Goals / Scope
+
+- Prevent the frontend from calling the organization follow-state endpoint for guest users.
+- Preserve the existing behavior for authenticated users, including the current follow-state UI and data flow.
+- Keep the fix focused on the organization detail page experience and avoid unrelated API or permission changes.
+
+### In scope
+- The organization detail page SSR/data-loading path.
+- Any initial follow-state fetch that runs before the page renders.
+- A regression-safe behavior change so guest requests skip the follow-state lookup.
+
+### Out of scope
+- Changing backend endpoint behavior or permissions broadly.
+- Reworking the follow/unfollow feature itself.
+- Changing other pages that may use the same follow-state pattern unless they are directly affected by the same bug.
+
+---
+
+## Current Behavior
+
+On the organization detail page, the frontend requests the follow-state endpoint as part of the page data initialization. For unauthenticated visitors, the request is still triggered and the backend logs an error because the request is not authorized for that endpoint.
+
+This results in:
+- browser console noise,
+- backend error logs for guest traffic,
+- unnecessary API calls for anonymous users.
+
+---
+
+## Proposed Solution
+
+Guard the follow-state lookup so it only runs when a valid authentication token is present.
+
+### Expected behavior
+- If the user is a guest (no auth token), the page should not call `/am_i_following/`.
+- The follow-state should default to a safe neutral value such as `false` or `null`, depending on the existing UI expectations.
+- If the user is logged in, the current follow-state flow should remain unchanged and continue to fetch the real follow status.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Visiting an organization detail page as a guest does not trigger the `/api/organizations/[org slug]/am_i_following/` request.
+- [ ] No backend error is produced for the guest-user organization page flow caused by this endpoint call.
+- [ ] The organization page still renders correctly for guests without broken follow-state UI.
+- [ ] Logged-in users still receive the real follow-state value and can use the follow/unfollow experience normally.
+- [ ] The fix does not introduce regressions in the existing organization page data loading flow.
+- [ ] A regression test or equivalent coverage is added to ensure guest users do not trigger the follow-state request.
+
+---
+
+## Constraints / Non-Negotiables
+
+- The fix should be minimal and targeted to the affected frontend path.
+- Existing authenticated behavior must remain intact.
+- The change should avoid introducing a new user-facing error state for guests.
+- No broad permission or API contract changes should be required for this issue.
+
+---
+
+## Domain Context
+
+Relevant implementation area:
+- Frontend organization page: [frontend/pages/organizations/[organizationUrl].tsx](frontend/pages/organizations/[organizationUrl].tsx)
+
+The page currently fetches organization data and follow-state together during server-side rendering. The follow-state helper is responsible for calling the organization follow-status endpoint and should be skipped whenever there is no authenticated session.
+
+---
+
+## Implementation Notes
+
+1. Inspect the organization page data-loading flow and identify the follow-state fetch path.
+2. Add a guard so the follow-state request is only executed when an auth token is present.
+3. Ensure the page state handles the unauthenticated case gracefully.
+4. Add a regression test around the organization page or the helper responsible for the follow-state fetch.
+
+### Suggested implementation shape
+- In the server-side props flow, only call the follow-state request when `auth_token` exists.
+- If no token is present, return a neutral/default follow state instead of issuing the request.
+- Keep the existing logged-in path unchanged.
+
+---
+
+## Verification Plan
+
+- Manually verify the organization detail page as a guest user.
+- Confirm that the follow-state request is no longer sent for unauthenticated visits.
+- Confirm the page still loads normally and no related errors appear in the backend logs.
+- Run the relevant frontend tests or linting checks after implementing the fix.

--- a/frontend/pages/organizations/[organizationUrl].test.tsx
+++ b/frontend/pages/organizations/[organizationUrl].test.tsx
@@ -1,0 +1,33 @@
+import { getIsUserFollowing } from "../../public/lib/organizationOperations";
+import { apiRequest } from "../../public/lib/apiOperations";
+
+jest.mock("../../public/lib/apiOperations", () => ({
+  apiRequest: jest.fn(),
+}));
+
+const mockedApiRequest = apiRequest as jest.MockedFunction<typeof apiRequest>;
+
+describe("getIsUserFollowing", () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+  });
+
+  it("skips the follow-status request for guest users", async () => {
+    await expect(getIsUserFollowing("my-org", undefined, "en")).resolves.toBeNull();
+    expect(mockedApiRequest).not.toHaveBeenCalled();
+  });
+
+  it("requests the follow-status endpoint for authenticated users", async () => {
+    mockedApiRequest.mockResolvedValue({ data: { is_following: true } } as any);
+
+    await expect(getIsUserFollowing("my-org", "token", "en")).resolves.toBe(true);
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "get",
+        url: "/api/organizations/my-org/am_i_following/",
+        token: "token",
+        locale: "en",
+      })
+    );
+  });
+});

--- a/frontend/pages/organizations/[organizationUrl].tsx
+++ b/frontend/pages/organizations/[organizationUrl].tsx
@@ -11,7 +11,7 @@ import ROLE_TYPES from "../../public/data/role_types";
 import { apiRequest, getLocalePrefix, getRolesOptions } from "../../public/lib/apiOperations";
 import { getImageUrl } from "../../public/lib/imageOperations";
 import { startPrivateChat } from "../../public/lib/messagingOperations";
-import { parseOrganization } from "../../public/lib/organizationOperations";
+import { getIsUserFollowing, parseOrganization } from "../../public/lib/organizationOperations";
 import { nullifyUndefinedValues } from "../../public/lib/profileOperations";
 import getTexts from "../../public/texts/texts";
 import AccountPage from "../../src/components/account/AccountPage";
@@ -97,7 +97,7 @@ export async function getServerSideProps(ctx) {
     getMembersByOrganization(organizationUrl, auth_token, ctx.locale),
     getOrganizationTypes(),
     getRolesOptions(auth_token, ctx.locale),
-    getIsUserFollowing(organizationUrl, auth_token, ctx.locale),
+    auth_token ? getIsUserFollowing(organizationUrl, auth_token, ctx.locale) : null,
     getHubTheme(hubUrl),
     getAllHubs(ctx.locale),
   ]);
@@ -470,24 +470,6 @@ async function getProjectsByOrganization(organizationUrl, token, locale) {
     }
   } catch (err) {
     console.log(err);
-    if (err.response && err.response.data) console.log("Error: " + err.response.data.detail);
-    return null;
-  }
-}
-
-async function getIsUserFollowing(organizationUrl, token, locale) {
-  try {
-    const resp = await apiRequest({
-      method: "get",
-      url: "/api/organizations/" + organizationUrl + "/am_i_following/",
-      token: token,
-      locale: locale,
-    });
-    if (resp.data.length === 0) return null;
-    else {
-      return resp.data.is_following;
-    }
-  } catch (err) {
     if (err.response && err.response.data) console.log("Error: " + err.response.data.detail);
     return null;
   }

--- a/frontend/public/lib/organizationOperations.ts
+++ b/frontend/public/lib/organizationOperations.ts
@@ -58,6 +58,24 @@ export async function getUserOrganizations(token, locale) {
   }
 }
 
+export async function getIsUserFollowing(organizationUrl, token, locale) {
+  if (!token) return null;
+
+  try {
+    const resp = await apiRequest({
+      method: "get",
+      url: "/api/organizations/" + organizationUrl + "/am_i_following/",
+      token: token,
+      locale: locale,
+    });
+    if (resp.data.length === 0) return null;
+    return resp.data.is_following;
+  } catch (err: any) {
+    if (err.response && err.response.data) console.log("Error: " + err.response.data.detail);
+    return null;
+  }
+}
+
 function getOrganizationInfo(organization, editMode) {
   const info = {
     location: organization.location,


### PR DESCRIPTION
## Description
this PR addresses issue [2175](https://github.com/climateconnect/climateconnect/issues/2175)
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

<!-- Be sure to follow our PR guidelines in the CONTRIBUTING.md doc! And aim to reference the GitHub issue number here (e.g. "#XXX") improve discoverability. 🔖 -->
