### PR TITLE
Extend event calendars to sub-hubs

### DIFF
--- a/frontend/pages/events.tsx
+++ b/frontend/pages/events.tsx
@@ -131,6 +131,7 @@ export default function EventsPage({
         className=""
         allHubs={hubs}
         fromPage="browse"
+        subHubSegment={undefined}
       />
       <EventCalendarContent
         initialEvents={initialEvents}

--- a/frontend/pages/hubs/[hubUrl]/[subHub]/events.tsx
+++ b/frontend/pages/hubs/[hubUrl]/[subHub]/events.tsx
@@ -1,0 +1,5 @@
+import HubEventsPage, { getHubEventsServerSideProps } from "../events";
+
+export const getServerSideProps = getHubEventsServerSideProps;
+
+export default HubEventsPage;

--- a/frontend/pages/hubs/[hubUrl]/events.tsx
+++ b/frontend/pages/hubs/[hubUrl]/events.tsx
@@ -1,9 +1,10 @@
-import { GetServerSideProps } from "next";
+import { GetServerSideProps, GetServerSidePropsContext } from "next";
 import NextCookies from "next-cookies";
 import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/router";
-import { Theme, useMediaQuery } from "@mui/material";
-import { getAllHubs } from "../../../public/lib/hubOperations";
+import { Container, Theme, useMediaQuery } from "@mui/material";
+import makeStyles from "@mui/styles/makeStyles";
+import { extractHubUrlsFromContext, getAllHubs } from "../../../public/lib/hubOperations";
 import { getSectorOptions } from "../../../public/lib/getOptions";
 import { apiRequest } from "../../../public/lib/apiOperations";
 import { getFeatureTogglesFromRequest } from "../../../src/hooks/featureToggles";
@@ -13,6 +14,7 @@ import WideLayout from "../../../src/components/layouts/WideLayout";
 import HubTabsNavigation from "../../../src/components/hub/HubTabsNavigation";
 import HubHeaderImage from "../../../src/components/hub/HubHeaderImage";
 import HubContent from "../../../src/components/hub/HubContent";
+import HubLinkButton from "../../../src/components/hub/HubLinkButton";
 import EventCalendarContent from "../../../src/components/eventCalendar/EventCalendarContent";
 import MobileBottomMenu from "../../../src/components/browse/MobileBottomMenu";
 import isLocationHubLikeHub from "../../../public/lib/isLocationHubLikeHub";
@@ -20,11 +22,37 @@ import {
   getHubAmbassadorData,
   getHubData,
   getHubSupportersData,
+  getLinkedHubsData,
 } from "../../../public/lib/getHubData";
 import getHubTheme from "../../../src/themes/fetchHubTheme";
 import { transformThemeData } from "../../../src/themes/transformThemeData";
 import { getImageUrl } from "../../../public/lib/imageOperations";
 import theme from "../../../src/themes/hubTheme";
+
+const useStyles = makeStyles((theme) => ({
+  linkedHubsContainer: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "center",
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+    gap: theme.spacing(1),
+  },
+  linkedHubsContainerMobile: {
+    display: "flex",
+    flexDirection: "row",
+    overflowX: "auto",
+    gap: theme.spacing(2),
+    padding: theme.spacing(2, 0),
+    marginBottom: theme.spacing(2),
+  },
+  subHubInfoText: {
+    fontStyle: "italic",
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+    textAlign: "left" as const,
+  },
+}));
 
 const toOffsetIso = (d: Date): string => {
   const pad = (n: number) => String(n).padStart(2, "0");
@@ -38,8 +66,17 @@ const toOffsetIso = (d: Date): string => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  const hubUrl = ctx.query.hubUrl as string;
+export async function getHubEventsServerSideProps(ctx: GetServerSidePropsContext) {
+  const parentHubUrl = Array.isArray(ctx.query.hubUrl)
+    ? ctx.query.hubUrl[0]
+    : ctx.query.hubUrl ?? "";
+  const subHubSegment = Array.isArray(ctx.query.subHub)
+    ? ctx.query.subHub[0]
+    : ctx.query.subHub ?? null;
+  const { subHub } = extractHubUrlsFromContext(ctx);
+
+  const hubSlug = subHub || parentHubUrl;
+
   const { featureToggles } = await getFeatureTogglesFromRequest(ctx.req);
   if (!featureToggles.EVENT_CALENDAR_FEATURE) {
     return { notFound: true };
@@ -49,16 +86,17 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const token = NextCookies(ctx).auth_token;
 
   const hubs = await getAllHubs(locale);
-  const hubExists = hubs.some((h: any) => h.url_slug === hubUrl);
+  const hubExists = hubs.some((h: any) => h.url_slug === parentHubUrl || h.url_slug === hubSlug);
   if (!hubExists) {
     return { notFound: true };
   }
 
   const sectorOptions = await getSectorOptions(locale);
 
-  const [hubData, hubThemeData] = await Promise.all([
-    getHubData(hubUrl, locale),
-    getHubTheme(hubUrl),
+  const [hubData, hubThemeData, linkedHubs] = await Promise.all([
+    getHubData(hubSlug, locale),
+    getHubTheme(parentHubUrl),
+    getLinkedHubsData(hubSlug),
   ]);
 
   const querySearch = (ctx.query.search as string) || "";
@@ -84,7 +122,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
       start_date: startDateStr,
       page: "1",
       page_size: "12",
-      hub: hubUrl,
+      hub: hubSlug,
     });
     if (querySearch) params.set("search", querySearch);
     if (querySectors) params.set("sectors", querySectors);
@@ -103,7 +141,9 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   return {
     props: {
       hubs,
-      hubUrl,
+      hubUrl: parentHubUrl,
+      subHubUrl: subHub || null,
+      subHubSegment: subHubSegment || null,
       filterChoices: { sectors: sectorOptions },
       initialEvents,
       initialHasMore,
@@ -112,13 +152,18 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
       initialSelectedDay: initialSelectedDay || null,
       hubData,
       hubThemeData,
+      linkedHubs: linkedHubs || [],
     },
   };
-};
+}
+
+export const getServerSideProps: GetServerSideProps = getHubEventsServerSideProps;
 
 export default function HubEventsPage({
   hubs,
   hubUrl,
+  subHubUrl,
+  subHubSegment,
   filterChoices,
   initialEvents,
   initialHasMore,
@@ -127,28 +172,38 @@ export default function HubEventsPage({
   initialSelectedDay,
   hubData,
   hubThemeData,
+  linkedHubs,
 }: any) {
   const { locale } = useContext(UserContext);
   const router = useRouter();
   const isNarrowScreen = useMediaQuery<Theme>((theme) => theme.breakpoints.down("md"));
-  const texts = useMemo(() => getTexts({ page: "hub", locale: locale }), [locale]);
+  const texts = useMemo(() => getTexts({ page: "hub", locale: locale, hubName: hubData?.name }), [
+    locale,
+    hubData?.name,
+  ]);
   const customTheme = hubThemeData ? transformThemeData(hubThemeData) : undefined;
+  const classes = useStyles();
 
   const isLocationHub = isLocationHubLikeHub(hubData?.hub_type, hubData?.parent_hub);
   const [hubAmbassador, setHubAmbassador] = useState(null);
   const [hubSupporters, setHubSupporters] = useState(null);
   const contentRef = useRef<HTMLDivElement>(null);
 
+  const effectiveHubUrl = subHubUrl || hubUrl;
+  const browsePath = subHubSegment
+    ? `/hubs/${hubUrl}/${subHubSegment}/browse`
+    : `/hubs/${hubUrl}/browse`;
+
   useEffect(() => {
     (async () => {
-      const retrievedHubAmbassador = await getHubAmbassadorData(hubUrl, locale);
+      const retrievedHubAmbassador = await getHubAmbassadorData(effectiveHubUrl, locale);
       setHubAmbassador(retrievedHubAmbassador);
       if (isLocationHub) {
-        const retrievedHubSupporters = await getHubSupportersData(hubUrl, locale);
+        const retrievedHubSupporters = await getHubSupportersData(effectiveHubUrl, locale);
         setHubSupporters(retrievedHubSupporters);
       }
     })();
-  }, [hubUrl, locale]);
+  }, [effectiveHubUrl, locale]);
 
   const scrollToContent = () => {
     contentRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -165,13 +220,13 @@ export default function HubEventsPage({
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
     const tab = TYPES_BY_TAB_VALUE[newValue];
     if (tab === "events") return;
-    router.push(`/hubs/${hubUrl}/browse#${tab}`);
+    router.push(`${browsePath}#${tab}`);
   };
 
   const BROWSE_TAB_TYPES = ["projects", "organizations", "members"];
   const handleBrowseTabChange = (event: React.SyntheticEvent, newValue: number) => {
     const tab = BROWSE_TAB_TYPES[newValue];
-    router.push(`/hubs/${hubUrl}/browse#${tab}`);
+    router.push(`${browsePath}#${tab}`);
   };
 
   return (
@@ -222,8 +277,28 @@ export default function HubEventsPage({
         className=""
         allHubs={hubs}
         fromPage="hub"
+        subHubSegment={subHubSegment}
       />
       <div ref={contentRef}>
+        <Container maxWidth="lg">
+          {isNarrowScreen && linkedHubs && linkedHubs.length > 0 && (
+            <div className={classes.linkedHubsContainerMobile}>
+              {linkedHubs.map((linkedHub: any) => (
+                <HubLinkButton key={linkedHub.hubUrl} hub={linkedHub} pageContext="events" />
+              ))}
+            </div>
+          )}
+          {!isNarrowScreen && linkedHubs && linkedHubs.length > 0 && (
+            <div className={classes.linkedHubsContainer}>
+              {linkedHubs.map((linkedHub: any) => (
+                <HubLinkButton key={linkedHub.hubUrl} hub={linkedHub} pageContext="events" />
+              ))}
+            </div>
+          )}
+          {hubData?.parent_hub && (
+            <div className={classes.subHubInfoText}>{texts.you_are_seeing_events_related_to}</div>
+          )}
+        </Container>
         <EventCalendarContent
           initialEvents={initialEvents}
           initialHasMore={initialHasMore}
@@ -231,7 +306,8 @@ export default function HubEventsPage({
           initialSectors={initialSectors}
           initialSelectedDay={initialSelectedDay}
           filterChoices={filterChoices}
-          hubUrl={hubUrl}
+          hubUrl={effectiveHubUrl}
+          subHubName={hubData?.parent_hub ? hubData?.name : undefined}
         />
       </div>
       {isNarrowScreen && (

--- a/frontend/public/texts/filter_and_search_texts.ts
+++ b/frontend/public/texts/filter_and_search_texts.ts
@@ -1,6 +1,6 @@
 import general_texts from "./general_texts.json";
 
-export default function getFilterAndSearchTexts({ filterType, hubName, locale }) {
+export default function getFilterAndSearchTexts({ filterType, hubName, locale, subHubName }) {
   return {
     point_out_max_selections: {
       en: "You can only choose up to",
@@ -77,10 +77,10 @@ export default function getFilterAndSearchTexts({ filterType, hubName, locale })
     could_not_find_any_items_of_type: {
       en: `Could not find any ${filterType ? general_texts[filterType][locale] : ""} ${
         hubName ? `in the ${hubName} hub ` : ""
-      }that match your filters.`,
+      }${subHubName ? `for the topic "${subHubName}" ` : ""}that match your filters.`,
       de: `Wir konnten keine ${filterType ? general_texts[filterType][locale] : ""} ${
         hubName ? `im ${hubName} Hub ` : ""
-      }finden, die deinen Filtern entsprechen.`,
+      }${subHubName ? `zum Thema "${subHubName}" ` : ""}finden, die deinen Filtern entsprechen.`,
     },
     additional_infos_for_location: {
       en: "Additional info (e.g. room, meeting link, ...)",

--- a/frontend/public/texts/getHubTexts.ts
+++ b/frontend/public/texts/getHubTexts.ts
@@ -159,6 +159,10 @@ export default function getHubTexts({ hubName, hubAmbassador }) {
       en: `You are seeing people interested in the topic "${hubName}"`,
       de: `Du siehst Menschen, die sich für das Thema "${hubName}" interessieren`,
     },
+    you_are_seeing_events_related_to: {
+      en: `You are seeing events related to the topic "${hubName}"`,
+      de: `Du siehst Events zum Thema "${hubName}"`,
+    },
     upcoming_events: {
       en: "Upcoming events",
       de: "Kommende Events",

--- a/frontend/public/texts/texts.ts
+++ b/frontend/public/texts/texts.ts
@@ -59,6 +59,7 @@ type Args<P extends Page> = {
   user?: User;
   hubAmbassador?: string;
   creator?: string;
+  subHubName?: string;
 };
 
 export default function getTexts<P extends Page>({
@@ -77,6 +78,7 @@ export default function getTexts<P extends Page>({
   user,
   hubAmbassador,
   creator,
+  subHubName,
 }: Args<P>) {
   // These are the multiple text files for various translations. They're
   // split up to reduce the amount of work required to download
@@ -94,6 +96,7 @@ export default function getTexts<P extends Page>({
       filterType: filterType,
       hubName: hubName,
       locale: locale,
+      subHubName: subHubName,
     }),
     general: general_texts,
     hub: getHubTexts({ hubName: hubName, hubAmbassador: hubAmbassador }),

--- a/frontend/src/components/browse/BrowseContent.tsx
+++ b/frontend/src/components/browse/BrowseContent.tsx
@@ -98,6 +98,7 @@ type BrowseContentProps = {
   isLocationHub?: boolean;
   linkedHubs?: LinkedHub[];
   fromPage?: "hub";
+  subHubSegment?: string;
 };
 
 export default function BrowseContent({
@@ -119,6 +120,7 @@ export default function BrowseContent({
   isLocationHub,
   linkedHubs,
   fromPage,
+  subHubSegment,
 }: BrowseContentProps) {
   const initialState = {
     items: {
@@ -273,8 +275,10 @@ export default function BrowseContent({
 
   const eventsContent = useMemo(() => {
     if (!shouldRenderUpcomingBand) return undefined;
-    return <UpcomingEventsGroup events={visibleEvents} hubUrl={hubUrl} />;
-  }, [shouldRenderUpcomingBand, visibleEvents, hubUrl]);
+    return (
+      <UpcomingEventsGroup events={visibleEvents} hubUrl={hubUrl} subHubSegment={subHubSegment} />
+    );
+  }, [shouldRenderUpcomingBand, visibleEvents, hubUrl, subHubSegment]);
 
   const locationInputRefs = {
     projects: useRef(null),
@@ -629,6 +633,7 @@ export default function BrowseContent({
         className={classes.hubsTabNavigation}
         allHubs={allHubs}
         fromPage={fromPage}
+        subHubSegment={subHubSegment}
       />
       <Container maxWidth="lg" className={classes.contentRefContainer}>
         {isNarrowScreen && hubSupporters && hubName && (
@@ -685,12 +690,14 @@ export default function BrowseContent({
             type={"projects"}
             {...tabContentWrapperProps}
             eventsContent={eventsContent}
+            subHubInfoText={
+              hubData?.parent_hub ? (
+                <div className={classes.subHubInfoText}>
+                  {texts.you_are_seeing_projects_related_to}
+                </div>
+              ) : undefined
+            }
           >
-            {hubData?.parent_hub && (
-              <div className={classes.subHubInfoText}>
-                {texts.you_are_seeing_projects_related_to}
-              </div>
-            )}
             <Suspense fallback={null}>
               <ProjectPreviews
                 hasMore={state.hasMore.projects}
@@ -704,12 +711,17 @@ export default function BrowseContent({
               />
             </Suspense>
           </TabContentWrapper>
-          <TabContentWrapper type={"organizations"} {...tabContentWrapperProps}>
-            {hubData?.parent_hub && (
-              <div className={classes.subHubInfoText}>
-                {texts.you_are_seeing_organizations_related_to}
-              </div>
-            )}
+          <TabContentWrapper
+            type={"organizations"}
+            {...tabContentWrapperProps}
+            subHubInfoText={
+              hubData?.parent_hub ? (
+                <div className={classes.subHubInfoText}>
+                  {texts.you_are_seeing_organizations_related_to}
+                </div>
+              ) : undefined
+            }
+          >
             <Suspense fallback={null}>
               <OrganizationPreviews
                 hasMore={state.hasMore.organizations}
@@ -721,12 +733,17 @@ export default function BrowseContent({
             </Suspense>
           </TabContentWrapper>
           {!hideMembers && (
-            <TabContentWrapper type={"members"} {...tabContentWrapperProps}>
-              {hubData?.parent_hub && (
-                <div className={classes.subHubInfoText}>
-                  {texts.you_are_seeing_members_related_to}
-                </div>
-              )}
+            <TabContentWrapper
+              type={"members"}
+              {...tabContentWrapperProps}
+              subHubInfoText={
+                hubData?.parent_hub ? (
+                  <div className={classes.subHubInfoText}>
+                    {texts.you_are_seeing_members_related_to}
+                  </div>
+                ) : undefined
+              }
+            >
               <Suspense fallback={null}>
                 <ProfilePreviews
                   hasMore={state.hasMore.members}

--- a/frontend/src/components/browse/NoItemsFound.tsx
+++ b/frontend/src/components/browse/NoItemsFound.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme) => {
   };
 });
 
-export default function NoItemsFound({ type, hubName, className }: any) {
+export default function NoItemsFound({ type, hubName, className, subHubName }: any) {
   const classes = useStyles();
   const { locale } = useContext(UserContext);
   const texts = getTexts({
@@ -21,6 +21,7 @@ export default function NoItemsFound({ type, hubName, className }: any) {
     locale: locale,
     filterType: type,
     hubName: hubName,
+    subHubName: subHubName,
   });
   return (
     <Typography component="h4" variant="h5" className={`${classes.infoMessage} ${className}`}>

--- a/frontend/src/components/browse/TabContentWrapper.tsx
+++ b/frontend/src/components/browse/TabContentWrapper.tsx
@@ -58,6 +58,7 @@ type TabContentWrapperProps = {
   linkedHubs: LinkedHub[];
   children: ReactNode;
   eventsContent?: ReactNode;
+  subHubInfoText?: ReactNode;
 
   // Search handler
   handleSearchSubmit: any;
@@ -87,6 +88,7 @@ export default function TabContentWrapper({
   linkedHubs,
   children,
   eventsContent,
+  subHubInfoText,
   handleSearchSubmit,
 }: TabContentWrapperProps) {
   const is600to718breakpoint = useMediaQuery("(min-width:600px) and (max-width:718px)");
@@ -146,6 +148,7 @@ export default function TabContentWrapper({
         </div>
       )}
 
+      {subHubInfoText}
       {eventsContent}
       {isFiltering && !childrenRenderedRef.current && <LoadingSpinner isLoading />}
       <div style={{ opacity: isFiltering && showChildren ? 0.5 : 1, transition: "opacity 150ms" }}>

--- a/frontend/src/components/browse/UpcomingEventsGroup.tsx
+++ b/frontend/src/components/browse/UpcomingEventsGroup.tsx
@@ -94,15 +94,19 @@ const useStyles = makeStyles((theme) => ({
 export default function UpcomingEventsGroup({
   events,
   hubUrl,
+  subHubSegment,
 }: {
   events: any[];
   hubUrl?: string;
+  subHubSegment?: string;
 }) {
   const { locale } = useContext(UserContext);
   const classes = useStyles();
   const texts = getTexts({ page: "hub", locale: locale });
 
-  const calendarHref = `${getLocalePrefix(locale)}${hubUrl ? `/hubs/${hubUrl}/events` : "/events"}`;
+  const calendarHref = `${getLocalePrefix(locale)}${
+    hubUrl ? `/hubs/${hubUrl}${subHubSegment ? `/${subHubSegment}` : ""}/events` : "/events"
+  }`;
 
   return (
     <section className={classes.group} aria-label={texts.upcoming_events}>

--- a/frontend/src/components/eventCalendar/EventCalendarContent.tsx
+++ b/frontend/src/components/eventCalendar/EventCalendarContent.tsx
@@ -170,6 +170,7 @@ export default function EventCalendarContent({
   initialSelectedDay,
   filterChoices,
   hubUrl,
+  subHubName,
 }: any) {
   const { locale } = useContext(UserContext);
   const classes = useStyles();
@@ -502,6 +503,7 @@ export default function EventCalendarContent({
             sectors={sectors}
             selectedDay={selectedDay}
             hubUrl={hubUrl}
+            subHubName={subHubName}
           />
         </div>
       </div>

--- a/frontend/src/components/eventCalendar/EventCalendarEventList.tsx
+++ b/frontend/src/components/eventCalendar/EventCalendarEventList.tsx
@@ -130,6 +130,7 @@ export default function EventCalendarEventList({
   sectors,
   selectedDay,
   hubUrl,
+  subHubName,
 }: {
   initialEvents?: any[];
   initialHasMore?: boolean;
@@ -137,14 +138,15 @@ export default function EventCalendarEventList({
   sectors: string[];
   selectedDay: Dayjs;
   hubUrl?: string;
+  subHubName?: string;
 }) {
   const { locale, CUSTOM_HUB_URLS } = useContext(UserContext);
-  const { hubData } = useContext(HubContext);
+  const { hubData, hubUrl: contextHubUrl } = useContext(HubContext);
   const hubName = hubData?.name;
   const classes = useStyles();
   const texts = getTexts({ page: "hub", locale: locale });
   const theme = useTheme();
-  const isCustomHub = CUSTOM_HUB_URLS?.includes(hubUrl);
+  const isCustomHub = CUSTOM_HUB_URLS?.includes(contextHubUrl || hubUrl);
   const startOfTodayMs = (() => {
     const d = new Date();
     d.setHours(0, 0, 0, 0);
@@ -236,7 +238,7 @@ export default function EventCalendarEventList({
         </Typography>
       )}
       {!loading && !error && dayGroups.length === 0 && (
-        <NoItemsFound type="events" hubName={hubName} />
+        <NoItemsFound type="events" hubName={hubName} subHubName={subHubName} />
       )}
       {!error &&
         dayGroups.map((group, groupIdx) => {

--- a/frontend/src/components/hub/HubBrowsePage.tsx
+++ b/frontend/src/components/hub/HubBrowsePage.tsx
@@ -52,6 +52,7 @@ export interface HubBrowsePageProps {
   headline: string;
   hubUrl: string;
   subHubUrl: string;
+  subHubSegment: string;
   image_attribution: string;
   image: string;
   isLocationHub: boolean;
@@ -76,6 +77,9 @@ export interface HubBrowsePageProps {
 export async function getHubBrowseServerSideProps(ctx: GetServerSidePropsContext) {
   const locale = ctx.locale as LocaleType;
   let hubUrl = Array.isArray(ctx.query.hubUrl) ? ctx.query.hubUrl[0] : ctx.query.hubUrl ?? "";
+  const subHubSegment = Array.isArray(ctx.query.subHub)
+    ? ctx.query.subHub[0]
+    : ctx.query.subHub ?? null;
   const { subHub } = extractHubUrlsFromContext(ctx);
 
   if (subHub) {
@@ -110,6 +114,7 @@ export async function getHubBrowseServerSideProps(ctx: GetServerSidePropsContext
     props: {
       hubUrl: ctx.query.hubUrl,
       subHubUrl: subHub || null,
+      subHubSegment: subHubSegment || null,
       isLocationHub: isLocationHubLikeHub(hubData?.hub_type, hubData?.parent_hub),
       hubData: hubData,
       name: hubData?.name ?? null,
@@ -143,6 +148,7 @@ export default function HubBrowsePage({
   headline,
   hubUrl,
   subHubUrl,
+  subHubSegment,
   image_attribution,
   image,
   isLocationHub,
@@ -315,6 +321,7 @@ export default function HubBrowsePage({
                 linkedHubs={linkedHubs}
                 isLocationHub={isLocationHub}
                 fromPage="hub"
+                subHubSegment={subHubSegment}
               />
             </FilterProvider>
           </BrowseContext.Provider>

--- a/frontend/src/components/hub/HubLinkButton.tsx
+++ b/frontend/src/components/hub/HubLinkButton.tsx
@@ -82,14 +82,21 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => {
   };
 });
 
-export default function HubLinkButton({ hub }: { hub: LinkedHub }) {
+export default function HubLinkButton({
+  hub,
+  pageContext = "browse",
+}: {
+  hub: LinkedHub;
+  pageContext?: "browse" | "events";
+}) {
   const isNarrowScreen = useMediaQuery<Theme>((theme) => theme.breakpoints.down("md"));
   const backgroundColor = hub.backgroundColor || "lightblue";
 
   const classes = useStyles({ backgroundColor, iconUrl: hub.icon, isNarrowScreen });
   const getLinkUrl = () => {
-    const baseUrl = hub.hubUrl;
-    const hash = window.location.hash;
+    const baseUrl =
+      pageContext === "events" ? hub.hubUrl.replace(/\/browse$/, "/events") : hub.hubUrl;
+    const hash = pageContext === "browse" ? window.location.hash : "";
     return `${baseUrl}${hash}`;
   };
   const linkUrl = getLinkUrl();

--- a/frontend/src/components/hub/HubTabsNavigation.tsx
+++ b/frontend/src/components/hub/HubTabsNavigation.tsx
@@ -130,6 +130,7 @@ export default function HubTabsNavigation({
   className,
   allHubs,
   fromPage,
+  subHubSegment,
 }) {
   const { locale, CUSTOM_HUB_URLS } = useContext(UserContext);
   const classes = useStyles();
@@ -248,7 +249,11 @@ export default function HubTabsNavigation({
           {isEventsEnabled && !isNarrowScreen && (
             <Link
               className={isEventsPage ? classes.activeEventLink : classes.link}
-              href={`${getLocalePrefix(locale)}${hubUrl ? `/hubs/${hubUrl}/events` : "/events"}`}
+              href={`${getLocalePrefix(locale)}${
+                hubUrl
+                  ? `/hubs/${hubUrl}${subHubSegment ? `/${subHubSegment}` : ""}/events`
+                  : "/events"
+              }`}
               underline={isEventsPage ? "none" : "hover"}
             >
               {texts.event_calendar ?? "Event calendar"}


### PR DESCRIPTION
## Checked the following
- [ ] Pages affected by this change work on mobile
- [ ] Pages affected by this change work when logged out
- [ ] Pages affected by this change work when logged in
- [ ] Pages affected by this change work with custom theme and default theme
- [ ] Run within `/backend`: `make format && make lint`

## What and Why

Implements sub-hub support for #2174 
